### PR TITLE
Add Segment analytics to docs via custom script (proxied)

### DIFF
--- a/docs/segment.js
+++ b/docs/segment.js
@@ -1,0 +1,83 @@
+/* eslint-disable */
+/**
+ * Segment analytics.js loader for the Mintlify docs site.
+ *
+ * Loaded automatically by Mintlify as a custom script on every page.
+ * Routes the CDN and ingest hosts through our Cloudflare Workers so
+ * adblockers don't drop events — matching how app.terminal49.com and
+ * terminal49.com already ship Segment.
+ *
+ * We do NOT use Mintlify's built-in `integrations.segment` config
+ * because it only accepts a write key and loads directly from
+ * cdn.segment.com / api.segment.io (no proxy support).
+ */
+(function () {
+  var WRITE_KEY = 'QGH911NkPhgr2Ai31FL9EZYphywFL7j2';
+  var CDN_HOST = 'https://cdn-segment-worker.t49.workers.dev';
+  var API_HOST = 'api-segment-worker.t49.workers.dev/v1';
+
+  var analytics = (window.analytics = window.analytics || []);
+  if (analytics.initialize) return;
+  if (analytics.invoked) {
+    if (window.console && console.error) {
+      console.error('Segment snippet included twice.');
+    }
+    return;
+  }
+  analytics.invoked = true;
+  analytics.methods = [
+    'trackSubmit', 'trackClick', 'trackLink', 'trackForm', 'pageview',
+    'identify', 'reset', 'group', 'track', 'ready', 'alias', 'debug',
+    'page', 'once', 'off', 'on', 'addSourceMiddleware',
+    'addIntegrationMiddleware', 'setAnonymousId', 'addDestinationMiddleware',
+  ];
+  analytics.factory = function (method) {
+    return function () {
+      var args = Array.prototype.slice.call(arguments);
+      args.unshift(method);
+      analytics.push(args);
+      return analytics;
+    };
+  };
+  for (var i = 0; i < analytics.methods.length; i++) {
+    var key = analytics.methods[i];
+    analytics[key] = analytics.factory(key);
+  }
+  analytics.load = function (key, opts) {
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = CDN_HOST + '/analytics.js/v1/' + key + '/analytics.min.js';
+    var first = document.getElementsByTagName('script')[0];
+    first.parentNode.insertBefore(script, first);
+    analytics._loadOptions = opts;
+  };
+  analytics._writeKey = WRITE_KEY;
+  analytics.SNIPPET_VERSION = '4.15.3';
+  analytics.load(WRITE_KEY, {
+    integrations: { 'Segment.io': { apiHost: API_HOST } },
+  });
+  analytics.page();
+
+  // Mintlify is a SPA — analytics.js v1 doesn't auto-track route changes,
+  // so patch history + listen to popstate to fire analytics.page() on
+  // every client-side navigation.
+  var origPushState = history.pushState;
+  var origReplaceState = history.replaceState;
+  function firePage() {
+    if (window.analytics && typeof window.analytics.page === 'function') {
+      window.analytics.page();
+    }
+  }
+  history.pushState = function () {
+    var ret = origPushState.apply(this, arguments);
+    firePage();
+    return ret;
+  };
+  history.replaceState = function () {
+    var ret = origReplaceState.apply(this, arguments);
+    firePage();
+    return ret;
+  };
+  window.addEventListener('popstate', firePage);
+})();

