### PR TITLE
Update some rail attribute names, remove others

### DIFF
--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -135,13 +135,12 @@ The following are new attributes that are specific to rail container tracking.
 
 - **pod_rail_loaded_at**: Time when the container is loaded onto a railcar at the POD.
 - **pod_rail_departed_at**: Time when the container departs from the POD.
-- **inland_destination_eta_at**: Estimated Time of Arrival at the destination terminal.
-- **inland_destination_ata_at**: Actual Time of Arrival at the destination terminal.
-- **inland_destination_rail_unloaded_at**: Time when the container is unloaded from the rail terminal.
-- **pickup_facility_lfd_on**: Last Free Day for demurrage charges.
-- **pickup_rail_carrier_scac**: SCAC code of the rail carrier that picks up the container from the POD (this could be different than the rail carrier that delivers to the destination terminal). {/* Linear ticket to rename: https://linear.app/terminal49/issue/DATA-2767/rename-pickup-rail-carrier-scac */}
-{/* Linear ticket to add matching delivery/destination rail carrier scac: https://linear.app/terminal49/issue/DATA-2768/add-destination-rail-carrier-scac-to-serializer */}
-
+- **ind_eta_at**: Estimated Time of Arrival at the inland destination.
+- **ind_ata_at**: Actual Time of Arrival at the inland destination.
+- **ind_rail_unloaded_at**: Time when the container is unloaded from rail at the inland destination.
+- **ind_facility_lfd_on**: Last Free Day for demurrage charges at the inland destination terminal.
+- **pod_rail_carrier_scac**: SCAC code of the rail carrier that picks up the container from the POD (this could be different than the rail carrier that delivers to the inland destination).
+- **ind_rail_carrier_scac**: SCAC code of the rail carrier that delivers the container to the inland destination.
 
 {/* TODO: Look at the other container attributes that could be fed via rail but are currently shipping-line-only.  Such as :current_issues, :pickup_appointment_at, :availability_known, :available_for_pickup  */}
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -84,9 +84,7 @@ graph LR
     E --> F[Empty Return]
 ``` */}
 
-In addition, there are events that update you on the status of your container at the rail terminal, marking it as available or unavailable.  Some of these events come directly from the carriers, while others we generate when we see the fees and holds on your container change.
-
-```mermaid
+{/* ```mermaid
 graph LR
     C[Previous events] --> D[Rail Unloaded]
     D --> G[Available for Pickup]
@@ -95,7 +93,7 @@ graph LR
     H --> G
     H -- Holds and Fees Updated --> H
     G --> E[Full Out]
-```
+``` */}
 
 ### Webhook Notifications
 
@@ -115,9 +113,6 @@ There's also a set of events that are triggered when the status of the container
 
 | Transport Event | Webhook Notification | Description | Example |
 |----------------|----------------------|-------------|---------|
-| Available for Pickup | `container.transport.available`     | (Unreleased) The container is available for pickup at the rail terminal. | - |
-| Not Available  | `container.transport.not_available` | (Unreleased) The container is not available for pickup at the rail terminal. | - |
-| Holds and Fees Updated | `container.transport.holds_and_fees_updated` | (Unreleased) The holds and fees for the container at the rail terminal have been changed, but not fully cleared. | - |
 | Full Out       | `container.transport.full_out`      | The full container leaves the rail terminal. | <a href="https://www.terminal49.com/docs/api-docs/useful-info/webhook-events-examples#container-transport-full-out" target="_blank">Example</a> |
 | Empty In       | `container.transport.empty_in`      | The empty container is returned to the terminal. | <a href="https://www.terminal49.com/docs/api-docs/useful-info/webhook-events-examples#container-transport-empty-in" target="_blank">Example</a> |
 

--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -138,9 +138,6 @@ The following are new attributes that are specific to rail container tracking.
 - **inland_destination_eta_at**: Estimated Time of Arrival at the destination terminal.
 - **inland_destination_ata_at**: Actual Time of Arrival at the destination terminal.
 - **inland_destination_rail_unloaded_at**: Time when the container is unloaded from the rail terminal.
-- **pickup_facility_holds**: Holds placed on the container at the rail terminal.
-- **pickup_facility_fees**: Fees associated with the container at the rail terminal.
-- **pickup_facility_yard_location**: Yard location of the container at the rail terminal.
 - **pickup_facility_lfd_on**: Last Free Day for demurrage charges.
 - **pickup_rail_carrier_scac**: SCAC code of the rail carrier that picks up the container from the POD (this could be different than the rail carrier that delivers to the destination terminal). {/* Linear ticket to rename: https://linear.app/terminal49/issue/DATA-2767/rename-pickup-rail-carrier-scac */}
 {/* Linear ticket to add matching delivery/destination rail carrier scac: https://linear.app/terminal49/issue/DATA-2768/add-destination-rail-carrier-scac-to-serializer */}

