### PR TITLE
docs: refresh non-mcp guides

### DIFF
--- a/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
+++ b/docs/api-docs/getting-started/tracking-shipments-and-containers.mdx
@@ -6,17 +6,10 @@ og:description: Track shipments and containers with ease via Terminal49's API. O
 ---
 
 ## What is a Tracking Request?
-
 Your tracking request includes two pieces of data:
 
     - Your Bill of Lading, Booking number, or container number from the carrier.
     - The SCAC code for that carrier.
-
-<Tip>
-  **Don't know the SCAC?** Use the [Auto-Detect
-  Carrier](/api-docs/in-depth-guides/auto-detect-carrier) endpoint to
-  automatically identify the shipping line from your tracking number.
-</Tip>
 
 You can see a complete list of supported SCACs in row 2 of the Carrier Data Matrix.
 
@@ -28,7 +21,7 @@ You can see a complete list of supported SCACs in row 2 of the Carrier Data Matr
     2. Booking number from the carrier
     3. Container number
 
-- Container number tracking support across ocean carriers is sometimes more limited. Please refer to the Carrier Data Matrix to see which SCACs are compatible with Container number tracking.
+* Container number tracking support across ocean carriers is sometimes more limited. Please refer to the Carrier Data Matrix to see which SCACs are compatible with Container number tracking.
 
 **Unsupported numbers**
 
@@ -38,7 +31,6 @@ You can see a complete list of supported SCACs in row 2 of the Carrier Data Matr
     - Internally generated numbers, for example PO numbers or customer reference numbers.
 
 ## How do I use Tracking Requests?
-
 Terminal49 is an event-based API, which means that the API can be used asynchronously. In general the data flow is:
 
     1. You send a tracking request to the API with your Bill of Lading number and SCAC.
@@ -48,7 +40,6 @@ Terminal49 is an event-based API, which means that the API can be used asynchron
     5. At any time, you can directly request a list of shipments and containers from Terminal49, and the API will return current statuses and information. This is covered in a different guide.
 
 ## How do you send me the data relating to the tracking request?
-
 You have two options. First, you can poll for updates. This is the way we'll show you first.
 
 You can poll the `GET /tracking_request/{id}` endpoint to see the status of your request. You just need to track the ID of your tracking request, which is returned to you by the API.
@@ -61,19 +52,17 @@ When we successfully lookup the Bill of Lading with the Carrier's SCAC, we will 
 
 If we encounter a problem we'll send the event `tracking_request.failed`.
 
-<Frame caption="Tracking Request Diagram">
-  ![](/images/create-shipment-flow.png)
-</Frame>
+<Frame caption="Tracking Request Diagram">![Tracking request flow diagram](/images/create-shipment-flow.png)</Frame>
+
 
 ## Authentication