--- a/docs/segment.js
+++ b/docs/segment.js
@@ -1,67 +1,114 @@
-/* eslint-disable */
 /**
- * Segment analytics.js loader for the Mintlify docs site.
+ * Segment analytics.js v5.2.1 loader for the Mintlify docs site.
  *
- * Loaded automatically by Mintlify as a custom script on every page.
- * Routes the CDN and ingest hosts through our Cloudflare Workers so
+ * Based on the official snippet from:
+ * https://www.twilio.com/docs/segment/connections/sources/catalog/libraries/website/javascript/quickstart
+ *
+ * Routes the CDN and API hosts through our Cloudflare Workers so
  * adblockers don't drop events — matching how app.terminal49.com and
  * terminal49.com already ship Segment.
  *
- * We do NOT use Mintlify's built-in `integrations.segment` config
- * because it only accepts a write key and loads directly from
- * cdn.segment.com / api.segment.io (no proxy support).
+ * We use a custom script instead of Mintlify's built-in
+ * `integrations.segment` config because it only accepts a write key
+ * and loads directly from cdn.segment.com (no proxy support).
  */
 (function () {
   var WRITE_KEY = 'QGH911NkPhgr2Ai31FL9EZYphywFL7j2';
   var CDN_HOST = 'https://cdn-segment-worker.t49.workers.dev';
   var API_HOST = 'api-segment-worker.t49.workers.dev/v1';
 
-  var analytics = (window.analytics = window.analytics || []);
+  var i = 'analytics';
+  var analytics = (window[i] = window[i] || []);
+
   if (analytics.initialize) return;
+
   if (analytics.invoked) {
     if (window.console && console.error) {
       console.error('Segment snippet included twice.');
     }
     return;
   }
+
   analytics.invoked = true;
+
   analytics.methods = [
-    'trackSubmit', 'trackClick', 'trackLink', 'trackForm', 'pageview',
-    'identify', 'reset', 'group', 'track', 'ready', 'alias', 'debug',
-    'page', 'once', 'off', 'on', 'addSourceMiddleware',
-    'addIntegrationMiddleware', 'setAnonymousId', 'addDestinationMiddleware',
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'screen',
+    'once',
+    'off',
+    'on',
+    'addSourceMiddleware',
+    'addIntegrationMiddleware',
+    'setAnonymousId',
+    'addDestinationMiddleware',
+    'register',
   ];
-  analytics.factory = function (method) {
+
+  analytics.factory = function (e) {
     return function () {
-      var args = Array.prototype.slice.call(arguments);
-      args.unshift(method);
-      analytics.push(args);
+      if (window[i].initialized) {
+        return window[i][e].apply(window[i], arguments);
+      }
+      var n = Array.prototype.slice.call(arguments);
+      if (
+        ['track', 'screen', 'alias', 'group', 'page', 'identify'].indexOf(e) >
+        -1
+      ) {
+        var c = document.querySelector("link[rel='canonical']");
+        n.push({
+          __t: 'bpc',
+          c: (c && c.getAttribute('href')) || void 0,
+          p: location.pathname,
+          u: location.href,
+          s: location.search,
+          t: document.title,
+          r: document.referrer,
+        });
+      }
+      n.unshift(e);
+      analytics.push(n);
       return analytics;
     };
   };
-  for (var i = 0; i < analytics.methods.length; i++) {
-    var key = analytics.methods[i];
+
+  for (var n = 0; n < analytics.methods.length; n++) {
+    var key = analytics.methods[n];
     analytics[key] = analytics.factory(key);
   }
-  analytics.load = function (key, opts) {
-    var script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.async = true;
-    script.src = CDN_HOST + '/analytics.js/v1/' + key + '/analytics.min.js';
+
+  analytics.load = function (key, options) {
+    var t = document.createElement('script');
+    t.type = 'text/javascript';
+    t.async = true;
+    t.setAttribute('data-global-segment-analytics-key', i);
+    t.src = CDN_HOST + '/analytics.js/v1/' + key + '/analytics.min.js';
     var first = document.getElementsByTagName('script')[0];
-    first.parentNode.insertBefore(script, first);
-    analytics._loadOptions = opts;
+    first.parentNode.insertBefore(t, first);
+    analytics._loadOptions = options;
   };
+
   analytics._writeKey = WRITE_KEY;
-  analytics.SNIPPET_VERSION = '4.15.3';
+  analytics.SNIPPET_VERSION = '5.2.1';
+
   analytics.load(WRITE_KEY, {
     integrations: { 'Segment.io': { apiHost: API_HOST } },
   });
   analytics.page();
 
-  // Mintlify is a SPA — analytics.js v1 doesn't auto-track route changes,
-  // so patch history + listen to popstate to fire analytics.page() on
-  // every client-side navigation.
+  // Mintlify is a SPA — analytics.js doesn't auto-track client-side
+  // navigation, so fire analytics.page() on every route change.
   var origPushState = history.pushState;
   var origReplaceState = history.replaceState;
   function firePage() {


### PR DESCRIPTION
## Summary
Adds Segment to the Mintlify docs site via a [custom script](https://www.mintlify.com/docs/customize/custom-scripts) (`docs/segment.js`) rather than the built-in `integrations.segment` config, so we can route through our existing Cloudflare Worker reverse proxies.

```
CDN: cdn-segment-worker.t49.workers.dev  →  cdn.segment.com
API: api-segment-worker.t49.workers.dev  →  api.segment.io
```

This matches how `app.terminal49.com` (tnt-ui) and `terminal49.com` (marketing, after [website#233](https://github.com/Terminal49/website/pull/233)) already ship Segment — so adblockers stop dropping docs events.

## Why not `integrations.segment`
Mintlify's built-in Segment integration only takes `{ key }` and loads scripts directly from `cdn.segment.com` / `api.segment.io`. There's no `apiHost` option. I verified this against [the docs](https://www.mintlify.com/docs/integrations/analytics/segment). So for proxy parity with the rest of our properties, we need the escape hatch.

## Why custom script works
[Mintlify docs](https://www.mintlify.com/docs/customize/custom-scripts): *"Mintlify includes any `.js` file inside your content directory on every page of your documentation site."* That means dropping `docs/segment.js` gets it injected as a global `<script>` on every page — same effect as Mintlify's built-in integration, but with full control over the snippet.

## What's in `docs/segment.js`
1. **Standard Segment v4.15.3 snippet**, but patched:
   - Loads `analytics.min.js` from `cdn-segment-worker.t49.workers.dev` instead of `cdn.segment.com`
   - Passes `integrations: { 'Segment.io': { apiHost: 'api-segment-worker.t49.workers.dev/v1' } }` to `analytics.load()` so events ingest via the API Worker
2. **SPA route tracking** — Mintlify is a SPA, and analytics.js v1 doesn't auto-track client-side nav. Patches `history.pushState` / `history.replaceState` + listens to `popstate` to fire `analytics.page()` on every route change.
3. Uses the same write key (`QGH9…L7j2`) as the marketing site and app, so docs events join the shared Segment source.

## Test plan
- [ ] Merge and wait for Mintlify rebuild
- [ ] Open `terminal49.com/docs` in a fresh private window, DevTools Network tab open:
  - [ ] `cdn-segment-worker.t49.workers.dev/analytics.js/v1/QGH9…/analytics.min.js` loads 200
  - [ ] Subsequent `/page`, `/track` calls go to `api-segment-worker.t49.workers.dev/v1/p` (not `api.segment.io`)
  - [ ] No CSP / CORS errors in console
- [ ] Click through a few docs pages — Network tab should show a new `analytics.page()` call to the API Worker per navigation (not just the initial load)
- [ ] In Segment's debugger for the shared source, confirm docs pageviews are flowing with the right URLs
- [ ] Repeat with uBlock Origin enabled — events should still flow (that's the whole point)

## Previously on this PR
First push used Mintlify's built-in `integrations.segment` config, force-pushed to swap in the custom-script approach after confirming Mintlify has no Segment proxy option. The PostHog proxy setup from #194 is untouched — PostHog keeps using `integrations.posthog` since that config *does* support `apiHost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)