### PR TITLE
test(sdk): regression test for Content-Type preservation through auth interceptor

### DIFF
--- a/sdks/typescript-sdk/CHANGELOG.md
+++ b/sdks/typescript-sdk/CHANGELOG.md
@@ -13,6 +13,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - JSDoc comments on all public classes, interfaces, methods, and types
 - `npm run docs` script for regenerating SDK reference pages
 
+### Tests
+
+- Regression test for `Content-Type` preservation through the auth interceptor.
+  Pins the invariant that body-bearing requests reach the wire with their
+  `Content-Type` intact (a class of bug that caused every write to 422 in an
+  earlier `buildFetch`-based design before the architecture refactor moved
+  header handling into `AuthInterceptor.onRequest`, which mutates
+  `request.headers` in place).
+
 ## [0.1.0] — 2026-03-01
 
 ### Added

--- a/sdks/typescript-sdk/src/client.request.test.ts
+++ b/sdks/typescript-sdk/src/client.request.test.ts
@@ -661,4 +661,38 @@ describe('Terminal49Client request building', () => {
     expect(items[1].id).toBe('ship-2');
     expect(items[1].status).toBe('discharged');
   });
+
+  it('preserves Content-Type from openapi-fetch Request on POST writes', async () => {
+    // Regression for a bug that caused 422 on every write: previously
+    // `authedFetch` (now AuthInterceptor) created fresh Headers from init
+    // only and replaced the Request's headers — dropping Content-Type and
+    // making the body unparseable server-side. The current implementation
+    // mutates `request.headers` in place, which preserves whatever
+    // openapi-fetch set. Asserts the regression stays fixed.
+    const { fetchImpl, calls } = createMockFetch({
+      '/tracking_requests/infer_number': () =>
+        jsonResponse({
+          data: {
+            type: 'infer_number_results',
+            attributes: { number_type: 'bill_of_lading' },
+          },
+        }),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    await client.trackingRequests.inferNumber('HLCUAMM260301785');
+
+    expect(calls.length).toBe(1);
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get('Authorization')).toBe('Token token-123');
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({ number: 'HLCUAMM260301785' }),
+    );
+  });
 });


### PR DESCRIPTION
## What this PR does now

Adds a single regression test that pins the invariant: body-bearing requests reach the wire with their `Content-Type` intact.

## Original story (for context)

The earlier `buildFetch`-based design had a bug — it seeded fresh `Headers` from `init.headers` only, then `fetch(Request, { headers })` replaced the Request's headers entirely, dropping `Content-Type`. Every write hit `422 /data/attributes/number` server-side because the body was unparseable. Affected `inferNumber`, `createTrackingRequest`, `updateTrackingRequest`, `stopTrackingShipment`.

The downstream [Terminal49/t49#2010](https://github.com/Terminal49/t49/pull/2010) (Zapier 2.0.6) had to route writes around the SDK via `z.request` because of this.

## Why it's now just a test

The architecture refactor in **#209** moved header handling from a `buildFetch` wrapper to `AuthInterceptor.onRequest`, which mutates `request.headers` in place rather than replacing them — so the underlying bug is **already fixed as a side effect**. Rebasing this PR onto current `main` showed the original `client.ts` change is no longer needed.

This PR keeps just the regression test (and a CHANGELOG entry under "Tests"). If anyone refactors header handling again in a way that loses `Content-Type`, this test fires.

## Verification

```
Test Files  4 passed | 1 skipped (5)
      Tests  50 passed | 2 skipped (52)
```

## Downstream cleanup

Once this lands and `@terminal49/sdk` is bumped in `Terminal49/t49#2010`, that PR's `apiPost`/`apiPatch` workaround in `apps/zapier/src/lib/raw_request.ts` can be removed and writes can route back through the typed SDK methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)