### PR TITLE
fix(ci): address Greptile review on Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # Required for Claude to post review comments back to the PR
+      issues: write
       id-token: write
 
     steps:
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,16 +12,18 @@ on:
 
 jobs:
   claude:
+    # Only trigger for trusted collaborators so outside accounts can't invoke
+    # Claude (and consume API quota) by posting "@claude" on an issue/PR.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # Required for Claude to push commits / create branches
+      pull-requests: write # Required for Claude to post comments and open PRs
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -32,7 +34,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Follow-up to #229, which was merged before the Greptile/Codex review was addressed. Resolves all four flagged issues.

## Changes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | P1 | Read-only `GITHUB_TOKEN` — Claude can authenticate to the AI backend but every attempt to post a comment/review or push code is rejected at runtime | `pull-requests: write` + `issues: write` in both workflows; `contents: write` in `claude.yml` for commits/branches |
| 3 | P2 | No actor guard — any commenter could trigger `claude.yml` and consume API quota | Restrict to `OWNER`/`MEMBER`/`COLLABORATOR` via `author_association` on each event type |
| 4 | P2 | `claude-code-action@v1` is a mutable tag — a force-push of a compromised version would run with the OAuth token in scope | Pinned to commit `787c5a0` (= `v1.0.133`) with a version comment, per GitHub's third-party action hardening guide |

## Deliberately not applied

**Issue 2 (P2 — "duplicate `actions: read`")**: kept `additional_permissions: actions: read` in `claude.yml`. The job-level `permissions` block scopes the `GITHUB_TOKEN`; `additional_permissions` is `claude-code-action`'s documented opt-in to actually enable CI-reading behavior. They serve different purposes — the [upstream example](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml) declares both — so removing it would be a regression, not a cleanup.

## Verification

- Both files validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the two Claude Code GitHub Actions workflows by fixing the `GITHUB_TOKEN` permission scope, adding an actor guard to the comment-triggered workflow, and pinning the `claude-code-action` reference to a specific commit hash to prevent supply-chain drift.

- **Permissions**: Both workflows now declare `pull-requests: write` and `issues: write`; `claude.yml` additionally gets `contents: write` so Claude can push commits and open branches.
- **Actor guard** (`claude.yml`): The `if` condition now gates each event type on `author_association` being `OWNER`, `MEMBER`, or `COLLABORATOR`, preventing arbitrary commenters from invoking Claude and consuming API quota.
- **Pinning**: Both usages of `anthropics/claude-code-action` are pinned to the full SHA `787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251` (`v1.0.133`) instead of the mutable `@v1` tag.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the permission and pinning fixes are correct, and the actor guard closes the main quota-abuse vector for comment-triggered workflows.

The actor guard in claude.yml uses github.event.issue.author_association for the issues.assigned event path, which reflects the issue creator's role rather than the person doing the assignment. A trusted collaborator silently fails to route an external user's @claude-tagged issue via assignment. This is a minor logic mismatch with the stated intent of the guard, but it does not open a security hole and workarounds exist (use a comment instead).

.github/workflows/claude.yml — specifically the issues.assigned branch of the if condition.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/claude-code-review.yml | Permissions upgraded to pull-requests: write and issues: write, and action pinned to commit hash — changes are correct for enabling PR review comments. |
| .github/workflows/claude.yml | Actor guard added via author_association checks, permissions expanded, and action pinned to commit hash; guard field for issues.assigned events checks the issue author rather than the assigning actor. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] --> B{Event type?}

    B -->|pull_request| C[claude-code-review.yml]
    C --> D[Runs on all repo PRs]
    D --> E[claude-code-action at 787c5a0]
    E --> F[Posts review via pull-requests write]

    B -->|issue_comment or review_comment or review| G{contains @claude?}
    B -->|issues opened or assigned| H{contains @claude?}

    G --> I{author_association trusted?}
    H --> J{issue.author_association trusted?}

    I -->|Yes| K[claude.yml runs]
    I -->|No| L[Skipped]
    J -->|Yes| K
    J -->|No| L

    K --> M[claude-code-action at 787c5a0]
    M --> N[Claude responds with contents write]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/claude.yml:21
**`issues.assigned` guard checks the wrong actor**

For `issues` events with type `assigned`, `github.event.issue.author_association` is the association of the **issue creator**, not the person performing the assignment (`github.actor`). In practice, only collaborators can assign issues on GitHub, so the risk is low — but the intent of the guard ("restrict who can invoke Claude") is better expressed by checking the actor who triggered the assignment. If a trusted collaborator tries to route an external user's issue (which happens to contain `@claude`) to Claude via assignment, the workflow silently does nothing because the issue author is `NONE`/`CONTRIBUTOR`. Using `github.actor` and checking it against the trusted-association list (or against team membership) would match the declared intent of the guard.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): address Greptile review on Clau..."](https://github.com/terminal49/api/commit/09ba2e691072f0776036caeb2050645c888019b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34640467)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->