### PR TITLE
ci(security): pin claude-code-action to a commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Pins `anthropics/claude-code-action` from the mutable `@v1` tag to the commit SHA it currently resolves to, in both Claude workflows.

## Why

`@v1` is a moving tag — if it's ever force-pushed to a compromised commit, every future run executes untrusted code with `CLAUDE_CODE_OAUTH_TOKEN` (and `ANTHROPIC_API_KEY`) in scope. GitHub's [hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to a full commit SHA.

## Change

```
- uses: anthropics/claude-code-action@v1
+ uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
```

in `.github/workflows/claude.yml` and `.github/workflows/claude-code-review.yml`. `787c5a0` is the commit `v1` resolved to (= release `v1.0.133`). Bump the SHA and trailing comment together on future upgrades.

## Context

This is the last open item from the Greptile review of #229. The other findings (write permissions, actor authorization) were already resolved by #228; this closes the remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens both Claude GitHub Actions workflows by replacing the mutable `@v1` tag on `anthropics/claude-code-action` with the full commit SHA `787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251` (verified as `v1.0.133`), preventing supply-chain attacks via tag force-push.

- **`claude-code-review.yml`**: Action pinned to full SHA; no functional change to review workflow behavior.
- **`claude.yml`**: Same pin applied to the interactive Claude action, which also holds `ANTHROPIC_API_KEY` in scope — making this the higher-risk workflow that most benefits from the fix.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a straightforward security improvement with no functional impact.

Both workflow files correctly pin the action to the verified SHA for v1.0.133. The one remaining gap is that useblacksmith/checkout@v1 in both workflows is still a mutable tag from a third-party action, leaving a partial supply-chain exposure that this PR does not address.

Both workflow files use useblacksmith/checkout@v1 which is still an unpinned third-party action.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/claude-code-review.yml | Pins anthropics/claude-code-action from @v1 to full commit SHA 787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 (v1.0.133); no other changes |
| .github/workflows/claude.yml | Pins anthropics/claude-code-action from @v1 to full commit SHA 787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 (v1.0.133); no other changes |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR or Issue Event] --> B{Workflow}
    B --> C[claude.yml]
    B --> D[claude-code-review.yml]
    C --> E[useblacksmith/checkout at v1 - unpinned]
    D --> F[useblacksmith/checkout at v1 - unpinned]
    E --> G[anthropics/claude-code-action at 787c5a0 - pinned]
    F --> H[anthropics/claude-code-action at 787c5a0 - pinned]
    G --> I[Secrets: CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_API_KEY]
    H --> J[Secrets: CLAUDE_CODE_OAUTH_TOKEN]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/claude-code-review.yml`, line 34 ([link](https://github.com/terminal49/api/blob/74209aa07d5140ff807a1570d88efe9682c9228f/.github/workflows/claude-code-review.yml#L34)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`useblacksmith/checkout` also uses a mutable tag**

   `useblacksmith/checkout@v1` (used in both workflows) is itself an unpinned third-party action. While it doesn't have API secrets passed to it directly, a compromised `v1` tag could tamper with the checked-out source before the subsequent Claude step runs. Pinning it to a full commit SHA would make the security posture consistent across both actions in these workflows.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/claude-code-review.yml
   Line: 34

   Comment:
   **`useblacksmith/checkout` also uses a mutable tag**

   `useblacksmith/checkout@v1` (used in both workflows) is itself an unpinned third-party action. While it doesn't have API secrets passed to it directly, a compromised `v1` tag could tamper with the checked-out source before the subsequent Claude step runs. Pinning it to a full commit SHA would make the security posture consistent across both actions in these workflows.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/claude-code-review.yml:34
**`useblacksmith/checkout` also uses a mutable tag**

`useblacksmith/checkout@v1` (used in both workflows) is itself an unpinned third-party action. While it doesn't have API secrets passed to it directly, a compromised `v1` tag could tamper with the checked-out source before the subsequent Claude step runs. Pinning it to a full commit SHA would make the security posture consistent across both actions in these workflows.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(security): pin claude-code-action to ..."](https://github.com/terminal49/api/commit/74209aa07d5140ff807a1570d88efe9682c9228f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34669701)</sub>

<!-- /greptile_comment -->