-
 The API uses Bearer Token style authentication. This means you send your API Key as your token in every request.
 
 To get your API token to Terminal49 and go to your [account API settings](https://app.terminal49.com/settings/api)
 
 The token should be sent with each API request in the Authentication header:
 
-Support [dev@terminal49.com](dev@terminal49.com)
+Support: dev@terminal49.com
 
 ```
 Authorization: Token YOUR_API_KEY
@@ -81,8 +70,7 @@ Authorization: Token YOUR_API_KEY
 
 ## How to Create a Tracking Request
 
-Here is javascript code that demonstates sending a tracking request
-
+Here is javascript code that demonstrates sending a tracking request
 ```json
 fetch("https://api.terminal49.com/v2/tracking_requests", {
   "method": "POST",
@@ -108,94 +96,83 @@ fetch("https://api.terminal49.com/v2/tracking_requests", {
   console.error(err);
 });
 ```
-
 ## Anatomy of a Tracking Request Response
 
 Here's what you'll see in a Response to a tracking request.
 
 ```json
 {
-  "data": {
-    "id": "478cd7c4-a603-4bdf-84d5-3341c37c43a3",
-    "type": "tracking_request",
-    "attributes": {
-      "request_number": "xxxxxx",
-      "request_type": "bill_of_lading",
-      "scac": "MAEU",
-      "ref_numbers": [],
-      "created_at": "2020-09-17T16:13:30Z",
-      "updated_at": "2020-09-17T17:13:30Z",
-      "status": "pending",
-      "failed_reason": null,
-      "is_retrying": false,
-      "retry_count": null
-    },
-    "relationships": {
-      "tracked_object": {
-        "data": null
-      }
-    },
-    "links": {
-      "self": "/v2/tracking_requests/478cd7c4-a603-4bdf-84d5-3341c37c43a3"
+    "data": {
+        "id": "478cd7c4-a603-4bdf-84d5-3341c37c43a3",
+        "type": "tracking_request",
+        "attributes": {
+            "request_number": "xxxxxx",
+            "request_type": "bill_of_lading",
+            "scac": "MAEU",
+            "ref_numbers": [],
+            "created_at": "2020-09-17T16:13:30Z",
+            "updated_at": "2020-09-17T17:13:30Z",
+            "status": "pending",
+            "failed_reason": null,
+            "is_retrying": false,
+            "retry_count": null
+        },
+        "relationships": {
+            "tracked_object": {
+                "data": null
+            }
+        },
+        "links": {
+            "self": "/v2/tracking_requests/478cd7c4-a603-4bdf-84d5-3341c37c43a3"
+        }
     }
-  }
 }
 ```
-
 Note that if you try to track the same shipment, you will receive an error like this:
-
 ```json
 {
-  "errors": [
-    {
-      "status": "422",
-      "source": {
-        "pointer": "/data/attributes/request_number"
-      },
-      "title": "Unprocessable Entity",
-      "detail": "Request number 'xxxxxxx' with scac 'MAEU' already exists in a tracking_request with a pending or created status",
-      "code": "duplicate"
-    }
-  ]
+    "errors": [
+        {
+            "status": "422",
+            "source": {
+                "pointer": "/data/attributes/request_number"
+            },
+            "title": "Unprocessable Entity",
+            "detail": "Request number 'xxxxxxx' with scac 'MAEU' already exists in a tracking_request with a pending or created status",
+            "code": "duplicate"
+        }
+    ]
 }
 ```
-
 <Info>
 **Why so much JSON? (A note on JSON API)**
 
-The Terminal49 API is JSON API compliant, which means that there are nifty libraries which can translate JSON into a fully fledged object model that can be used with an ORM. This is very powerful, but it also requires a larger, more structured payload to power the framework. The tradeoff, therefore, is that it's less convenient if you're parsing the JSON directly. Ultimately we strongly recommend you set yourself up with a good library to use JSON API to its fullest extent. But for the purposes of understanding the API's fundamentals and getting your feet wet, we'll work with the data directly.
-
+The Terminal49 API is JSON API compliant, which means that there are nifty libraries which can translate JSON into a fully fledged object model that can be used with an ORM. This is very powerful, but it also requires a larger, more structured payload to power the framework. The tradeoff, therefore, is that it's less convenient if you're parsing the JSON directly. Ultimately we strongly recommend you set yourself up with a good library to use JSON API to its fullest extent. But for the purposes of understanding the APIs fundamentals and getting your feet wet, we'll work with the data directly.
 </Info>
 
 ## Try It: Make a Tracking Request
-
 Try it using the request maker below!
 
     1. Enter your API token in the autorization header value.
     2. Enter a value for the `request_number` and `scac`. The request number has to be a shipping line booking or master bill of lading number. The SCAC has to be a shipping line scac (see data sources to get a list of valid SCACs)
 
 Note that you can also access sample code in multiple languages by clicking the "Code Generation" below.
-
 <Warning>
 **Tracking Request Troubleshooting**
 
 The most common issue people encounter is that they are entering the wrong number.
 
-Please check that you are entering the Bill of Lading number, booking number, or container number and not internal reference at your company or by your frieght forwarder. You can the number you are supplying by going to a carrier's website and using their tools to track your shipment using the request number. If this works, and if the SCAC is supported by T49, you should able to track it with us.
-
-If you're unsure of the correct SCAC, try the [Auto-Detect Carrier](/api-docs/api-reference/tracking-requests/auto-detect-carrier) endpoint first.
+Please check that you are entering the Bill of Lading number, booking number, or container number and not internal reference at your company or by your freight forwarder. You can the number you are supplying by going to a carrier's website and using their tools to track your shipment using the request number. If this works, and if the SCAC is supported by T49, you should able to track it with us.
 
 It is entirely possible that's neither us nor you but the shipping line is giving us a headache. Temporary network problems, not populated manifest and other things happen! You can read on how are we handling them in the [Tracking Request Retrying](/api-docs/useful-info/tracking-request-retrying) section.
-
 </Warning>
 
 <Info>
-  Rate limiting: You can create up to 100 tracking requests per minute.
+Rate limiting: You can create up to 100 tracking requests per minute.
 </Info>
 
 <Info>
-  You can always email us at support@terminal49.com if you have persistent
-  issues.
+You can always email us at support@terminal49.com if you have persistent issues.
 </Info>
 
 ```json
@@ -211,8 +188,7 @@ It is entirely possible that's neither us nor you but the shipping line is givin
 ```
 
 ## Try It: List Your Active Tracking Requests
-
-We have not yet set up a webook to receive status updates from the Terminal49 API, so we will need to manually poll to check if the Tracking Request has succeeded or failed.
+We have not yet set up a webhook to receive status updates from the Terminal49 API, so we will need to manually poll to check if the Tracking Request has succeeded or failed.
 
 **Try it below. Click "Headers" and replace `<YOUR_API_KEY>` with your API key.**
 
@@ -226,13 +202,9 @@ We have not yet set up a webook to receive status updates from the Terminal49 AP
   }
 }
 ```
-
 ## Next Up: Get your Shipments
-
 Now that you've made a tracking request, let's see how you can list your shipments and retrieve the relevant data.
 
 <Info>
-  Go to this
-  [page](https://help.terminal49.com/en/articles/8074102-how-to-initiate-shipment-tracking-on-terminal49)
-  to see different ways of initiating shipment tracking on Terminal49.
+Go to this [page](https://help.terminal49.com/en/articles/8074102-how-to-initiate-shipment-tracking-on-terminal49) to see different ways of initiating shipment tracking on Terminal49.
 </Info>

--- a/docs/api-docs/in-depth-guides/including-resources.mdx
+++ b/docs/api-docs/in-depth-guides/including-resources.mdx
@@ -3,7 +3,7 @@ title: Including Resources
 ---
 Throughout the documentation you will notice that many of the endpoints include a `relationships` object inside of the `data` attribute.
 
-For example, if you are [requesting a container](/api/4c6091811c4e0-get-a-container) the relationships will include `shipment`, and possibly `pod_terminal` and `transport_events`
+For example, if you are requesting a container (see containers API reference in this site) the relationships will include `shipment`, and possibly `pod_terminal` and `transport_events`
 
 If you want to load the `shipment` and `pod_terminal` without making any additional requests you can add the query parameter `include` and provide a comma delimited list of the related resources:
 ```
@@ -14,4 +14,3 @@ You can even traverse the relationships up or down. For example if you wanted to
 ```
 containers/{id}?include=shipment,shipment.port_of_lading
 ```
-

--- a/docs/api-docs/in-depth-guides/quickstart.mdx
+++ b/docs/api-docs/in-depth-guides/quickstart.mdx
@@ -13,12 +13,6 @@ You'll need a four things to get started.
 3. **A Terminal49 Account.** If you don't have one yet, [sign up here.](https://app.terminal49.com/register)
 4. **An API key.** Sign in to your Terminal49 account and go to your [developer portal page](https://app.terminal49.com/developers) to get your API key.
 
-<Tip>
-  Not sure which SCAC to use? The [Auto-Detect
-  Carrier](/api-docs/in-depth-guides/auto-detect-carrier) API can identify it
-  from your tracking number.
-</Tip>
-
 ## Track a Shipment
 
 You can try this using the embedded request maker below, or using Postman.
@@ -42,17 +36,19 @@ Note that you can also access sample code, include a cURL template, by clicking 
 
 ## Check Your Tracking Request Succeeded
 
-We have not yet set up a webook to receive status updates from the Terminal49 API, so we will need to manually poll to check if the Tracking Request has succeeded or failed.
+We have not yet set up a webhook to receive status updates from the Terminal49 API, so we will need to manually poll to check if the Tracking Request has succeeded or failed.
+
+
 
 > ### Tracking Request Troubleshooting
+> The most common issue people encounter is that they are  entering the wrong number.
 >
-> The most common issue people encounter is that they are entering the wrong number.
->
-> Please check that you are entering the Bill of Lading number, booking number, or container number and not internal reference at your company or by your frieght forwarder. You can the number you are supplying by going to a carrier's website and using their tools to track your shipment using the request number. If this works, and if the SCAC is supported by T49, you should able to track it with us.
+> Please check that you are entering the Bill of Lading number, booking number, or container number and not internal reference at your company or by your freight forwarder. You can the number you are supplying by going to a carrier's website and using their tools to track your shipment using the request number. If this works, and if the SCAC is supported by T49, you should able to track it with us.
 >
 > You can always email us at support@terminal49.com if you have persistent issues.
 
 ** Try it below. Click "Headers" and replace `<YOUR_API_KEY>` with your API key.**
+
 
 ```json http
 {
@@ -102,6 +98,7 @@ Try it after replacing `<YOUR_API_KEY>` with your API key.
   }
 }
 ```
+
 
 ## Listening for Updates with Webhooks
 

--- a/docs/api-docs/in-depth-guides/webhooks.mdx
+++ b/docs/api-docs/in-depth-guides/webhooks.mdx
@@ -7,10 +7,10 @@ You may subscribe to events through webhooks to be alerted when events are trigg
 
 Visit https://app.terminal49.com/developers/webhooks and click the 'Create Webhook Endpoint' button to create your webhook through the UI.
 
-If you prefer to create webhooks programatically then see the [webhooks post endpoint documentation](/api-docs/api-reference/webhooks/create-a-webhook).
+If you prefer to create webhooks programmatically then see the [webhooks post endpoint documentation](/api-docs/api-reference/webhooks/create-a-webhook).
 
 
-## Available Webook Events
+## Available Webhook Events
 
 Each `WebhookNotification` event represents some change to a model which you may be notified of.
 

--- a/docs/api-docs/useful-info/api-data-sources-availability.mdx
+++ b/docs/api-docs/useful-info/api-data-sources-availability.mdx
@@ -4,7 +4,6 @@ description: Our platform gets data from variety of sources in order to create a
 og:title: API Data Sources Availability | Terminal49 API
 og:description: Access availability of API data sources to enhance shipping logistics with Terminal49's comprehensive tools.
 ---
-
 # Data Sources
 
 - **Ocean carriers (aka steamship lines):** bill of lading/booking details, vessel eta, containers and milestones
@@ -13,21 +12,13 @@ og:description: Access availability of API data sources to enhance shipping logi
 - **AIS data:** vessel details and real-time location tracking (coming soon!)
 
 ## Supported Ocean Carriers
-
 View a complete list of supported carriers and attributes on [Google Sheets](https://docs.google.com/spreadsheets/d/1cWK8sNpkjY5V-KlXe1fHi8mU_at2HcJYqjCvGQgixQk/edit#gid=0)
 
-<Tip>
-  You can also use the [Auto-Detect
-  Carrier](/api-docs/in-depth-guides/auto-detect-carrier) API to automatically
-  identify the SCAC from a tracking number.
-</Tip>
+{/* Carriers screenshot removed due to missing asset. See Google Sheet for details. */}
 
-[![Carriers Screenshot](../../assets/images/carriers_screenshot.png "Carriers Screenshot")](https://docs.google.com/spreadsheets/d/1cWK8sNpkjY5V-KlXe1fHi8mU_at2HcJYqjCvGQgixQk/edit#gid=0)
 
 ## Ports and Terminals
-
-Presently, the Terminal 49 api integrates with terminals at the following ports:
-
+Presently, the Terminal 49 API integrates with terminals at the following ports:
 - Baltimore
 - Boston
 - Charleston
@@ -67,173 +58,185 @@ You can view a complete list of supported terminals and attributes on [Google Sh
 - Union Pacific Railroad (UP)
 
 ## Known Issues (ocean)
-
 Shipment data is populated from requests to the shipping lines.
 
 Below are a list of known issues with our data sources:
 
 ### Cma-Cgm, APL, ANL
-
 - No container weight
 - No container seal number
 
 ### Maersk, Sealand, Safmarine
-
 - Shipment departure/arrival events are not always available depending on when BL is entered into system.
 - No container seal number
 
 ### Hamburg Süd
-
 - No estimated departure time
 - No container weight
 - No container seal number
 
 ### MSC
-
 - No container seal number
 
 ### Hapag Lloyd
-
 - No container weight
 - No container seal number
 
 ### Evergreen
-
 - All dates are provided as dates, not datetimes. We record and return them all as midnight at the location the event happened (when location is available) or midnight UTC.
 - Only Dry, Reefer, and Flatpack container types are mapped to our system
 
 ### COSCO
-
 - No departure or arrival events. Does not affect departure/arrival times.
 
-### OOCL
-
+###  OOCL
 - No container seal number
 
 ### ONE
-
 - Only Dry, and Reefer container types are mapped to our system
 
 ### Yang-Ming
-
 - When BL has multiple containers, the container weight returned is the average of the shipment. (i.e. the BL gross weight / number of containers)
 
 ### Hyundai Merchant Marine
-
 - No container type
 
 ### ZIM
-
 - No container weight
 - No container seal number
 
 ### Westwood Shipping
-
 - No container weight
 - Only Dry container types are mapped to our system
 
-{/* Rail Coverage section archived */}
+{/* ## Rail Coverage
+
+Rail data is populated from requests to the rail carriers.  Some carriers provide more data than others.
+
+
+| Event                       | BNSF | Canadian National Railway | Canadian Pacific Railway | Norfolk Southern Railway | Union Pacific Railroad | CSX Transportation |
+|-----------------------------|------|---------------------------|--------------------------|--------------------------|------------------------|---------------------|
+| rail_loaded                 |  ❌  |           ✅                |       ✅                   |       ✅                   |         ✅               |       ❌              |
+| rail_departed               |  ❌  |           ❌                |       ✅                   |           ✅               |           ✅             |       ✅              |
+| rail_arrived                |  ✅  |           ✅                |       ✅                   |           ✅               |           ✅             |       ✅              |
+| arrived_at_destination      |  ❌  |           ❌                |       ✅                   |         ❌                |         ❌               |        ❌             |
+| rail_unloaded               |  ✅  |           ✅                |       ❌                   |           ✅               |           ✅             |       ❌              |
+| train_passing               |  ❌  |           ❌                |       ❌                   |        ❌                  |         ✅               |       ❌              |
+| rail_interchange_delivered  |  ❌  |           ✅                |       ✅                   |           ✅               |           ✅             |       ❌              |
+| rail_interchange_received   |  ❌  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅              |
+| full_out                    |  ❌  |           ✅                |       ✅                   |           ✅               |           ✅             |       ❌              |
+| empty_in                    |  ❌  |           ✅                |       ❌                   |         ❌                |         ✅               |        ❌             |
+| full_in                     |  ❌  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅              |
+| empty_out                   |  ❌  |           ✅                |       ❌                   |         ❌                |         ❌               |        ❌             |
+| available                   |  ✅  |           ✅                |       ✅                   |         ✅                 |         ✅               |       ✅             |
+| customs_release             |  ❌  |           ✅                |       ❌                   |         ❌                |         ❌               |        ❌             |
+| not_available               |      |                           |                          |                          |                        |                     |
+| holds_and_fees_changed      |      |                           |                          |                          |                        |                     |
+| last_free_day_changed       |  ✅    |         ✅                  |     ✅                     |         ✅                 |          ✅              |     ✅                |
+
+In addition to some data not being provided by all carriers, there are a couple other known issues:
+
+- BNSF does not provide an event history
+- ETAs are notoriously incorrect (we're working on a way to improve on what we get from the carriers) */}
 
 # Data Fields & Availability
 
 {/* These seem very out of date... many new properties added since we updated it years ago.  Should we update it, or remove it? */}
-{/* I went ahead and added the newest properties to Container Data */}
+{/* I went ahead and added the newest properties to Container Data  */}
 
-Below is a list of data that can be retrieved via the API, including whether is is always available, or whether it is only supported by certain carriers (Carrier Dependent), certain Terminals (Terminal Dependent) or on certain types of journeys (Journey dependent).
+Below is a list of data that can be retrieved via the API, including whether it is always available, or whether it is only supported by certain carriers (Carrier Dependent), certain Terminals (Terminal Dependent) or on certain types of journeys (Journey dependent).
 
 ## Shipment Data
-
 Shipment Data is the primary data that comes from the Carrier. It containers the details of the shipment retrieved from the Bill of Lading, and references multiple container objects.
 
-| Data                                           | Availability                         | More details                                                                         | Notes                                                                      |
-| ---------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Port of Lading                                 | Always                               | Port of Lading name, Port of Lading UN/LOCODE, Port of Lading Timezone               |                                                                            |
-| Port of Discharge                              | Always                               | Port of Discharge name, Port of discharge UN/LOCODE,Port of Discharge Timezone       |                                                                            |
+| Data                                           | Availability            | More details           | Notes |
+| ------ |-----|-----|-----|
+| Port of Lading                                 | Always                               | Port of Lading name, Port of Lading UN/LOCODE, Port of Lading Timezone                |                                                                            |
+| Port of Discharge                              | Always                               | Port of Discharge name, Port of discharge UN/LOCODE,Port of Discharge Timezone        |                                                                            |
 | Final Destination beyond Port of Discharge     | Carrier dependent, Journey Dependent | Destination name, Destination UN/LOCODE, Destination UN/LOCODE, Destination Timezone | Only for shipments with inland moves provided by or booked by the carrier. |
-| Listing of Container Numbers                   | Always                               | A list of container numbers with data attributes listed below                        |                                                                            |
-| Bill of Lading Number                          | Always (inputted by user)            | BOL                                                                                  |                                                                            |
-| Shipping Line Details                          | Always                               | SCAC, SSL Name                                                                       |                                                                            |
-| Voyage Details                                 | Milestone-based                      | Vessel Name, Vessel IMO, Voyage Number                                               |                                                                            |
-| Estimated Time of Departure                    | Carrier dependent                    | Timestamp                                                                            |                                                                            |
-| Actual Time of Departure                       | Always                               | Timestamp                                                                            | After departure                                                            |
-| Estimated Time of Arrival at Port of Discharge | Carrier dependent                    | Timestamp                                                                            |                                                                            |
-| Actual Time of Arrival at Port of Discharge    | Always                               | Timestamp                                                                            | Available after arrival                                                    |
-| Estimated Time of Arrival at Final Destination | Carrier dependent, Journey dependent | Timestamp                                                                            | Only for vessels with inland moves.                                        |
+| Listing of Container Numbers                   | Always                               | A list of container numbers with data attributes listed below                         |                                                                            |
+| Bill of Lading Number                          | Always (inputted by user)            | BOL                                                                                   |                                                                            |
+| Shipping Line Details                          | Always                               | SCAC, SSL Name                                                                        |                                                                            |
+| Voyage Details                                 | Milestone-based                      | Vessel Name, Vessel IMO, Voyage Number                                                |                                                                            |
+| Estimated Time of Departure                    | Carrier dependent                    | Timestamp                                                                             |                                                                            |
+| Actual Time of Departure                       | Always                               | Timestamp                                                                             | After departure                                                            |
+| Estimated Time of Arrival at Port of Discharge | Carrier dependent                    | Timestamp                                                                             |                                                                            |
+| Actual Time of Arrival at Port of Discharge    | Always                               | Timestamp                                                                             | Available after arrival                                                    |
+| Estimated Time of Arrival at Final Destination | Carrier dependent, Journey dependent | Timestamp                                                                             | Only for vessels with inland moves.                                        |
+
 
 ## Container Data
-
 At the container level, the following data is available. Container data is combined from all sources to create a single data view of the container. As such some of this data will only available when certain milestones have passed.
 
-| Data                                   | Availability                         | More Details                                     | Notes                                                                                                                                           |
-| -------------------------------------- | ------------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Container Number                       | Always                               | number                                           |                                                                                                                                                 |
-| Seal Number                            | Carrier dependent                    | number                                           |                                                                                                                                                 |
-| Equipment Type                         | Always                               | Dry, reefer, open top, flat rack, tank, hard top | Enumerated data type                                                                                                                            |
-| Equipment length                       | Always                               | 20, 40, 45, 50                                   | Enumerated Data Type                                                                                                                            |
-| Equipment height                       | Always                               | Standard, high cube                              | Enumerated Data Type                                                                                                                            |
-| Weight                                 | Carrier Dependent                    | Number                                           |                                                                                                                                                 |
-| Terminal Availability                  | Always                               | Availability Known, Availability for Pickup      |                                                                                                                                                 |
-| Holds                                  | Terminal Dependent                   | Array of statuses                                | Each status includes the hold name (one of: customs, freight, TMF, other, USDA) and the status (pending, hold) as well as any extra description |
-| Fees                                   | Terminal Dependent                   | Array of statuses                                | Each status includes the fee type (one of: Demurrage, Exam, Other) and the amount the hold is for (a float)                                     |
-| Last Free Day                          | Terminal Dependent                   | Date of last free day                            |                                                                                                                                                 |
-| Arrived at Port of Discharge           | Always                               | Once Arrived                                     |                                                                                                                                                 |
-| Discharged at Port of Discharge        | Always                               | Once discharged                                  |                                                                                                                                                 |
-| Full Out at Port of Discharge          | Always                               |                                                  |                                                                                                                                                 |
-| Full out at final destination          | Journey Dependent                    | Only if non-port final destination               |                                                                                                                                                 |
-| Rail Loaded At Port of Discharge       | Journey Dependent                    | Only if non-port final destination               |                                                                                                                                                 |
-| Rail Departed At Port of Discharge     | Journey Dependent                    | Only if non-port final destination               |                                                                                                                                                 |
-| Rail Carrier Scac at Port of Discharge | Journey Dependent                    | Only if non-port final destination               |                                                                                                                                                 |
-| ETA for final destination              | Carrier Dependent, Journey Dependent | Only if non-port final destination               |                                                                                                                                                 |
-| ATA for final destination              | Journey Dependent                    | Only if non-port final destination               |                                                                                                                                                 |
-| LFD at final destination               | Carrier Dependent, Journey Dependent | Only if non-port final destination               |                                                                                                                                                 |
+|    Data          |     Availability          |                More Details                   |        Notes          |
+| ---------------- | ----------------- | ------------------------------------------------ | -------------------- |
+| Container Number | Always            | number                                           |                      |
+| Seal Number      | Carrier dependent | number                                           |                      |
+| Equipment Type   | Always            | Dry, reefer, open top, flat rack, tank, hard top | Enumerated data type |
+| Equipment length | Always            | 20, 40, 45, 50                                   | Enumerated Data Type |
+| Equipment height | Always            | Standard, high cube                              | Enumerated Data Type |
+| Weight           | Carrier Dependent | Number                                           |                      |
+| Terminal Availability               | Always            | Availability Known, Availability for Pickup | |
+| Holds                               | Terminal Dependent| Array of    statuses   |  Each status includes the hold name (one of: customs, freight, TMF, other, USDA) and the status (pending, hold) as well as any extra description|
+| Fees                                | Terminal Dependent| Array of statuses| Each status includes the fee type (one of: Demurrage, Exam, Other) and the amount the hold is for  (a float)|
+| Last Free Day                       | Terminal Dependent| Date of last free day |     |
+| Arrived at Port of Discharge        | Always            | Once Arrived |        |
+| Discharged at Port of Discharge     | Always            | Once discharged          |                |
+| Full Out at Port of Discharge       | Always            |  | |
+| Full out at final destination       | Journey Dependent | Only if non-port final destination |  |
+| Rail Loaded At Port of Discharge    | Journey Dependent | Only if non-port final destination |  |
+| Rail Departed At Port of Discharge  | Journey Dependent | Only if non-port final destination |  |
+| Rail Carrier SCAC at Port of Discharge |Journey Dependent | Only if non-port final destination | |
+| ETA for final destination           | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
+| ATA for final destination           | Journey Dependent | Only if non-port final destination |  |
+| LFD at final destination            | Carrier Dependent, Journey Dependent | Only if non-port final destination |  |
 
-## Milestone Event Data
 
+##  Milestone Event Data
 When a milestone passes, the Terminal49 API will ping one of your webhooks with a Milestone event. For each milestone, the following data is always provided. Container, Shipment, Vessel, Location and Terminal data will be provided as objects that contain the information listed above.
 
-| Milestone Data | Description                                                     |
-| -------------- | --------------------------------------------------------------- |
-| Event Name     | the name of the event. e.g. 'container.transport.vessel_loaded' |
-| Created At     | when the event was created in our system                        |
-| Timestamp      | when the event occured                                          |
-| Timezone       | Which timezone did the event occur in.                          |
-| Voyage Number  | the voyage number of the vessel                                 |
-| Container      | A link to the Container Data                                    |
-| Shipment       | A link to the Shipment Data                                     |
-| Vessel         | Which vessel did the event occur on.                            |
-| Location       | Where did the event oocur.                                      |
-| Terminal       | Which terminal did this occur at.                               |
+| Milestone Data |         Description                                              |
+| -------------- | ---------------------------------------------------------------- |
+| Event Name     | the name of the event. e.g. 'container.transport.vessel\_loaded' |
+| Created At     | when the event was created in our system                         |
+| Timestamp      | when the event occurred                                           |
+| Timezone       | Which timezone did the event occur in.                           |
+| Voyage Number  | the voyage number of the vessel                                  |
+| Container      | A link to the Container Data                                     |
+| Shipment       | A link to the Shipment Data                                      |
+| Vessel         | Which vessel did the event occur on.                             |
+| Location       | Where did the event occur.                                       |
+| Terminal       | Which terminal did this occur at.                                |
 
 ## Milestones Events Supported
-
 A list of milestones that the API can track, as well as the event name used in the API. In future, further events may be supported.
 
 {/* Why do we have this here when we already have a list of events in multiple other places? */}
 
-| Milestone Event Name                    | Event Name                                                  |
-| --------------------------------------- | ----------------------------------------------------------- |
-| Vessel Loaded                           | container.transport.vessel_loaded                           |
-| Vessel Departed                         | container.transport.vessel_departed                         |
-| Vessel Arrived                          | container.transport.vessel_arrived                          |
-| Vessel Berthed                          | container.transport.vessel_berthed                          |
-| Vessel Discharged                       | container.transport.vessel_discharged                       |
-| Empty Out                               | container.transport.empty_out                               |
-| Full In                                 | container.transport.full_in                                 |
-| Full Out                                | container.transport.full_out                                |
-| Empty In                                | container.transport.empty_in                                |
-| Rail Departed                           | container.transport.rail_departed                           |
-| Rail Arrived                            | container.transport.rail_arrived                            |
-| Rail Loaded                             | container.transport.rail_loaded                             |
-| Rail Unloaded                           | container.transport.rail_unloaded                           |
-| Transshipment Arrived                   | container.transport.transshipment_arrived                   |
-| Transshipment Discharged                | container.transport.transshipment_discharged                |
-| Transshipment Loaded                    | container.transport.transshipment_loaded                    |
-| Transshipment Departed                  | container.transport.transshipment_departed                  |
-| Feeder Arrived                          | container.transport.feeder_arrived                          |
-| Feeder Discharged                       | container.transport.feeder_discharged                       |
-| Feeder Loaded                           | container.transport.feeder_loaded                           |
-| Feeder Departed                         | container.transport.feeder_departed                         |
-| Arrived at inland destination           | container.transport.arrived_at_inland_destination           |
-| Estimated Arrived at inland destination | container.transport.estimated.arrived_at_inland_destination |
-| Pickup LFD changed                      | container.pickup_lfd.changed                                |
-| Available at Destination                | container.transport.available                               |
+|              Milestone Event Name        | Event Name           |
+| -------------------- | -------------------------------------- |
+| Vessel Loaded   | container.transport.vessel\_loaded |
+| Vessel Departed   | container.transport.vessel\_departed |
+| Vessel Arrived    | container.transport.vessel\_arrived |
+| Vessel Berthed    | container.transport.vessel\_berthed |
+| Vessel Discharged   | container.transport.vessel\_discharged |
+| Empty Out   | container.transport.empty\_oud |
+| Full In   | container.transport.full\_id |
+| Full Out    | container.transport.full\_out |
+| Empty In    | container.transport.empty\_id |
+| Rail Departed   | container.transport.rail\_departed |
+| Rail Arrived    | container.transport.rail\_arrived |
+| Rail Loaded   | container.transport.rail\_loaded |
+| Rail Unloaded   | container.transport.rail\_unloaded |
+| Transshipment Arrived   | container.transport.transshipment\_arrived |
+| Transshipment Discharged    | container.transport.transshipment\_discharged |
+| Transshipment Loaded    | container.transport.transshipment\_loaded |
+| Transshipment Departed    | container.transport.transshipment\_departed |
+| Feeder Arrived    | container.transport.feeder\_arrived |
+| Feeder Discharged   | container.transport.feeder\_discharged |
+| Feeder Loaded   | container.transport.feeder\_loaded |
+| Feeder Departed   | container.transport.feeder\_departed |
+| Arrived at inland destination   | container.transport.arrived\_at\_inland\_destination |
+| Estimated Arrived at inland destination   | container.transport.estimated.arrived\_at\_inland\_destination |
+| Pickup LFD changed   | container.pickup_lfd.changed |
+| Available at Destination | container.transport.available |


### PR DESCRIPTION
## Summary
- Refresh non-MCP guides (tracking shipments, including resources, quickstart, webhooks, data sources availability)

## Testing
- Not run (docs-only)