--- a/docs/api-docs/useful-info/api-data-sources-availability.mdx
+++ b/docs/api-docs/useful-info/api-data-sources-availability.mdx
@@ -187,9 +187,6 @@ At the container level, the following data is available. Container data is combi
 | Rail Carrier Scac at Port of Discharge |Journey Dependent | Only if non-port final destination | |
 | ETA for final destination           | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
 | ATA for final destination           | Journey Dependent | Only if non-port final destination |  |
-| Holds at final destination          | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
-| Fees at final destination           | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
-| Yard Location at final destination  | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
 | LFD at final destination            | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
 
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -772,13 +772,14 @@
                             "pod_timezone": "America/New_York",
                             "final_destination_timezone": "US/Eastern",
                             "empty_terminated_timezone": "US/Eastern",
-                            "pickup_rail_carrier_scac": "CSXT",
+                            "pod_rail_carrier_scac": "CSXT",
+                            "ind_rail_carrier_scac": "CSXT",
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": null,
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": null,
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -3426,13 +3427,14 @@
                             "pod_timezone": "America/New_York",
                             "final_destination_timezone": null,
                             "empty_terminated_timezone": "America/New_York",
-                            "pickup_rail_carrier_scac": null,
+                            "pod_rail_carrier_scac": null,
+                            "ind_rail_carrier_scac": null,
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": null,
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": null,
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -3591,13 +3593,14 @@
                             "pod_timezone": "America/New_York",
                             "final_destination_timezone": "America/Chicago",
                             "empty_terminated_timezone": "America/Chicago",
-                            "pickup_rail_carrier_scac": "CSXT",
+                            "pod_rail_carrier_scac": "CSXT",
+                            "ind_rail_carrier_scac": "CSXT",
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": "2024-07-02T14:20:00Z",
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": "2024-07-02T14:20:00Z",
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -3779,13 +3782,14 @@
                             "pod_timezone": "America/Los_Angeles",
                             "final_destination_timezone": "Asia/Shanghai",
                             "empty_terminated_timezone": "Asia/Shanghai",
-                            "pickup_rail_carrier_scac": null,
+                            "pod_rail_carrier_scac": null,
+                            "ind_rail_carrier_scac": null,
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": null,
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": null,
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -3964,13 +3968,14 @@
                             "pod_timezone": "America/Los_Angeles",
                             "final_destination_timezone": "America/New_York",
                             "empty_terminated_timezone": "America/New_York",
-                            "pickup_rail_carrier_scac": "BNSF",
+                            "pod_rail_carrier_scac": "BNSF",
+                            "ind_rail_carrier_scac": "CSXT",
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": "2024-07-07T08:00:00Z",
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": "2024-07-07T08:00:00Z",
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -4096,13 +4101,14 @@
                             "pod_timezone": "America/Los_Angeles",
                             "final_destination_timezone": "America/Chicago",
                             "empty_terminated_timezone": "America/Chicago",
-                            "pickup_rail_carrier_scac": "BNSF",
+                            "pod_rail_carrier_scac": "BNSF",
+                            "ind_rail_carrier_scac": "BNSF",
                             "pod_rail_loaded_at": null,
                             "pod_rail_departed_at": null,
