### PR TITLE
Update old documentation links and code styles

### DIFF
--- a/docs/api-docs/getting-started/list-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/list-shipments-and-containers.mdx
@@ -134,7 +134,7 @@ function listTrackedShipments(){
     'method' : 'GET',
     'headers' : {
       'content-type': 'application/vnd.api+json',
-      'authorization' : 'Token MY_API_KEY'
+      'authorization' : 'Token YOUR_API_KEY'
     },
       'payload' : ''
    };

--- a/docs/api-docs/getting-started/list-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/list-shipments-and-containers.mdx
@@ -131,18 +131,18 @@ Because Google App Script does not have native JSON API support, we need to pars
 function listTrackedShipments(){
   // first we construct the request.
   var options = {
-    'method' : 'GET',
-    'headers' : {
-      'content-type': 'application/vnd.api+json',
-      'authorization' : 'Token YOUR_API_KEY'
+    "method" : "GET",
+    "headers" : {
+      "content-type": "application/vnd.api+json",
+      "authorization" : "Token YOUR_API_KEY"
     },
-      'payload' : ''
+      "payload" : ""
    };
 
 
   try {
     // note that URLFetchApp is a function of Google App Script, not a standard JS function.
-    var response = UrlFetchApp.fetch('https://api.terminal49.com/v2/shipments', options);
+    var response = UrlFetchApp.fetch("https://api.terminal49.com/v2/shipments", options);
     var json = response.getContentText();
     var shipments = JSON.parse(json)["data"];
     var shipment_values = [];

--- a/docs/api-docs/getting-started/recieve-status-updates.mdx
+++ b/docs/api-docs/getting-started/recieve-status-updates.mdx
@@ -225,18 +225,18 @@ Some objects have **relationships**. These are simply links to another object. T
 function registerWebhook(){
   // Make a POST request with a JSON payload.
   options = {
-    'method' : 'POST'
-    'headers' : {
-      'content-type': 'application/vnd.api+json',
-      'authorization' : 'Token YOUR_API_KEY"
+    "method" : "POST"
+    "headers" : {
+      "content-type": "application/vnd.api+json",
+      "authorization" : "Token YOUR_API_KEY"
     },
-    'payload' : {
-      'data': {  
-        'type': 'webhook',
-        'attributes': {
-          'url': "http://yourwebhookurl.com/webhook",
-          'active': true,
-          'events': ['tracking_request.succeeded']
+    "payload" : {
+      "data": {  
+        "type": "webhook",
+        "attributes": {
+          "url": "http://yourwebhookurl.com/webhook",
+          "active": true,
+          "events": ["tracking_request.succeeded"]
         }
       }
     }

--- a/docs/api-docs/getting-started/recieve-status-updates.mdx
+++ b/docs/api-docs/getting-started/recieve-status-updates.mdx
@@ -228,7 +228,7 @@ function registerWebhook(){
     'method' : 'POST'
     'headers' : {
       'content-type': 'application/vnd.api+json',
-      'authorization' : 'Token ' + "YOUR API KEY"
+      'authorization' : 'Token YOUR_API_KEY"
     },
     'payload' : {
       'data': {  
@@ -309,7 +309,7 @@ View the "Code Generation" button to see sample code.
   "url": "https://api.terminal49.com/v2/webhooks",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   },
   "body": "{\r\n  \"data\": {\r\n    \"type\": \"webhook\",\r\n    \"attributes\": {\r\n      \"url\": \"https:\/\/webhook.site\/\",\r\n      \"active\": true,\r\n      \"events\": [\r\n        \"tracking_request.succeeded\"\r\n      ]\r\n    }\r\n  }\r\n}"
 }

--- a/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
@@ -63,7 +63,7 @@ The token should be sent with each API request in the Authentication header:
 Support [dev@terminal49.com](dev@terminal49.com)
 
 ```
-Authorization: Token YOUR_API_TOKEN
+Authorization: Token YOUR_API_KEY
 ```
 
 ## How to Create a Tracking Request
@@ -191,7 +191,7 @@ We have not yet set up a webook to receive status updates from the Terminal49 AP
   "url": "https://api.terminal49.com/v2/tracking_requests",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   }
 }
 ```

--- a/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
@@ -161,7 +161,7 @@ The most common issue people encounter is that they are entering the wrong numbe
 
 Please check that you are entering the Bill of Lading number, booking number, or container number and not internal reference at your company or by your frieght forwarder. You can the number you are supplying by going to a carrier's website and using their tools to track your shipment using the request number. If this works, and if the SCAC is supported by T49, you should able to track it with us.
 
-It is entirely possible that's neither us nor you but the shipping line is giving us a headache. Temporary network problems, not populated manifest and other things happen! You can read on how are we handling them in the [Tracking Request Retrying](https://developers.terminal49.com/docs/api/95984bab0bf17-tracking-request-retrying) section.
+It is entirely possible that's neither us nor you but the shipping line is giving us a headache. Temporary network problems, not populated manifest and other things happen! You can read on how are we handling them in the [Tracking Request Retrying](/docs/api-docs/useful-info/tracking-request-retrying) section.
 </Warning>
 
 <Info>

--- a/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
@@ -63,7 +63,7 @@ The token should be sent with each API request in the Authentication header:
 Support [dev@terminal49.com](dev@terminal49.com)
 
 ```
-Authentication: Token YOUR_API_TOKEN
+Authorization: Token YOUR_API_TOKEN
 ```
 
 ## How to Create a Tracking Request

--- a/docs/api-docs/in-depth-guides/including-resources.mdx
+++ b/docs/api-docs/in-depth-guides/including-resources.mdx
@@ -3,7 +3,7 @@ title: Including Resources
 ---
 Throughout the documentation you will notice that many of the endpoints include a `relationships` object inside of the `data` attribute.
 
-For example, if you are [requesting a container](https://developers.terminal49.com/docs/api/docs/reference/terminal49/terminal49.v1.json/paths/~1containers~1%7Bid%7D/get) the relationships will include `shipment`, and possibly `pod_terminal` and `transport_events`
+For example, if you are [requesting a container](/docs/api/4c6091811c4e0-get-a-container) the relationships will include `shipment`, and possibly `pod_terminal` and `transport_events`
 
 If you want to load the `shipment` and `pod_terminal` without making any additional requests you can add the query parameter `include` and provide a comma delimited list of the related resources:
 ```

--- a/docs/api-docs/in-depth-guides/quickstart.mdx
+++ b/docs/api-docs/in-depth-guides/quickstart.mdx
@@ -54,7 +54,7 @@ We have not yet set up a webook to receive status updates from the Terminal49 AP
   "url": "https://api.terminal49.com/v2/tracking_requests",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   }
 }
 ```
@@ -75,7 +75,7 @@ If you had trouble adding your first shipment, try adding a few more.
   "url": "https://api.terminal49.com/v2/shipments",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   }
 }
 ```
@@ -92,7 +92,7 @@ Try it after replacing `<YOUR_API_KEY>` with your API key.
   "url": "https://api.terminal49.com/v2/containers",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   }
 }
 ```
@@ -116,7 +116,7 @@ View the "Code Generation" button to see sample code.
   "url": "https://api.terminal49.com/v2/webhooks",
   "headers": {
     "Content-Type": "application/vnd.api+json",
-    "Authorization": "Token <YOUR_API_KEY>"
+    "Authorization": "Token YOUR_API_KEY"
   },
   "body": "{\r\n  \"data\": {\r\n    \"type\": \"webhook\",\r\n    \"attributes\": {\r\n      \"url\": \"https:\/\/webhook.site\/\",\r\n      \"active\": true,\r\n      \"events\": [\r\n        \"*\"\r\n      ]\r\n    }\r\n  }\r\n}"
 }

--- a/docs/api-docs/in-depth-guides/terminal49-map.mdx
+++ b/docs/api-docs/in-depth-guides/terminal49-map.mdx
@@ -6,7 +6,7 @@ description: The Terminal49 Map allows you to embed real-time visualized contain
 
 - A Terminal49 account.
 - A Publishable API key, you can get one by reaching out to us at support@terminal49.com.
-- Familiarity with our [Shipments API](https://developers.terminal49.com/docs/api/d31aeeda6fa44-list-shipments) and [Containers API](https://developers.terminal49.com/docs/api/f77d723c227c1-list-containers).
+- Familiarity with our [Shipments API](/docs/api-docs/api-reference/shipments/list-shipments) and [Containers API](/docs/api-docs/api-reference/containers/list-containers).
 In the following examples we'll be passing a `containerId` and `shipmentId` variables to the embedded map.
 They relate to `id` attributes of the container and shipment objects that are returned by the API.
 

--- a/docs/api-docs/in-depth-guides/tracking-request-lifecycle.mdx
+++ b/docs/api-docs/in-depth-guides/tracking-request-lifecycle.mdx
@@ -60,4 +60,4 @@ Terminal49 will stop tracking requests for the following reasons:
 
 ## Retrieving Status
 
-If you want to see the status of your tracking request you can make a [GET request](https://developers.terminal49.com/docs/api/docs/reference/terminal49/terminal49.v1.json/paths/~1tracking_requests~1%7Bid%7D/get) on what the most recent failure reason was (`failed_reason` field).
+If you want to see the status of your tracking request you can make a [GET request](/docs/api-docs/api-reference/tracking-requests/get-a-single-tracking-request) on what the most recent failure reason was (`failed_reason` field).

--- a/docs/api-docs/in-depth-guides/webhooks.mdx
+++ b/docs/api-docs/in-depth-guides/webhooks.mdx
@@ -7,7 +7,7 @@ You may subscribe to events through webhooks to be alerted when events are trigg
 
 Visit https://app.terminal49.com/developers/webhooks and click the 'Create Webhook Endpoint' button to create your webhook through the UI.
 
-If you prefer to create webhooks programatically then see the [webhooks post endpoint documentation](https://developers.terminal49.com/docs/api/b3A6MTYyMzcyMA-create-a-webhook).
+If you prefer to create webhooks programatically then see the [webhooks post endpoint documentation](/docs/api-docs/api-reference/webhooks/create-a-webhook).
 
 
 ## Available Webook Events

--- a/docs/api-docs/useful-info/tracking-request-retrying.mdx
+++ b/docs/api-docs/useful-info/tracking-request-retrying.mdx
@@ -8,4 +8,4 @@ If we are having difficulty connecting to the shipping line, or if we are unable
 
 If the shipping line returns a response that it cannot find the provided number then we will immediately return the `tracking_request.failed` event to your webhook.
 
-If you want to see the status of your tracking request you can make a [GET request](https://developers.terminal49.com/docs/api/docs/reference/terminal49/terminal49.v1.json/paths/~1tracking_requests~1%7Bid%7D/get) on it's `id` to see how many times it has retried, and what the most recent failure reason was.
+If you want to see the status of your tracking request you can make a [GET request](/docs/api-docs/api-reference/tracking-requests/get-a-single-tracking-request) on it's `id` to see how many times it has retried, and what the most recent failure reason was.

--- a/docs/datasync/home.mdx
+++ b/docs/datasync/home.mdx
@@ -3,8 +3,8 @@ title: Terminal49 Dev Documentation
 ---
 We offer two fantastic ways to track your shipments from origin to destination.
 
-    1. [Terminal49 DataSync](https://terminal49.stoplight.io/docs/data-sync/hm7z2564h2be8-overview). Get tables full of fresh information delivered into your current data system. Easy to set up, and perfect for complementing your current data.
-    2. [Terminal49 API](https://developers.terminal49.com/docs/api/43898cdb7bad1-1-start-here). Connect directly with the API, pull data for specific shipments and containers, and get updates via webhooks.
+    1. [Terminal49 DataSync](/docs/datasync/overview). Get tables full of fresh information delivered into your current data system. Easy to set up, and perfect for complementing your current data.
+    2. [Terminal49 API](/docs/api-docs/getting-started/start-here). Connect directly with the API, pull data for specific shipments and containers, and get updates via webhooks.
 
 If you already have a data store that feeds the rest of your system, DataSync is probably what you want.
 

--- a/docs/datasync/overview.mdx
+++ b/docs/datasync/overview.mdx
@@ -3,9 +3,9 @@ title: Overview
 ---
 DataSync is the easiest way to get fresh, up-to-date container and shipment data into your system.
 
-DataSync will create 3 tables in your system, in the schema / dataset / folder / spreadsheet of your choice: [containers](https://developers.terminal49.com/docs/data-sync/zjjg8zr2zu0e6-containers), [shipments](https://developers.terminal49.com/docs/data-sync/yeuqjfl43ax44-shipments), and [tracking_requests](https://developers.terminal49.com/docs/data-sync/ufj16839ldwtj-tracking-requests). In addition to these 3 tables, a technical table named [_transfer_status](https://developers.terminal49.com/docs/data-sync/49tfwr53m246j-transfer-status) is also created, which tells you when each table was last refreshed.
+DataSync will create 3 tables in your system, in the schema / dataset / folder / spreadsheet of your choice: [containers](/docs/datasync/table-properties/containers), [shipments](/docs/datasync/table-properties/shipments), and [tracking_requests](/docs/datasync/table-properties/tracking-requests). In addition to these 3 tables, a technical table named [_transfer_status](/docs/datasync/table-properties/transfer-status) is also created, which tells you when each table was last refreshed.
 
-We can send the data to almost any database, data warehouse, or object store, as well as to Google Sheets. See the [full list of supported systems](https://terminal49.stoplight.io/docs/data-sync/j9gw5vf0ujemv-supported-destinations).
+We can send the data to almost any database, data warehouse, or object store, as well as to Google Sheets. See the [full list of supported systems](/docs/datasync/supported-destinations).
 
 
 ## How often does the data update?
@@ -13,7 +13,7 @@ DataSync will keep the data tables updated with a refresh every hour.
 
 Each refresh reloads only the rows that have been changed since the previous refresh, so you won't have excess writes to your system.
 
-To check when a table was last updated, check the [_transfer_status](https://developers.terminal49.com/docs/data-sync/49tfwr53m246j-transfer-status) table - for each row in that table there is a unique table key, and the time when the latest sync occurred for that table.
+To check when a table was last updated, check the [_transfer_status](/docs/datasync/table-properties/transfer-status) table - for each row in that table there is a unique table key, and the time when the latest sync occurred for that table.
 
 
 ## How to use the data
@@ -44,7 +44,7 @@ There are many ways you can start tracking shipments with Terminal49. They all r
     - [Send an email with a CSV to track@terminal49.com](https://help.terminal49.com/en/articles/5506959-how-to-add-shipments-via-email)
     - Upload a CSV through [our dashboard](https://app.terminal49.com/shipments/imports/new)
     - Input shipments directly through [our dashboard](https://app.terminal49.com/shipments/imports/new)
-    - [Use the Terminal49 API to create TrackingRequests](https://developers.terminal49.com/docs/api/bcc30e6df9ed9-create-a-tracking-request)
+    - [Use the Terminal49 API to create TrackingRequests](/docs/api-docs/api-reference/tracking-requests/create-a-tracking-request)
 
 
 ## Getting Started

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -3,8 +3,8 @@ title: Terminal49 Dev Documentation
 ---
 We offer two fantastic ways to track your shipments from origin to destination.
 
-    1. [Terminal49 DataSync](https://terminal49.stoplight.io/docs/data-sync/hm7z2564h2be8-overview). Get tables full of fresh information delivered into your current data system. Easy to set up, and perfect for complementing your current data.
-    2. [Terminal49 API](https://developers.terminal49.com/docs/api/43898cdb7bad1-1-start-here). Connect directly with the API, pull data for specific shipments and containers, and get updates via webhooks.
+    1. [Terminal49 DataSync](/docs/datasync/overview). Get tables full of fresh information delivered into your current data system. Easy to set up, and perfect for complementing your current data.
+    2. [Terminal49 API](/docs/api-docs/getting-started/start-here). Connect directly with the API, pull data for specific shipments and containers, and get updates via webhooks.
 
 If you already have a data store that feeds the rest of your system, DataSync is probably what you want.
 


### PR DESCRIPTION
- fixed links that go to old documentation page like `https://terminal49.stoplight.io/` or `https://developers.terminal49.com/`
- fix bad code example ("Authentication:" instead of "Authorization")
- add consistency to code examples: "Token YOUR_API_KEY", "Token <YOUR_API_KEY>", "Token MY_API_KEY"
- add consistency to code examples that change between `'` and `"`