### PR TITLE
docs: add Vale config

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,0 +1,31 @@
+# Top level styles
+StylesPath = styles
+MinAlertLevel = suggestion
+IgnoredScopes = code, tt, img, url, a
+SkippedScopes = script, style, pre, figure, code, json
+
+
+# This is required since Vale doesn't officially support MDX
+[formats]
+mdx = md
+
+# MDX support
+[*.mdx]
+BasedOnStyles = Vale
+Vale.Terms = NO
+Vale.Spelling = NO
+
+# `import ...`, `export ...`
+# `<Component ... />`
+# `<Component>...</Component>`
+# `{ ... }`
+TokenIgnores = (?sm)((?:import|export) .+?$), \
+(?<!`)(<\w+ ?.+ ?\/>)(?!`), \
+(<[A-Z]\w+>.+?<\/[A-Z]\w+>)
+
+# Exclude:
+# `<Component \n ... />`
+BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
+(?sm)^({.+.*})
+
+CommentDelimiters = {/*, */}

--- a/docs/config/vocabularies/Terminal49/accept.txt
+++ b/docs/config/vocabularies/Terminal49/accept.txt
@@ -1,0 +1,179 @@
+Terminal49
+terminal49
+T49
+SCAC
+SCACs
+BOL
+HBOL
+UN/LOCODE
+LOCODE
+IMO
+ETA
+ATA
+ETD
+ATD
+LFD
+TMF
+USDA
+Demurrage
+Reefer
+Flatpack
+Flatrack
+datetimes
+datetime
+Maersk
+Sealand
+Safmarine
+Hapag
+Hapag-Lloyd
+Westwood
+COSCO
+OOCL
+ONE
+Yang-Ming
+Hyundai
+MSC
+CMA-CGM
+APL
+ANL
+Hamburg
+Süd
+Evergreen
+ZIM
+BNSF
+CN
+CP
+CSX
+NS
+UP
+UPRR
+Union Pacific
+Canadian National
+Canadian Pacific
+Norfolk Southern
+Namespaced
+dotenv
+Vercel
+streamable
+StreamableHTTPServerTransport
+SSE
+JSON-RPC
+JSON:API
+openapi-fetch
+openapi-typescript
+MCP
+Model Context Protocol
+McpServer
+StdioServerTransport
+SSEServerTransport
+Dry
+Open Top
+Flat Rack
+Tank
+Hard Top
+Baltimore
+Boston
+Charleston
+Fraser
+Surrey
+Halifax
+Houston
+Jacksonville
+London Gateway
+Long Beach
+Los Angeles
+Miami
+Mobile
+New Orleans
+New York
+New Jersey
+Oakland
+Philadelphia
+Port Everglades
+Portland
+Prince Rupert
+Savannah
+Seattle
+Southampton
+Tacoma
+Tampa
+Vancouver
+Virginia
+BNSF Railway
+Canadian National Railway
+Canadian Pacific Railway
+CSX Transportation
+Norfolk Southern Railway
+Union Pacific Railroad
+JSON:API
+JSON-RPC
+REST
+GraphQL
+WebSocket
+OAuth
+JWT
+Bearer
+API
+APIs
+SDK
+SDKs
+CLI
+HTTP
+HTTPS
+URI
+URL
+CORS
+CSRF
+XHR
+XHR2
+WebSocket
+localhost
+middleware
+runtime
+webhook
+webhooks
+JSON
+YAML
+MDX
+TypeScript
+JavaScript
+Node.js
+NodeJS
+npm
+yarn
+pnpm
+ESLint
+Prettier
+GitHub
+GitLab
+Bitbucket
+VSCode
+Visual Studio Code
+dev
+env
+config
+ctx
+desc
+dir
+elem
+err
+len
+msg
+num
+obj
+prev
+proc
+ptr
+req
+res
+str
+tmp
+val
+vars
+todo
+href
+lang
+nav
+prev
+next
+toc

--- a/docs/styles/Vale/Spelling.yml
+++ b/docs/styles/Vale/Spelling.yml
@@ -1,0 +1,5 @@
+extends: spelling
+message: "Did you really mean '%s'?"
+level: error
+wordlist:
+  - styles/Vocab/Terminal49/accept.txt

