### PR TITLE
fix: write SDK publish version output safely

### DIFF
--- a/.github/workflows/publish_typescript_sdk.yml
+++ b/.github/workflows/publish_typescript_sdk.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Read SDK version
         id: sdk-version
         run: |
-          node -e "const { version } = require('./sdks/typescript-sdk/package.json'); const fs = require('fs'); fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}\n`);"
+          version=$(node -p "require('./sdks/typescript-sdk/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Check release tag matches SDK version
         id: tag-check


### PR DESCRIPTION
## Summary
- replace the SDK version Node one-liner with shell-safe output handling
- avoids bash interpreting JavaScript template backticks before Node runs

## Verification
- inspected failed Actions job 25515301576 / 74884722052
- compare against main shows only `.github/workflows/publish_typescript_sdk.yml` changed