### PR TITLE
docs: add container.pickup_lfd_rail.changed webhook event

### DIFF
--- a/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
+++ b/docs/api-docs/in-depth-guides/rail-integration-guide.mdx
@@ -115,6 +115,7 @@ Here's a list of the rail-specific events which support webhook notifications:
 | Rail Arrived   | `container.transport.rail_arrived`  | The container arrives at a rail terminal (not always at the destination terminal). | <a href="https://www.terminal49.com/docs/api-docs/useful-info/webhook-events-examples#container-transport-rail-arrived" target="_blank">Example</a> |
 | Arrived At Inland Destination | `container.transport.arrived_at_inland_destination` | The container arrives at the destination terminal. | <a href="https://www.terminal49.com/docs/api-docs/useful-info/webhook-events-examples#container-transport-arrived-at-inland-destination" target="_blank">Example</a> |
 | Rail Unloaded  | `container.transport.rail_unloaded` | The container is unloaded from a railcar. | <a href="https://www.terminal49.com/docs/api-docs/useful-info/webhook-events-examples#container-transport-rail-unloaded" target="_blank">Example</a> |
+| Rail LFD Changed | `container.pickup_lfd_rail.changed` | The Rail Last Free Day (LFD) for the container has changed. |  |
 
 There's also a set of events that are triggered when the status of the container at the destination rail terminal changes.  For containers without rail, they would have been triggered at the ocean terminal.
 

--- a/docs/api-docs/in-depth-guides/webhooks.mdx
+++ b/docs/api-docs/in-depth-guides/webhooks.mdx
@@ -61,6 +61,7 @@ Event | Description
  `container.transport.estimated.arrived_at_inland_destination` | ETA change notification (for destination)
  `container.pickup_lfd.changed` | Last Free Day (LFD) changed for container
  `container.pickup_lfd_line.changed` | Shipping Line Last Free Day (LFD) changed for container
+ `container.pickup_lfd_rail.changed` | Rail Last Free Day (LFD) changed for container (Rail Plan only)
  `container.transport.available` | Container is available at destination
 
 


### PR DESCRIPTION
## Summary
- Add `container.pickup_lfd_rail.changed` to the webhook events list in the Webhooks guide, noted as Rail Plan only.
- Add the same event to the rail-specific webhook notifications table in the Rail Integration Guide.

## Test plan
- [ ] Preview both pages and confirm the new event appears in the correct tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)