--- a/docs/styles/Vale/Terms.yml
+++ b/docs/styles/Vale/Terms.yml
@@ -1,0 +1,19 @@
+extends: substitution
+message: "'%s' is not recognized"
+level: suggestion
+ignorecase: true
+swap:
+  SCAC: SCAC
+  SCACs: SCACs
+  streamable: streamable
+  OAuth: OAuth
+  repo: repo
+  url: url
+  mcpServers: mcpServers
+  javascript: javascript
+  uuid: uuid
+  enum: enum
+  anyOf: anyOf
+  Http: Http
+  programatically: programmatically
+

--- a/docs/styles/Vocab/Terminal49/accept.txt
+++ b/docs/styles/Vocab/Terminal49/accept.txt
@@ -1,0 +1,219 @@
+Terminal49
+terminal49
+T49
+SCAC
+SCACs
+scac
+BOL
+HBOL
+UN/LOCODE
+LOCODE
+IMO
+ETA
+ATA
+ETD
+ATD
+LFD
+TMF
+USDA
+Demurrage
+Reefer
+Flatpack
+Flatrack
+datetimes
+datetime
+Maersk
+Sealand
+Safmarine
+Hapag
+Hapag-Lloyd
+Westwood
+COSCO
+OOCL
+ONE
+Yang-Ming
+Hyundai
+MSC
+CMA-CGM
+APL
+ANL
+Hamburg
+Süd
+Evergreen
+ZIM
+BNSF
+CN
+CP
+CSX
+NS
+UP
+UPRR
+Union Pacific
+Canadian National
+Canadian Pacific
+Norfolk Southern
+Namespaced
+dotenv
+Vercel
+streamable
+StreamableHTTPServerTransport
+SSE
+JSON-RPC
+JSON:API
+openapi-fetch
+openapi-typescript
+MCP
+Model Context Protocol
+McpServer
+StdioServerTransport
+SSEServerTransport
+Dry
+Open Top
+Flat Rack
+Tank
+Hard Top
+Baltimore
+Boston
+Charleston
+Fraser
+Surrey
+Halifax
+Houston
+Jacksonville
+London Gateway
+Long Beach
+Los Angeles
+Miami
+Mobile
+New Orleans
+New York
+New Jersey
+Oakland
+Philadelphia
+Port Everglades
+Portland
+Prince Rupert
+Savannah
+Seattle
+Southampton
+Tacoma
+Tampa
+Vancouver
+Virginia
+BNSF Railway
+Canadian National Railway
+Canadian Pacific Railway
+CSX Transportation
+Norfolk Southern Railway
+Union Pacific Railroad
+JSON:API
+JSON-RPC
+REST
+GraphQL
+WebSocket
+OAuth
+JWT
+Bearer
+API
+APIs
+SDK
+SDKs
+CLI
+HTTP
+HTTPS
+URI
+URL
+CORS
+CSRF
+XHR
+XHR2
+WebSocket
+localhost
+middleware
+runtime
+webhook
+webhooks
+JSON
+YAML
+MDX
+TypeScript
+JavaScript
+Node.js
+NodeJS
+npm
+yarn
+pnpm
+ESLint
+Prettier
+GitHub
+GitLab
+Bitbucket
+VSCode
+Visual Studio Code
+dev
+env
+config
+ctx
+desc
+dir
+elem
+err
+len
+msg
+num
+obj
+prev
+proc
+ptr
+req
+res
+str
+tmp
+val
+vars
+todo
+href
+lang
+nav
+prev
+next
+toc
+tracking_request
+tracking_requests
+request_type
+request_number
+bill_of_lading
+scac
+ref_numbers
+created_at
+updated_at
+failed_reason
+is_retrying
+retry_count
+tracked_object
+pod_terminal
+pickup_lfd
+pickup_appointment_at
+holds_at_pod_terminal
+fees_at_pod_terminal
+available_for_pickup
+estimated_event
+transport_event
+container_updated_event
+delivery_status
+reference_object
+webhook_notification
+anyOf
+enum
+uuid
+url
+mcpServers
+OAuth
+repo
+Http
+javascript
+url
+URL
+urls
+URLs
+xxxxxx


### PR DESCRIPTION
## Summary
- Add Vale config and Terminal49 vocab/terms rules

## Testing
- Not run (docs tooling)
