### PR TITLE
Add stop_tracking and resume_tracking endpoints to the API (Stoplight Branch)

### DIFF
--- a/docs/api-docs/api-reference/shipments/resume-tracking-shipment.mdx
+++ b/docs/api-docs/api-reference/shipments/resume-tracking-shipment.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /shipments/{id}/resume_tracking
+---

--- a/docs/api-docs/api-reference/shipments/stop-tracking-shipment.mdx
+++ b/docs/api-docs/api-reference/shipments/stop-tracking-shipment.mdx
@@ -1,0 +1,3 @@
+---
+openapi: patch /shipments/{id}/stop_tracking
+---

--- a/docs/reference/terminal49/terminal49.v1.json
+++ b/docs/reference/terminal49/terminal49.v1.json
@@ -836,6 +836,80 @@
         }
       }
     },
+    "/shipments/{id}/stop_tracking": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "patch": {
+        "summary": "Stop tracking a shipment",
+        "operationId": "patch-shipments-id-stop-tracking",
+        "tags": [
+          "Shipments"
+        ],
+        "description": "We'll stop tracking the shipment, which means that there will be no more updates.  You can still access the shipment's previously-collected information via the API or dashboard.\n\nYou can resume tracking a shipment by calling the `resume_tracking` endpoint, but keep in mind that some information is only made available by our data sources at specific times, so a stopped and resumed shipment may have some information missing.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/shipment"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shipments/{id}/resume_tracking": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "patch": {
+        "summary": "Resume tracking a shipment",
+        "operationId": "patch-shipments-id-resume-tracking",
+        "tags": [
+          "Shipments"
+        ],
+        "description": "Resume tracking a shipment.  Keep in mind that some information is only made available by our data sources at specific times, so a stopped and resumed shipment may have some information missing.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/shipment"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tracking_requests": {
       "post": {
         "summary": "Create a tracking request",
@@ -1150,7 +1224,7 @@
             }
           }
         },
-        "description": "Returns a list of your tracking requests. The trackig requests are returned sorted by creation date, with the most recent tracking request appearing first.",
+        "description": "Returns a list of your tracking requests. The tracking requests are returned sorted by creation date, with the most recent tracking request appearing first.",
         "tags": [
           "Tracking Requests"
         ],


### PR DESCRIPTION
Just in case we need to keep updating Stoplight ([Mintlify branch here](https://github.com/Terminal49/API/pull/103))

I'm not sure if it works - when I tried to preview the docs from the branch, I didn't see the new API endpoints.  However, I'm not entirely sure I was previewing this branch and not the master branch.  Stoplight's UI for viewing docs on different branches is confusing, and given that we're replacing Stoplight very very soon I don't think it's worth the time learning.