-                            "inland_destination_eta_at": "2024-07-04T22:00:00Z",
-                            "inland_destination_ata_at": null,
-                            "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_lfd_on": null
+                            "ind_eta_at": "2024-07-04T22:00:00Z",
+                            "ind_ata_at": null,
+                            "ind_rail_unloaded_at": null,
+                            "ind_facility_lfd_on": null
                           },
                           "relationships": {
                             "shipment": {
@@ -4390,13 +4396,14 @@
                           "pod_timezone": "America/New_York",
                           "final_destination_timezone": "US/Eastern",
                           "empty_terminated_timezone": "US/Eastern",
-                          "pickup_rail_carrier_scac": "CSXT",
+                          "pod_rail_carrier_scac": "CSXT",
+                          "ind_rail_carrier_scac": "CSXT",
                           "pod_rail_loaded_at": null,
                           "pod_rail_departed_at": null,
-                          "inland_destination_eta_at": null,
-                          "inland_destination_ata_at": null,
-                          "inland_destination_rail_unloaded_at": null,
-                          "pickup_facility_lfd_on": null
+                          "ind_eta_at": null,
+                          "ind_ata_at": null,
+                          "ind_rail_unloaded_at": null,
+                          "ind_facility_lfd_on": null
                         },
                         "relationships": {
                           "shipment": {
@@ -6017,7 +6024,8 @@
               "pod_full_out_at": "2022-02-11T22:18:00Z",
               "empty_terminated_at": null,
               "terminal_checked_at": "2022-02-11T22:45:32Z",
-              "pickup_rail_carrier_scac": "UPRR",
+              "pod_rail_carrier_scac": "UPRR",
+              "ind_rail_carrier_scac": "CSXT",
               "pod_timezone": "America/Los_Angeles",
               "final_destination_timezone": null,
               "empty_terminated_timezone": null,
@@ -6025,10 +6033,10 @@
               "shipment_last_tracking_request_at": "2022-02-11T22:40:00Z",
               "pod_rail_loaded_at": "2022-02-11T22:18:00Z",
               "pod_rail_departed_at": "2022-02-11T23:30:00Z",
-              "inland_destination_eta_at": null,
-              "inland_destination_ata_at": "2022-02-15T01:12:00Z",
-              "inland_destination_rail_unloaded_at": "2022-02-15T07:54:00Z",
-              "pickup_facility_lfd_on": null
+              "ind_eta_at": null,
+              "ind_ata_at": "2022-02-15T01:12:00Z",
+              "ind_rail_unloaded_at": "2022-02-15T07:54:00Z",
+              "ind_facility_lfd_on": null
             },
             "relationships": {
               "shipment": {
@@ -6271,9 +6279,14 @@
                 "description": "IANA tz. Applies to attribute empty_terminated_at.",
                 "nullable": true
               },
-              "pickup_rail_carrier_scac": {
+              "pod_rail_carrier_scac": {
                 "type": "string",
                 "description": "The SCAC of the rail carrier for the pickup leg of the container's journey.(BETA)",
+                "nullable": true
+              },
+              "ind_rail_carrier_scac": {
+                "type": "string",
+                "description": "The SCAC of the rail carrier for the delivery leg of the container's journey.(BETA)",
                 "nullable": true
               },
               "pod_last_tracking_request_at": {
@@ -6296,22 +6309,22 @@
                 "format": "date-time",
                 "nullable": true
               },
-              "inland_destination_eta_at": {
+              "ind_eta_at": {
                 "type": "string",
                 "format": "date-time",
                 "nullable": true
               },
-              "inland_destination_ata_at": {
+              "ind_ata_at": {
                 "type": "string",
                 "format": "date-time",
                 "nullable": true
               },
-              "inland_destination_rail_unloaded_at": {
+              "ind_rail_unloaded_at": {
                 "type": "string",
                 "format": "date-time",
                 "nullable": true
               },
-              "pickup_facility_lfd_on": {
+              "ind_facility_lfd_on": {
                 "type": "string",
                 "format": "date-time",
                 "nullable": true

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -778,9 +778,6 @@
                             "inland_destination_eta_at": null,
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -3435,9 +3432,6 @@
                             "inland_destination_eta_at": null,
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -3603,9 +3597,6 @@
                             "inland_destination_eta_at": "2024-07-02T14:20:00Z",
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -3794,9 +3785,6 @@
                             "inland_destination_eta_at": null,
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -3982,9 +3970,6 @@
                             "inland_destination_eta_at": "2024-07-07T08:00:00Z",
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -4117,9 +4102,6 @@
                             "inland_destination_eta_at": "2024-07-04T22:00:00Z",
                             "inland_destination_ata_at": null,
                             "inland_destination_rail_unloaded_at": null,
-                            "pickup_facility_holds": null,
-                            "pickup_facility_fees": null,
-                            "pickup_facility_yard_location": null,
                             "pickup_facility_lfd_on": null
                           },
                           "relationships": {
@@ -4414,9 +4396,6 @@
                           "inland_destination_eta_at": null,
                           "inland_destination_ata_at": null,
                           "inland_destination_rail_unloaded_at": null,
-                          "pickup_facility_holds": null,
-                          "pickup_facility_fees": null,
-                          "pickup_facility_yard_location": null,
                           "pickup_facility_lfd_on": null
                         },
                         "relationships": {
@@ -6049,9 +6028,6 @@
               "inland_destination_eta_at": null,
               "inland_destination_ata_at": "2022-02-15T01:12:00Z",
               "inland_destination_rail_unloaded_at": "2022-02-15T07:54:00Z",
-              "pickup_facility_holds": null,
-              "pickup_facility_fees": null,
-              "pickup_facility_yard_location": null,
               "pickup_facility_lfd_on": null
             },
             "relationships": {
@@ -6333,24 +6309,6 @@
               "inland_destination_rail_unloaded_at": {
                 "type": "string",
                 "format": "date-time",
-                "nullable": true
-              },
-              "pickup_facility_holds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "nullable": true
-              },
-              "pickup_facility_fees": {
-                "type": "array",
-                "items": {
-                  "type": "object"
-                },
-                "nullable": true
-              },
-              "pickup_facility_yard_location": {
-                "type": "string",
                 "nullable": true
               },
               "pickup_facility_lfd_on": {


### PR DESCRIPTION
https://linear.app/terminal49/issue/DATA-3123/review-and-update-rail-api-documentation

We're renaming a bunch of properties in the API, based on https://github.com/Terminal49/tnt-api/pull/7480/files

@mattyturner also requested the following as part of the ticket:

> Remove fees / holds / yard location

We are still sending empty holds and fees, but I think we just want to remove the documentation?  I've gone ahead and removed all references.  Maybe we split up these two things if we're not sure how far we want to go with removing holds and fees.