### PR TITLE
[BUGFIX] make postman public

### DIFF
--- a/.github/workflows/deploy_postman.yml
+++ b/.github/workflows/deploy_postman.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Deploy to Postman API
         env:
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
-          POSTMAN_COLLECTION_UID: 9bcc557f-7a58-4fce-86be-d799fee4e31b
+          POSTMAN_COLLECTION_UID: 5900de09-f05a-4528-8b12-9ad1d0477023
         run: |
           echo "On main branch with changes to collection - deploying to Postman API..."
           

--- a/Terminal49-API.postman_collection.json
+++ b/Terminal49-API.postman_collection.json
@@ -4357,7 +4357,7 @@
     ],
     "info": {
         "_postman_id": "54d3dd1f-0ab6-4f2e-9d83-23d837fc9ac0",
-        "name": "Terminal49 API Reference",
+        "name": "Terminal49 API Reference - Public",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {
             "content": "The Terminal 49 API offers a convenient way to programmatically track your shipments from origin to destination.\n\nPlease enter your API key into the \"Variables\" tab before using these endpoints within Postman.\n\nContact Support:\n Name: Terminal49 API support\n Email: support@terminal49.com",

--- a/docs/api-docs/getting-started/start-here.mdx
+++ b/docs/api-docs/getting-started/start-here.mdx
@@ -7,7 +7,7 @@ Our API responses use [JSONAPI](https://jsonapi.org/) schema. There are [client 
 
 Our APIs can be used with any HTTP client; choose your favorite! We love Postman, it's a friendly graphical interface to a powerful cross-platform HTTP client. Best of all it has support for the OpenAPI specs that we publish with all our APIs. We have created a collection of requests for you to easily test the API endpoints with your API Key. Link to the collection below.
 
-<Card icon = "caret-right" href="https://terminal49-api.postman.co/workspace/Terminal49-API-Workspace~19bbea84-be4f-4088-92d7-ef42bdefa737/collection/26830108-9bcc557f-7a58-4fce-86be-d799fee4e31b?action=share&creator=26830108">
+<Card icon = "caret-right" href="https://www.postman.com/terminal49-api/terminal49-api/collection/x2podso/terminal49-api-reference-public">
 **Run in Postman**
 </Card>
 


### PR DESCRIPTION
https://linear.app/terminal49/issue/DATA-6075/request-access-to-postman

Our previous "public" link required people to request access to the team, and then postman limited the number of guests we could accept.

This is a truly public link, which people can freely fork