### PR TITLE
Rail carrier coverage table

### DIFF
--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -107,13 +107,24 @@ Integrate these notifications by subscribing to the webhooks and handling the in
 
 #### Rail Container Attributes
 
-- **Pickup Facility**: Information about the inland destination, rail terminal, and FIRMS code.
-- **Rail ETA**: Estimated Time of Arrival at the destination terminal.
-- **Rail ATA**: Actual Time of Arrival at the destination terminal.
-- **Available for Pickup**: Status indicating when the container is available for pickup.
-- **Demurrage LFD**: Last Free Day for demurrage charges.
-- **Rail Terminal Holds**: Holds placed on the container at the rail terminal.
-- **Rail Terminal Fees**: Fees associated with the container at the rail terminal.
+The following are new attributes that are specific to rail container tracking.
+
+- **pod_rail_loaded_at**: Time when the container is loaded onto a railcar at the POD.
+- **pod_rail_departed_at**: Time when the container departs from the POD.
+- **inland_destination_eta_at**: Estimated Time of Arrival at the destination terminal.
+- **inland_destination_ata_at**: Actual Time of Arrival at the destination terminal.
+- **inland_destination_rail_unloaded_at**: Time when the container is unloaded from the rail terminal.
+- **pickup_facility_holds**: Holds placed on the container at the rail terminal.
+- **pickup_facility_fees**: Fees associated with the container at the rail terminal.
+- **pickup_facility_yard_location**: Yard location of the container at the rail terminal.
+- **pickup_facility_lfd_on**: Last Free Day for demurrage charges.
+- **pickup_rail_carrier_scac**: SCAC code of the rail carrier that picks up the container from the POD (this could be different than the rail carrier that delivers to the destination terminal). {/* I think this is a bad name.  We should rename it to pod_rail_carrier_scac -- which is actually what it's named internally, but we change it for the serializer! */}
+{/* Why is there not a rail carrier scac for the delivery destination in the serializer?  We should add */}
+
+
+{/* TODO: Look at the other container attributes that could be fed via rail but are currently shipping-line-only.  Such as :current_issues, :pickup_appointment_at, :availability_known, :available_for_pickup  */}
+
+These attributes can be found on [container objects](http://localhost:3000/api-docs/api-reference/containers/get-a-container).
 
 ## Integration Methods
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -46,7 +46,7 @@ We also provide a set of attributes that let you know the current status of your
 ### Rail Milestones (aka rail events)
 
 {/* TODO: create rail-carriers page or section */}
-There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events, (see [known issues for Rail Carriers](/api-docs/useful-info/api-data-sources-availability#known-issues-rail) for more details), but in general these are the key events for a container.
+There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events, (see [Rail Coverage](/api-docs/useful-info/api-data-sources-availability#rail-coverage) for more details), but in general these are the key events for a container.
 
 ```mermaid
 graph LR

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -7,11 +7,10 @@ mode: "wide"
 
 {/* TODO - maybe a table of contents? */}
 
-## Terminal49 Rail Integrations Overview
+## Supported Rail Carriers
 
-Terminal49 container tracking platform integrates with all major North American Class-1 railroads, providing comprehensive visibility into rail container movements. Our platform supports the following carriers:
+Terminal49 container tracking platform integrates with all North American Class-1 railroads that handle container shipping, providing comprehensive visibility into your rail container movements.
 
-### Supported Rail Carriers
 - BNSF Railway
 - Canadian National Railway (CN)
 - Canadian Pacific Railway (CP)
@@ -21,17 +20,15 @@ Terminal49 container tracking platform integrates with all major North American 
 
 By integrating with these carriers, Terminal49 ensures that you have real-time access to critical tracking data, enabling better decision-making and operational efficiency.
 
-### Supported Rail Milestones and Data Attributes
-
-Terminal49 tracks various milestones and data attributes that are essential for effective rail container management. The key events and attributes include:
+## Supported Rail Milestones and Data Attributes
 
 Terminal49 seamlessly tracks your containers as they go from container ship, to ocean terminal, to rail carrier.
 
-We provide a set of milestones/events that let you track the status of your containers as they move through the rail system.  Each milestone contains a timestamp and a location.
+We provide a set of milestones/events that let you track the status of your containers as they move through the rail system.  You can be notified by webhook whenever these events occur.
 
 We also provide a set of attributes that let you know the current status of your container at any given time, as well as useful information such as ETA, pickup facility, and availability information.
 
-#### Rail Milestones (aka rail events)
+### Rail Milestones (aka rail events)
 
 {/* TODO: create rail-carriers page or section */}
 There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events (see [Rail Carriers](#rail-carriers) for more details), but in general these are the key events for a container.
@@ -45,9 +42,7 @@ D --> E[Full Out]
 E --> F[Empty Return]
 ```
 
-
-
-However, not all shipments have a simple journey.  Yo umay want to track events such as when a train passes through a town, when the container switches trains or rail carriers at an interchange, and when the status of your container at the terminal changes.
+However, not all shipments have a simple journey.  You may want to track events such as when a train passes through a town, when the container switches trains or rail carriers at an interchange, and when the status of your container at the terminal changes.
 
 This is a more complex diagram that shows the various events that can occur in a container's rail journey.
 
@@ -64,7 +59,7 @@ graph LR
     C --> X[Rail Interchange Delivered]
     X --> Z
     D --> G[Available for Pickup]
-    D --> H[Unavailable]
+    D --> H[Not Available]
     H -- Holds and Fees Updated --> H
     G --> H
     H --> G
@@ -72,9 +67,11 @@ graph LR
     E --> F[Empty Return]
 ```
 
-Terminal49 provides a series of webhook notifications to keep you updated on key milestones in a container's rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications. Here's a list of the supported rail events:
+### Webhook Notifications
 
-{/* TODO: update this list to include all the others we have listed */}
+Terminal49 provides webhook notifications to keep you updated on key milestones in a container's rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications.
+
+Here's a list of the rail-specific events which support webhook notifications:
 
 | Milestone | Webhook Notification | Description |
 |----------------|----------------------|-------------|
@@ -82,11 +79,26 @@ Terminal49 provides a series of webhook notifications to keep you updated on key
 | Rail Departed  | `container.transport.rail_departed` | The container departs on the railcar (usually from port of discharge). |
 | Rail Arrived   | `container.transport.rail_arrived`  | The container arrives at the destination terminal. |
 | Rail Unloaded  | `container.transport.rail_unloaded` | The container is unloaded from a railcar. |
+
+There's also a set of events that are triggered when the status of the container at the destination rail terminal changes.  For containers without rail, they would have been triggered at the ocean terminal.
+
+| Milestone | Webhook Notification | Description |
+|----------------|----------------------|-------------|
+| Available for Pickup | `container.transport.available`     | (Coming Soon) The container is available for pickup at the rail terminal. |
+| Not Available  | `container.transport.not_available` | (Coming Soon) The container is not available for pickup at the rail terminal. |
+| Holds and Fees Updated | `container.transport.holds_and_fees_updated` | (Coming Soon) The holds and fees for the container at the rail terminal have been changed, but not fully cleared. |
 | Full Out       | `container.transport.full_out`      | The full container leaves the rail terminal. |
 | Empty In       | `container.transport.empty_in`      | The empty container is returned to the terminal. |
+
+Finally, we plan to provide webhook notifications for when estimated rail arrival times change, but this is still under development.
+
+| Milestone | Webhook Notification | Description |
+|----------------|----------------------|-------------|
 | Estimated Rail Arrival | `container.estimated.rail_arrival` | (Coming soon) Estimated time of arrival for the container at the rail terminal. |
 
 Integrate these notifications by subscribing to the webhooks and handling the incoming data to update your systems.
+
+> Note: We do not have webhook notifications planned for Train Passing, Rail Interchange Received, or Rail Interchange Delivered.  However, you can still see them in the dashboard.
 
 #### Rail Container Attributes
 
@@ -115,9 +127,8 @@ Terminal49's DataSync service automatically syncs up-to-date tracking data with 
 
 [Learn more about DataSync](/datasync/overview)
 
-
-
 ---
+
 Other Links
 - [Blog post on North American intermodal rail visibility](https://www.terminal49.com/blog/launching-north-american-intermodal-rail-visibility-on-terminal49/).
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -36,7 +36,7 @@ We also provide a set of attributes that let you know the current status of your
 ### Rail Milestones (aka rail events)
 
 {/* TODO: create rail-carriers page or section */}
-There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events (see [Rail Carriers](#rail-carriers) for more details), but in general these are the key events for a container.
+There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events, {/* (see [Rail Carriers](#rail-carriers) for more details), */} but in general these are the key events for a container.
 
 ```mermaid
 graph LR

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -89,6 +89,7 @@ Terminal49 provides a series of webhook notifications to keep you updated on key
 Integrate these notifications by subscribing to the webhooks and handling the incoming data to update your systems.
 
 #### Rail Container Attributes
+
 - **Pickup Facility**: Information about the inland destination, rail terminal, and FIRMS code.
 - **Rail ETA**: Estimated Time of Arrival at the destination terminal.
 - **Rail ATA**: Actual Time of Arrival at the destination terminal.
@@ -97,18 +98,22 @@ Integrate these notifications by subscribing to the webhooks and handling the in
 - **Rail Terminal Holds**: Holds placed on the container at the rail terminal.
 - **Rail Terminal Fees**: Fees associated with the container at the rail terminal.
 
-### Integration Methods
+## Integration Methods
 
 There are two primary methods to integrate Terminal49's rail tracking data programmatically: via API and DataSync.
 
-**A. Integration via API**
+#### A. Integration via API
 
-Terminal49 provides a robust API that allows you to programmatically access rail container tracking data and receive updates via webhooks. Here's a step-by-step guide to get started:
+Terminal49 provides a robust API that allows you to programmatically access rail container tracking data and receive updates via webhooks. You will receive rail events and attributes alongside events and attributes from the ocean terminal and carrier.
+
+[Here's a step-by-step guide to get started](/api-docs/getting-started/start-here)
 
 
-**B. Integration via DataSync**
+#### B. Integration via DataSync
 
-Terminal49's DataSync service automatically syncs up-to-date tracking data with your system. Here's how to set it up:
+Terminal49's DataSync service automatically syncs up-to-date tracking data with your system.  The rail data will be in the same tables alongside the ocean terminal and carrier data.
+
+[Learn more about DataSync](/datasync/overview)
 
 
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -5,12 +5,22 @@ mode: "wide"
 
 ---
 
-{/* TODO - maybe a table of contents? */}
 
 This is a technical article about rail data within Terminal49's API and DataSync.
 
 For a broader overview, including the reasons why you'd want rail visibility and how to use it in the Terminal49 dashboard,
  [read our announcement post](https://www.terminal49.com/blog/launching-north-american-intermodal-rail-visibility-on-terminal49/).
+
+## Table of Contents
+
+- [Supported Rail Carriers](#supported-rail-carriers)
+- [Supported Rail Milestones and Data Attributes](#supported-rail-milestones-and-data-attributes)
+  - [Rail Milestones (aka rail events)](#rail-milestones-aka-rail-events)
+  - [Webhook Notifications](#webhook-notifications)
+  - [Rail Container Attributes](#rail-container-attributes)
+- [Integration Methods](#integration-methods)
+  - [Integration via API](#integration-via-api)
+  - [Integration via DataSync](#integration-via-datasync)
 
 ## Supported Rail Carriers
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -24,38 +24,53 @@ By integrating with these carriers, Terminal49 ensures that you have real-time a
 
 Terminal49 tracks various milestones and data attributes that are essential for effective rail container management. The key events and attributes include:
 
+Terminal49 seamlessly tracks your containers as they go from container ship, to ocean terminal, to rail carrier.
 
-```mermaid
-graph LR
-    A[Rail Loaded] --> B[Rail Departed]
-    B --> C[Rail Arrived]
-    C --> D[Rail Unloaded]
-    D --> E[Full Out]
-    E --> F[Empty Return]
-  ```
+We provide a set of milestones/events that let you track the status of your containers as they move through the rail system.  Each milestone contains a timestamp and a location.
 
-```mermaid
-timeline
-    title Container Milestones (Rail Import)
-    section Port of Discharge
-        Vessel Arrived : Port of discharge : Terminal details : arrival timestamp
-        Vessel Berthed : Port of discharge : Terminal details : berth timestamp
-        Vessel Discharged : Port of discharge : Terminal details : discharged timestamp
-    section Container On Rail
-        Rail Loaded : Loaded location : loaded timestamp
-        Rail Departed : Departed location : departed timestamp
-        Rail Arrived : Arrived location : arrived timestamp
-        Rail Unloaded : Unloaded location : unloaded timestamp
-    section Final Destination (Rail Terminal)
-        Full Out : Full out port : Full out terminal : full out timestamp
-        Empty Return : empty return timestamp
-
-```
+We also provide a set of attributes that let you know the current status of your container at any given time, as well as useful information such as ETA, pickup facility, and availability information.
 
 #### Rail Milestones (aka rail events)
 
+{/* TODO: create rail-carriers page or section */}
+There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events (see [Rail Carriers](#rail-carriers) for more details), but in general these are the key events for a container.
+
+```mermaid
+graph LR
+A[Rail Loaded] --> B[Rail Departed]
+B --> C[Rail Arrived]
+C --> D[Rail Unloaded]
+D --> E[Full Out]
+E --> F[Empty Return]
+```
+
+
+
+However, not all shipments have a simple journey.  Yo umay want to track events such as when a train passes through a town, when the container switches trains or rail carriers at an interchange, and when the status of your container at the terminal changes.
+
+This is a more complex diagram that shows the various events that can occur in a container's rail journey.
+    Y[From ocean terminal or carrier] --> A
+    Z[Rail Interchange Received] --> B
+    A[Rail Loaded] --> B[Rail Departed]
+    B --> L[Train Passing]
+    B --> C[Rail Arrived]
+    L --> L
+    L --> C
+    C --> D[Rail Unloaded]
+    C --> X[Rail Interchange Delivered]
+    X --> Z
+    D --> G[Available for Pickup]
+    D --> H[Unavailable]
+    H -- Holds and Fees Updated --> H
+    G --> H
+    H --> G
+    G --> E[Full Out]
+    E --> F[Empty Return]
+```
+
 Terminal49 provides a series of webhook notifications to keep you updated on key milestones in a container's rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications. Here's a list of the supported rail events:
 
+{/* TODO: update this list to include all the others we have listed */}
 | Milestone | Webhook Notification | Description |
 |----------------|----------------------|-------------|
 | Rail Loaded    | `container.transport.rail_loaded`   | The container is loaded onto a railcar. |

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -38,16 +38,16 @@ graph LR
 timeline
     title Container Milestones (Rail Import)
     section Port of Discharge
-        Vessel Arrival : Port of discharge : Terminal details : discharged timestamp
-        Vessel Berth : Port of discharge : Terminal details : berth timestamp
-        Container Discharged : Port of discharge : Terminal details : discharged timestamp
+        Vessel Arrived : Port of discharge : Terminal details : arrival timestamp
+        Vessel Berthed : Port of discharge : Terminal details : berth timestamp
+        Vessel Discharged : Port of discharge : Terminal details : discharged timestamp
     section Container On Rail
         Rail Loaded : Loaded location : loaded timestamp
         Rail Departed : Departed location : departed timestamp
         Rail Arrived : Arrived location : arrived timestamp
         Rail Unloaded : Unloaded location : unloaded timestamp
     section Final Destination (Rail Terminal)
-        Full Out : Full out port : Full out terminal : Full out timestamp
+        Full Out : Full out port : Full out terminal : full out timestamp
         Empty Return : empty return timestamp
 
 ```
@@ -58,12 +58,12 @@ Terminal49 provides a series of webhook notifications to keep you updated on key
 
 | Milestone | Webhook Notification | Description |
 |----------------|----------------------|-------------|
-| Rail Loaded    | `container.transport.rail_loaded`   | Notification when the container is loaded onto a railcar. |
-| Rail Departed  | `container.transport.rail_departed` | Notification when the container departs from the origin terminal (usually port of discharge). |
-| Rail Arrived   | `container.transport.rail_arrived`  | Notification when the container arrives at the destination terminal. |
-| Rail Unloaded  | `container.transport.rail_unloaded` | Notification when the container is unloaded from a railcar. |
-| Full Out       | `container.transport.full_out`      | Update when the full container leaves the rail terminal. |
-| Empty In       | `container.transport.empty_in`      | Notification when the empty container is returned to the terminal. |
+| Rail Loaded    | `container.transport.rail_loaded`   | The container is loaded onto a railcar. |
+| Rail Departed  | `container.transport.rail_departed` | The container departs on the railcar (usually from port of discharge). |
+| Rail Arrived   | `container.transport.rail_arrived`  | The container arrives at the destination terminal. |
+| Rail Unloaded  | `container.transport.rail_unloaded` | The container is unloaded from a railcar. |
+| Full Out       | `container.transport.full_out`      | The full container leaves the rail terminal. |
+| Empty In       | `container.transport.empty_in`      | The empty container is returned to the terminal. |
 | Estimated Rail Arrival | `container.estimated.rail_arrival` | (Coming soon) Estimated time of arrival for the container at the rail terminal. |
 
 Integrate these notifications by subscribing to the webhooks and handling the incoming data to update your systems.

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -15,7 +15,6 @@ Terminal49 container tracking platform integrates with all major North American 
 - Canadian National Railway (CN)
 - Canadian Pacific Railway (CP)
 - CSX Transportation
-- Kansas City Southern Railway (KCS)
 - Norfolk Southern Railway (NS)
 - Union Pacific Railroad (UP)
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -19,8 +19,8 @@ For a broader overview, including the reasons why you'd want rail visibility and
   - [Webhook Notifications](#webhook-notifications)
   - [Rail Container Attributes](#rail-container-attributes)
 - [Integration Methods](#integration-methods)
-  - [Integration via API](#integration-via-api)
-  - [Integration via DataSync](#integration-via-datasync)
+  - [Integration via API](#a-integration-via-api)
+  - [Integration via DataSync](#b-integration-via-datasync)
 
 ## Supported Rail Carriers
 
@@ -140,14 +140,14 @@ These attributes can be found on [container objects](http://localhost:3000/api-d
 
 There are two primary methods to integrate Terminal49's rail tracking data programmatically: via API and DataSync.
 
-#### A. Integration via API
+### A. Integration via API
 
 Terminal49 provides a robust API that allows you to programmatically access rail container tracking data and receive updates via webhooks. You will receive rail events and attributes alongside events and attributes from the ocean terminal and carrier.
 
 [Here's a step-by-step guide to get started](/api-docs/getting-started/start-here)
 
 
-#### B. Integration via DataSync
+### B. Integration via DataSync
 
 Terminal49's DataSync service automatically syncs up-to-date tracking data with your system.  The rail data will be in the same tables alongside the ocean terminal and carrier data.
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -46,7 +46,7 @@ We also provide a set of attributes that let you know the current status of your
 ### Rail Milestones (aka rail events)
 
 {/* TODO: create rail-carriers page or section */}
-There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events, {/* (see [Rail Carriers](#rail-carriers) for more details), */} but in general these are the key events for a container.
+There are several core milestones that occur on most rail journeys.  Some rail carriers do not share all events, (see [known issues for Rail Carriers](/api-docs/useful-info/api-data-sources-availability#known-issues-rail) for more details), but in general these are the key events for a container.
 
 ```mermaid
 graph LR

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -6,7 +6,7 @@ mode: "wide"
 ---
 
 
-## Terminal40 Rail Integrations Overview
+## Terminal49 Rail Integrations Overview
 
 Terminal49 container tracking platform integrates with all major North American Class-1 railroads, providing comprehensive visibility into rail container movements. Our platform supports the following carriers:
 
@@ -39,7 +39,7 @@ timeline
     title Container Milestones (Rail Import)
     section Port of Discharge
         Vessel Arrival : Port of discharge : Terminal details : discharged timestamp
-        Vessel Birth : Port of discharge : Terminal details : Birth timestamp
+        Vessel Berth : Port of discharge : Terminal details : berth timestamp
         Container Discharged : Port of discharge : Terminal details : discharged timestamp
     section Container On Rail
         Rail Loaded : Loaded location : loaded timestamp
@@ -54,7 +54,7 @@ timeline
 
 #### Rail Milestones (aka rail events)
 
-Terminal49 provides a series of webhook notifications to keep you updated on key milestones in a container’s rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications. Here’s a list of the supported rail events:
+Terminal49 provides a series of webhook notifications to keep you updated on key milestones in a container's rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications. Here's a list of the supported rail events:
 
 | Milestone | Webhook Notification | Description |
 |----------------|----------------------|-------------|
@@ -66,7 +66,7 @@ Terminal49 provides a series of webhook notifications to keep you updated on key
 | Empty In       | `container.transport.empty_in`      | Notification when the empty container is returned to the terminal. |
 | Estimated Rail Arrival | `container.estimated.rail_arrival` | (Coming soon) Estimated time of arrival for the container at the rail terminal. |
 
-Integrate these notifications by subscribing to the webhooks and handling the incoming data to update your systems. 
+Integrate these notifications by subscribing to the webhooks and handling the incoming data to update your systems.
 
 #### Rail Container Attributes
 - **Pickup Facility**: Information about the inland destination, rail terminal, and FIRMS code.
@@ -79,21 +79,21 @@ Integrate these notifications by subscribing to the webhooks and handling the in
 
 ### Integration Methods
 
-There are two primary methods to integrate Terminal49’s rail tracking data programmatically: via API and DataSync.
+There are two primary methods to integrate Terminal49's rail tracking data programmatically: via API and DataSync.
 
 **A. Integration via API**
 
-Terminal49 provides a robust API that allows you to programmatically access rail container tracking data. Here’s a step-by-step guide to get started:
+Terminal49 provides a robust API that allows you to programmatically access rail container tracking data and receive updates via webhooks. Here's a step-by-step guide to get started:
 
 
 **B. Integration via DataSync**
 
-Terminal49’s DataSync service provides a continuous feed of tracking data, automatically syncing with your system. Here’s how to set it up:
+Terminal49's DataSync service automatically syncs up-to-date tracking data with your system. Here's how to set it up:
 
 
 
 ---
-Other Links 
+Other Links
 - [Blog post on North American intermodal rail visibility](https://www.terminal49.com/blog/launching-north-american-intermodal-rail-visibility-on-terminal49/).
 
 If you have any questions or need further assistance, please contact Terminal49 support.

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -1,10 +1,11 @@
 ---
 title: 'Integrate Rail Container Tracking Data'
-description: 'This guide provides a comprehensive, step-by-step approach for integrating North American Class-1 rail container tracking data into your systems. Whether you are a shipper or a logistics service provider, this guide will help you track all your rail container via single API.'
+description: 'This guide provides a comprehensive, step-by-step approach for integrating North American Class-1 rail container tracking data into your systems. Whether you are a shipper or a logistics service provider, this guide will help you track all your rail containers via single API.'
 mode: "wide"
 
 ---
 
+{/* TODO - maybe a table of contents? */}
 
 ## Terminal49 Rail Integrations Overview
 
@@ -49,6 +50,9 @@ E --> F[Empty Return]
 However, not all shipments have a simple journey.  Yo umay want to track events such as when a train passes through a town, when the container switches trains or rail carriers at an interchange, and when the status of your container at the terminal changes.
 
 This is a more complex diagram that shows the various events that can occur in a container's rail journey.
+
+```mermaid
+graph LR
     Y[From ocean terminal or carrier] --> A
     Z[Rail Interchange Received] --> B
     A[Rail Loaded] --> B[Rail Departed]
@@ -71,6 +75,7 @@ This is a more complex diagram that shows the various events that can occur in a
 Terminal49 provides a series of webhook notifications to keep you updated on key milestones in a container's rail journey. These notifications allow you to integrate near real-time tracking data directly into your applications. Here's a list of the supported rail events:
 
 {/* TODO: update this list to include all the others we have listed */}
+
 | Milestone | Webhook Notification | Description |
 |----------------|----------------------|-------------|
 | Rail Loaded    | `container.transport.rail_loaded`   | The container is loaded onto a railcar. |

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -1,11 +1,16 @@
 ---
 title: 'Integrate Rail Container Tracking Data'
-description: 'This guide provides a comprehensive, step-by-step approach for integrating North American Class-1 rail container tracking data into your systems. Whether you are a shipper or a logistics service provider, this guide will help you track all your rail containers via single API.'
+description: 'This guide provides a comprehensive, step-by-step approach for integrating North American Class-1 rail container tracking data into your systems. Whether you are a shipper or a logistics service provider, this guide will help you track all your rail containers via a single API.'
 mode: "wide"
 
 ---
 
 {/* TODO - maybe a table of contents? */}
+
+This is a technical article about rail data within Terminal49's API and DataSync.
+
+For a broader overview, including the reasons why you'd want rail visibility and how to use it in the Terminal49 dashboard,
+ [read our announcement post](https://www.terminal49.com/blog/launching-north-american-intermodal-rail-visibility-on-terminal49/).
 
 ## Supported Rail Carriers
 
@@ -126,10 +131,3 @@ Terminal49 provides a robust API that allows you to programmatically access rail
 Terminal49's DataSync service automatically syncs up-to-date tracking data with your system.  The rail data will be in the same tables alongside the ocean terminal and carrier data.
 
 [Learn more about DataSync](/datasync/overview)
-
----
-
-Other Links
-- [Blog post on North American intermodal rail visibility](https://www.terminal49.com/blog/launching-north-american-intermodal-rail-visibility-on-terminal49/).
-
-If you have any questions or need further assistance, please contact Terminal49 support.

--- a/docs/api-docs/useful-info/api-data-sources-availability.mdx
+++ b/docs/api-docs/useful-info/api-data-sources-availability.mdx
@@ -107,44 +107,35 @@ Below are a list of known issues with our data sources:
 - No container weight
 - Only Dry container types are mapped to our system
 
-## Known Issues (Rail)
+## Rail Coverage
 
-Rail data is populated from requests to the rail carriers.
+Rail data is populated from requests to the rail carriers.  Some carriers provide more data than others.
 
-Below are a list of known issues with our rail data sources.
 
-{/* The following are taken from this Notion document: https://www.notion.so/terminal49/Rail-Integration-Research-c54287a8a6b34a5e9a3f73498a3f09a1?pvs=4#889f3227c0104781b38be4d780ece49f */}
-{/* However, I think what we care about has changed since then */}
-{/* TODO: collaborate with Matt/Arman/Edy to update this list */}
+| Event                       | BNSF | Canadian National Railway | Canadian Pacific Railway | Norfolk Southern Railway | Union Pacific Railroad | CSX Transportation |
+|-----------------------------|------|---------------------------|--------------------------|--------------------------|------------------------|---------------------|
+| rail_loaded                 |  ❌  |           ✅                |       ✅                   |       ✅                   |         ✅               |       ❌              |
+| rail_departed               |  ❌  |           ❌                |       ✅                   |           ✅               |           ✅             |       ✅              |
+| rail_arrived                |  ✅  |           ✅                |       ✅                   |           ✅               |           ✅             |       ✅              |
+| arrived_at_destination      |  ❌  |           ❌                |       ✅                   |         ❌                |         ❌               |        ❌             |
+| rail_unloaded               |  ✅  |           ✅                |       ❌                   |           ✅               |           ✅             |       ❌              |
+| train_passing               |  ❌  |           ❌                |       ❌                   |        ❌                  |         ✅               |       ❌              |
+| rail_interchange_delivered  |  ❌  |           ✅                |       ✅                   |           ✅               |           ✅             |       ❌              |
+| rail_interchange_received   |  ❌  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅              |
+| full_out                    |  ❌  |           ✅                |       ✅                   |           ✅               |           ✅             |       ❌              |
+| empty_in                    |  ❌  |           ✅                |       ❌                   |         ❌                |         ✅               |        ❌             |
+| full_in                     |  ❌  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅              |
+| empty_out                   |  ❌  |           ✅                |       ❌                   |         ❌                |         ❌               |        ❌             |
+| available                   |  ✅  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅             |
+| customs_release             |  ❌  |           ✅                |       ❌                   |         ❌                |         ❌               |        ❌             |
+| not_available               |      |                           |                          |                          |                        |                     |
+| holds_and_fees_changed      |      |                           |                          |                          |                        |                     |
+| last_free_day_changed       |  ✅    |         ✅                  |     ✅                     |         ✅                 |          ✅              |     ✅                |
 
-### General Rail Issues
+In addition to some data not being provided by all carriers, there are a couple other known issues:
 
-The ETAs from rail carriers are not particularly accurate.  We are working on strategies to provide intelligence beyond what is provided by the rail carriers themselves.
-
-### BNSF
-
-- No Demmurage data
-- Inexact event times
-- Can't get events from before tracking started
-
-### Canadian National Railway (CN)
-
-- No Demmurage data
-- Can't get events from before tracking started
-
-### Canadian Pacific Railway (CP)
-
-- No LFD
-
-### Norfolk Southern Railway (NS)
-
-- Can't get events from before tracking started
-
-### Union Pacific Railroad (UP)
-
-{/* TODO: this was not on the list from Rail Integration Research */}
-
-### CSX Transportation
+- BNSF does not provide an event history
+- ETAs are notoriously incorrect (we're working on a way to improve on what we get from the carriers)
 
 # Data Fields & Availability
 

--- a/docs/api-docs/useful-info/api-data-sources-availability.mdx
+++ b/docs/api-docs/useful-info/api-data-sources-availability.mdx
@@ -46,6 +46,14 @@ Presently, the Terminal 49 api integrates with terminals at the following ports:
 
 You can view a complete list of supported terminals and attributes on [Google Sheets](https://docs.google.com/spreadsheets/d/1cWK8sNpkjY5V-KlXe1fHi8mU_at2HcJYqjCvGQgixQk/edit#gid=1406366493)
 
+## Rail Carriers
+
+- BNSF Railway
+- Canadian National Railway (CN)
+- Canadian Pacific Railway (CP)
+- CSX Transportation
+- Norfolk Southern Railway (NS)
+- Union Pacific Railroad (UP)
 
 ## Known Issues (ocean)
 Shipment data is populated from requests to the shipping lines.
@@ -99,6 +107,45 @@ Below are a list of known issues with our data sources:
 - No container weight
 - Only Dry container types are mapped to our system
 
+## Known Issues (Rail)
+
+Rail data is populated from requests to the rail carriers.
+
+Below are a list of known issues with our rail data sources.
+
+{/* The following are taken from this Notion document: https://www.notion.so/terminal49/Rail-Integration-Research-c54287a8a6b34a5e9a3f73498a3f09a1?pvs=4#889f3227c0104781b38be4d780ece49f */}
+{/* However, I think what we care about has changed since then */}
+{/* TODO: collaborate with Matt/Arman/Edy to update this list */}
+
+### General Rail Issues
+
+The ETAs from rail carriers are not particularly accurate.  We are working on strategies to provide intelligence beyond what is provided by the rail carriers themselves.
+
+### BNSF
+
+- No Demmurage data
+- Inexact event times
+- Can't get events from before tracking started
+
+### Canadian National Railway (CN)
+
+- No Demmurage data
+- Can't get events from before tracking started
+
+### Canadian Pacific Railway (CP)
+
+- No LFD
+
+### Norfolk Southern Railway (NS)
+
+- Can't get events from before tracking started
+
+### Union Pacific Railroad (UP)
+
+{/* TODO: this was not on the list from Rail Integration Research */}
+
+### CSX Transportation
+
 # Data Fields & Availability
 
 Below is a list of data that can be retrieved via the API, including whether is is always available, or whether it is only supported by certain carriers (Carrier Dependent), certain Terminals (Terminal Dependent) or on certain types of journeys (Journey dependent).
@@ -110,7 +157,7 @@ Shipment Data is the primary data that comes from the Carrier. It containers the
 | ------ |-----|-----|-----|
 | Port of Lading                                 | Always                               | Port of Lading name, Port of Lading UN/LOCODE, Port of Lading Timezone                |                                                                            |
 | Port of Discharge                              | Always                               | Port of Discharge name, Port of discharge UN/LOCODE,Port of Discharge Timezone        |                                                                            |
-| Final Destination beyond Port of Discharge     | Carrier dependent, Journey Dependent | ,Destination name, Destination UN/LOCODE, Destination UN/LOCODE, Destination Timezone | Only for shipments with inland moves provided by or booked by the carrier. |
+| Final Destination beyond Port of Discharge     | Carrier dependent, Journey Dependent | Destination name, Destination UN/LOCODE, Destination UN/LOCODE, Destination Timezone | Only for shipments with inland moves provided by or booked by the carrier. |
 | Listing of Container Numbers                   | Always                               | A list of container numbers with data attributes listed below                         |                                                                            |
 | Bill of Lading Number                          | Always (inputted by user)            | BOL                                                                                   |                                                                            |
 | Shipping Line Details                          | Always                               | SCAC, SSL Name                                                                        |                                                                            |

--- a/docs/api-docs/useful-info/api-data-sources-availability.mdx
+++ b/docs/api-docs/useful-info/api-data-sources-availability.mdx
@@ -25,7 +25,7 @@ Presently, the Terminal 49 api integrates with terminals at the following ports:
 - Houston
 - Jacksonville
 - London Gateway (UK)
-- Long Beach 
+- Long Beach
 - Los Angeles
 - Miami
 - Mobile
@@ -50,7 +50,7 @@ You can view a complete list of supported terminals and attributes on [Google Sh
 ## Known Issues (ocean)
 Shipment data is populated from requests to the shipping lines.
 
-Below are a list of known issuses with our data sources:
+Below are a list of known issues with our data sources:
 
 ### Cma-Cgm, APL, ANL
 - No container weight


### PR DESCRIPTION
I got this data from reading through the rail parsers and seeing which events were referenced, so it should be accurate as of our current code.

Note that this includes https://github.com/Terminal49/API/pull/105, since we want it linked from the updated guide.  The important commit is [the last one](https://github.com/Terminal49/API/pull/108/commits/7d205a48af58db9d46185ee1bb6e4c728d8d51ef).

<img width="777" alt="Screenshot 2024-06-26 at 6 22 24 PM" src="https://github.com/Terminal49/API/assets/839123/0e7d7748-864e-412a-809b-d9aeb628896b">

# Questions

1. Would it be a good idea to delete some rows that only one or two sources use - such as `empty_in`, `empty_out`, `train_passing`, `arrived_at_destination`, etc.?
2. Is there any parsing later on in the pipeline that I should look at, where events are added/changed?
