### PR TITLE
fix: publish SDK after Release Please release

### DIFF
--- a/.github/workflows/publish_typescript_sdk.yml
+++ b/.github/workflows/publish_typescript_sdk.yml
@@ -3,6 +3,12 @@ name: Publish TypeScript SDK
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish, for example sdk-v-v0.2.0
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,8 +18,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release tag
+        id: release-tag
+        run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-tag.outputs.tag }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -29,7 +41,7 @@ jobs:
       - name: Check release tag matches SDK version
         id: tag-check
         run: |
-          tag="${{ github.event.release.tag_name }}"
+          tag="${{ steps.release-tag.outputs.tag }}"
           version="${{ steps.sdk-version.outputs.version }}"
           if [[ "$tag" == "v$version" || "$tag" == "sdk-v$version" || "$tag" == "$version" || "$tag" == "sdk-v-v$version" ]]; then
             echo "publish=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release_please_sdk.yml
+++ b/.github/workflows/release_please_sdk.yml
@@ -7,6 +7,7 @@ on:
       - "sdks/typescript-sdk/**"
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -15,6 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Dispatch SDK publish
+        if: ${{ steps.release.outputs['sdks/typescript-sdk--release_created'] == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs['sdks/typescript-sdk--tag_name'] }}
+        run: gh workflow run publish_typescript_sdk.yml --ref main -f tag="$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- dispatch the SDK publish workflow from the Release Please workflow when an SDK release is created
- keep npm publishing in the existing trusted-publishing workflow file
- add a manual `workflow_dispatch` tag input so missed releases can be published by tag

## Verification
- ruby YAML parse for both workflow files
- git diff --check