### PR TITLE
Fix presentation of deprecation warning on raw events

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4960,7 +4960,7 @@
           }
         },
         "operationId": "get-containers-id-raw_events",
-        "description": "<!-- theme: warning -->\n> #### Deprecation warning\n>\n> The `raw_events` endpoint is provided as-is.\n>\n> For past events we recommend consuming `transport_events`.\n\n\nGet a list of past and future (estimated) milestones for a container as reported by the carrier. Some of the data is normalized even though the API is called raw_events. \n\nNormalized attributes: `event` and `timestamp` timestamp. Not all of the `event` values have been normalized. You can expect the the events related to container movements to be normalized but there are cases where events are not normalized. \n\nFor past historical events we recommend consuming `transport_events`. Although there are fewer events here those events go through additional vetting and normalization to avoid false positives and get you correct data.",
+        "description": "#### Deprecation warning\nThe `raw_events` endpoint is provided as-is.\n\n For past events we recommend consuming `transport_events`.\n\n---\nGet a list of past and future (estimated) milestones for a container as reported by the carrier. Some of the data is normalized even though the API is called raw_events. \n\nNormalized attributes: `event` and `timestamp` timestamp. Not all of the `event` values have been normalized. You can expect the the events related to container movements to be normalized but there are cases where events are not normalized. \n\nFor past historical events we recommend consuming `transport_events`. Although there are fewer events here those events go through additional vetting and normalization to avoid false positives and get you correct data.",
         "deprecated": true
       }
     },


### PR DESCRIPTION
Before
![CleanShot 2024-09-12 at 16 04 15@2x](https://github.com/user-attachments/assets/eeab64f0-2370-4671-bda4-8ee9679aff9f)


After
![CleanShot 2024-09-12 at 16 04 03@2x](https://github.com/user-attachments/assets/a483bff4-a3d6-4382-8bf0-2709e65d5916)
