### PR TITLE
DEV-10071: refresh container statuses developer doc

### DIFF
--- a/docs/api-docs/in-depth-guides/container-statuses.mdx
+++ b/docs/api-docs/in-depth-guides/container-statuses.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Terminal49 Container Statuses"
-description: "Understand every Terminal49 container status value, from empty-out to empty-return, so your integration can interpret each shipment lifecycle stage."
+description: "Understand every Terminal49 container status value, from on-ship to empty-returned, so your integration can interpret each shipment lifecycle stage."
 keywords:
   - "Terminal49 API"
   - "container tracking API"
@@ -13,84 +13,114 @@ keywords:
 ---
 The `current_status` attribute on container objects provides a high-level view of where a container is in its journey. This guide explains the different status values and their meanings.
 
-## Available status values
+The API returns the raw backend value (for example `grounded`). The Terminal49 dashboard often displays a friendlier label for the same value (for example **At Terminal**), so each status below lists both. Integrations should always key off the backend `current_status` value, not the dashboard label.
 
-The `current_status` field can have one of the following values:
+## Quick reference
+
+| `current_status` (API) | Dashboard label | Meaning |
+| --- | --- | --- |
+| `new` | No Status | Tracking started, no status milestone yet |
+| `on_ship` | On Ship | On the vessel |
+| `grounded` | At Terminal | Discharged at the terminal |
+| `available` | Available | Available for pickup |
+| `not_available` | Not available | At the terminal but held / not released |
+| `awaiting_inland_transfer` | Awaiting Inland Transfer | Discharged at POD, awaiting the inland rail leg |
+| `on_rail` | On Rail | On a rail car to the inland destination |
+| `off_dock` | Available at Shippers | Moved to an off-dock / shipper's-own yard |
+| `picked_up` | Picked up | Picked up by a trucker |
+| `delivered` | Delivered | Delivered (manually marked) |
+| `empty_returned` | Empty Returned | Returned empty; tracking ends |
+
+## Status values
 
 ### new
-**Default state** - The container is tracked but Terminal49 doesn't yet have enough information to determine its actual status. This is the initial state when tracking begins.
+**Dashboard label: "No Status"**
+
+**Default state** — The container is being tracked but no status milestone has been received yet. This is the initial state when tracking begins, typically before the container has been loaded onto a vessel at the port of lading.
 
 ### on_ship
-**In transit by vessel** - The container is on a ship at any point prior to arrival at the Port of Discharge (POD). This status can apply at multiple stages:
-- During the ocean voyage from origin to destination
-- Before vessel departure from the Port of Lading
-- Any time the container is loaded on a vessel
+**Dashboard label: "On Ship"**
+
+**In transit by vessel** — The container is on a vessel. In the lifecycle this status first appears when the container is loaded or the vessel departs the port of lading, and it persists through the ocean voyage until the container is discharged at the Port of Discharge (POD).
+
+Triggered by the *vessel loaded* or *vessel departed* milestone (and kept by subsequent on-vessel milestones such as *vessel arrived*, *vessel berthed*, and transshipment events).
+
+### grounded
+**Dashboard label: "At Terminal"**
+
+**At the terminal** — The container has been discharged and is physically at the terminal, but its availability for pickup has not yet been confirmed (the terminal isn't yet providing availability data).
+
+- For containers **without** an inland destination: discharged at the POD terminal. Triggered by the *vessel discharged* milestone.
+- For containers **with** an inland destination: unloaded from the rail car at the inland terminal. Triggered by the *rail unloaded* milestone.
 
 ### available
-**Ready for pickup** - The container has arrived at the POD or inland destination and is confirmed available for pickup. You can proceed with arranging pickup when you see this status. For a definitive readiness check that combines `available_for_pickup` with hold data, see [Container Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
+**Dashboard label: "Available"**
+
+**Ready for pickup** — The container has arrived at the POD or inland destination and is confirmed available for pickup, with no clearance issues preventing it from leaving the facility. Triggered by the *available* milestone (or terminal availability data). For a definitive readiness check that combines `available_for_pickup` with hold data, see [Container Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 ### not_available
-**Arrived but not ready** - The container is at the POD or inland destination but is not yet available for pickup. This could be due to:
-- Customs holds
+**Dashboard label: "Not available"**
+
+**At the terminal but not ready** — The container is at the POD or inland destination but has not been cleared to leave. This could be due to:
 - Terminal holds
+- Customs holds
+- Line holds
 - Documentation requirements
 - Other restrictions
 
-See [Container Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees) for details on specific hold types and how to determine when the container is released.
-
-### grounded
-**Availability unknown** - The container is physically at the POD, but Terminal49 doesn't currently know whether it's available for pickup or not. This typically means the terminal isn't providing real-time availability data.
+While a hold is in place, the terminal will not release the container for pickup until it is cleared, and the LFD countdown continues (which can result in demurrage fees). Triggered by the *not available* milestone from the terminal. See [Container Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees) for details on specific hold types and how to determine when the container is released.
 
 ### awaiting_inland_transfer
-**Moving inland** - The container is either:
-- Still at the POD waiting to be loaded onto rail for an inland move
-- In transit between the POD and a rail terminal
-- At a rail terminal but not yet loaded onto a rail car
+**Dashboard label: "Awaiting Inland Transfer"**
 
-This status is specific to shipments with inland rail movements.
+**Awaiting the inland leg** — The container has been discharged at the POD but still has an inland destination, so it is waiting to be loaded onto rail for the inland move. Triggered by the *vessel discharged* milestone when the shipment has an inland destination distinct from the POD. This status is specific to shipments with inland rail movements.
 
 ### on_rail
-**In transit by rail** - The container has been loaded onto a rail car and is being transported to its inland destination.
+**Dashboard label: "On Rail"**
 
-### picked_up
-**Out for delivery** - The container has been picked up from the terminal or facility for delivery. 
+**In transit by rail** — The container has been loaded onto a rail car and is being transported toward its inland destination after being discharged from the POD. Triggered by the *rail departed* or *rail loaded* milestone.
 
 ### off_dock
-**At alternative facility** - The container has been moved to a different terminal or off-dock storage facility for pickup. You may need to go to this alternative location rather than the original POD terminal.
+**Dashboard label: "Available at Shippers"**
+
+**At an off-dock facility** — The terminal reported that the container has moved off the main terminal to an off-dock or shipper's-own yard, where it's available for pickup. When this happens, Terminal49 attempts to identify the off-dock facility and re-point tracking to it, so this status can also appear briefly during that transition before status is pulled from the new facility. This value comes from terminal data (not the steamship line) and is uncommon.
+
+### picked_up
+**Dashboard label: "Picked up"**
+
+**Out for delivery** — The container has been picked up by a trucker from the POD or inland destination and is on its way to the warehouse. Triggered by the *full out* milestone.
 
 ### delivered
-**Delivery confirmed** - This status is only shown when delivery has been [manually marked as delivered](https://help.terminal49.com/articles/4713318249-how-to-mark-containers-as-delivered) through the Terminal49 dashboard.
+**Dashboard label: "Delivered"**
+
+**Delivery confirmed** — The container has been delivered to the warehouse. This status is only set when delivery is [manually marked as delivered](https://help.terminal49.com/articles/4713318249-how-to-mark-containers-as-delivered) through the Terminal49 dashboard, because delivery date/time data is only available to the customer (Terminal49 does not have access to it).
 
 ### empty_returned
-**Container returned empty** - The container has been emptied and returned to the shipping line or designated return location.
+**Dashboard label: "Empty Returned"**
 
-### dropped
-**Not currently used** - This status value is defined but not actively used in the system.
-
-### loaded
-**Not currently used** - This status value is defined but not actively used in the system.
+**Container returned empty** — The container has been emptied and returned to the shipping line or designated return location, completing its journey. Terminal49 stops tracking the container at this point. Triggered by the *empty returned* or *empty in* milestone.
 
 ## Important considerations
 
 ### Status accuracy
-The logic to derive container statuses is complex and involves processing data from multiple sources including:
+The logic to derive container statuses is complex and involves processing data from multiple sources, including:
 - Shipping line updates
 - Terminal systems
 - Rail carrier feeds
 - Manual updates
 
-**There can sometimes be errors in the reported `current_status`**. When making critical business decisions:
-- Cross-referencing with transport events
+**There can sometimes be errors in the reported `current_status`.** When making critical, time-sensitive business decisions, consider:
+- Cross-referencing with the container's transport events
 - Contacting the terminal directly for time-sensitive pickups
 
 ### Status transitions
 Containers don't always follow a linear path through these statuses. For example:
 - A container may go from `on_ship` directly to `available` if terminal data arrives quickly
-- A container might alternate between `available` and `not_available` if holds are placed and removed
-- The status may remain as `new` for some time if data from the shipping line is delayed
+- A container might alternate between `available` and `not_available` as holds are placed and removed
+- The status may remain `new` for some time if data from the shipping line is delayed
 
 ### API usage
-To get the current status of a container, you can read the container's `current_status` attribute in your API responses:
+To get the current status of a container, read the container's `current_status` attribute in your API responses:
 
 ```bash
 GET /v2/containers/{id}


### PR DESCRIPTION
## What & why

Updates the developer documentation page **Container Statuses** (`docs/api-docs/in-depth-guides/container-statuses.mdx`) so the descriptions match the actual backend status logic, and so each status shows both the API value and the dashboard (frontend) label.

This is the developer-doc half of DEV-10071; the customer-facing helpdesk article is the other half (separate system, updated manually).

## Changes

- **Added the dashboard (frontend) label to every status**, plus a quick-reference table mapping `current_status` → dashboard label → meaning, and a note that integrations should key off the backend value (which is what the API returns) rather than the label.
- **`grounded`** rewritten from "Availability unknown" to the accurate **"At Terminal"** meaning — discharged at the POD terminal (no inland destination) *or* unloaded from rail at the inland terminal — with the triggering milestones (*vessel discharged* / *rail unloaded*).
- **Added the triggering milestone(s)** to each status, consistent with `update_container_status_from_events.rb`.
- **`off_dock`** corrected to the verified behavior (terminal reports an off-dock / shipper's-own yard; T49 re-points tracking to that facility; uncommon).
- **`awaiting_inland_transfer`** tightened to its real trigger (vessel discharged at POD when a distinct inland destination exists).
- **`on_ship`** clarified (first appears at load/departure, persists through arrival/berth).
- **Removed `dropped` and `loaded`** — defined in the enum but never actually set (0 in production).
- Fixed the intro description ("on-ship to empty-returned") and the broken "Status accuracy" bullet list.
- Reordered the detailed sections into lifecycle order.

## Verification

Confirmed the API exposes the raw backend value (`V2::ContainerSerializer` serializes `:current_status` directly). Rendered the page locally with the Mintlify (`mint`) dev server — the article returns HTTP 200 and displays the updated content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the **Container Statuses** developer guide to align with actual backend logic and expose the dashboard (frontend) labels alongside each API value.

- Adds a quick-reference table mapping every `current_status` value to its dashboard label and a plain-English meaning, with a clear note that integrations should key off the backend value.
- Rewrites `grounded` from the inaccurate "Availability unknown" to the correct "At Terminal" meaning, covering both the POD (vessel discharged) and inland terminal (rail unloaded) cases; adds triggering milestones to every status.
- Removes `dropped` and `loaded` (defined in the enum but never set in production) and reorders all sections into lifecycle order.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only change with no impact on runtime behaviour.

The content is well-researched and materially more accurate than what it replaces. Three small wording imprecisions were found: 'discharged' in the grounded intro technically excludes the rail-unloaded path, 'to the warehouse' in delivered over-specifies the destination type, and '(or terminal availability data)' in the available trigger is unexplained for developers. None of these would cause an incorrect integration, but they could mislead a reader scanning individual sections in isolation.

No files require special attention — all changes are in docs/api-docs/in-depth-guides/container-statuses.mdx.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/api-docs/in-depth-guides/container-statuses.mdx | Comprehensive documentation rewrite adding dashboard labels, a quick-reference table, lifecycle-ordered sections, and triggering milestones to all statuses; removes unused `dropped`/`loaded` entries and fixes the `grounded` description. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([new]) -->|vessel loaded / departed| B([on_ship])
    B -->|vessel discharged — no inland dest| C([grounded\nAt Terminal])
    B -->|vessel discharged — inland dest exists| D([awaiting_inland_transfer])
    B -->|vessel discharged + availability data| E([available])
    B -->|vessel discharged + hold| F([not_available])
    D -->|rail loaded / departed| G([on_rail])
    G -->|rail unloaded| C
    C -->|availability confirmed| E
    C -->|hold detected| F
    F <-->|hold placed / cleared| E
    E -->|terminal reports off-dock move| H([off_dock])
    E -->|full out| I([picked_up])
    H -->|full out| I
    I -->|manually marked| J([delivered])
    I -->|empty returned / empty in| K([empty_returned])
    J -->|empty returned / empty in| K
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22sylvain%2Fdev-10071-update-container-status-helpdesk-article-and-documentation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sylvain%2Fdev-10071-update-container-status-helpdesk-article-and-documentation%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fapi-docs%2Fin-depth-guides%2Fcontainer-statuses.mdx%3A51%0AThe%20intro%20sentence%20uses%20%22discharged%22%20as%20the%20universal%20framing%2C%20but%20one%20of%20the%20two%20triggering%20paths%20is%20*rail%20unloaded*%20%28at%20an%20inland%20terminal%29%2C%20not%20vessel%20discharge.%20Maritime%20developers%20familiar%20with%20the%20term%20%22discharged%22%20will%20interpret%20it%20as%20vessel-only%20discharge%20and%20may%20be%20confused%20when%20they%20observe%20%60grounded%60%20appearing%20after%20a%20rail%20event.%20Removing%20the%20word%20avoids%20the%20ambiguity%20while%20keeping%20the%20bullets%20%28which%20already%20cover%20both%20triggers%29%20accurate.%0A%0A%60%60%60suggestion%0A**At%20the%20terminal**%20%E2%80%94%20The%20container%20is%20physically%20at%20the%20terminal%2C%20but%20its%20availability%20for%20pickup%20has%20not%20yet%20been%20confirmed%20%28the%20terminal%20isn't%20yet%20providing%20availability%20data%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fapi-docs%2Fin-depth-guides%2Fcontainer-statuses.mdx%3A59%0A**Vague%20second%20trigger%20on%20%60available%60**%0A%0A%22Triggered%20by%20the%20*available*%20milestone%20%28or%20terminal%20availability%20data%29%22%20leaves%20developers%20guessing%20about%20the%20second%20path.%20%22Terminal%20availability%20data%22%20is%20undefined%20anywhere%20in%20the%20guide%20%E2%80%94%20it's%20unclear%20whether%20this%20means%20a%20different%20milestone%20type%2C%20a%20background%20polling%20mechanism%2C%20or%20something%20else.%20A%20brief%20gloss%20%28e.g.%2C%20%22or%20by%20availability%20data%20polled%20directly%20from%20terminal%20systems%22%29%20would%20tell%20integrators%20that%20there%20are%20two%20distinct%20trigger%20mechanisms%20and%20set%20expectations%20about%20timing%20differences%20between%20them.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fapi-docs%2Fin-depth-guides%2Fcontainer-statuses.mdx%3A96%0A%22The%20container%20has%20been%20delivered%20to%20the%20warehouse%22%20is%20narrower%20than%20reality%20%E2%80%94%20containers%20are%20delivered%20to%20distribution%20centres%2C%20factories%2C%20retail%20stores%2C%20and%20other%20facility%20types%2C%20not%20only%20warehouses.%20The%20previous%20wording%20avoided%20this%20over-specification.%0A%0A%60%60%60suggestion%0A**Delivery%20confirmed**%20%E2%80%94%20The%20container%20has%20been%20delivered%20to%20its%20destination.%20This%20status%20is%20only%20set%20when%20delivery%20is%20%5Bmanually%20marked%20as%20delivered%5D%28https%3A%2F%2Fhelp.terminal49.com%2Farticles%2F4713318249-how-to-mark-containers-as-delivered%29%20through%20the%20Terminal49%20dashboard%2C%20because%20delivery%20date%2Ftime%20data%20is%20only%20available%20to%20the%20customer%20%28Terminal49%20does%20not%20have%20access%20to%20it%29.%0A%60%60%60%0A%0A&repo=terminal49%2Fapi&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/api-docs/in-depth-guides/container-statuses.mdx:51
The intro sentence uses "discharged" as the universal framing, but one of the two triggering paths is *rail unloaded* (at an inland terminal), not vessel discharge. Maritime developers familiar with the term "discharged" will interpret it as vessel-only discharge and may be confused when they observe `grounded` appearing after a rail event. Removing the word avoids the ambiguity while keeping the bullets (which already cover both triggers) accurate.

```suggestion
**At the terminal** — The container is physically at the terminal, but its availability for pickup has not yet been confirmed (the terminal isn't yet providing availability data).
```

### Issue 2 of 3
docs/api-docs/in-depth-guides/container-statuses.mdx:59
**Vague second trigger on `available`**

"Triggered by the *available* milestone (or terminal availability data)" leaves developers guessing about the second path. "Terminal availability data" is undefined anywhere in the guide — it's unclear whether this means a different milestone type, a background polling mechanism, or something else. A brief gloss (e.g., "or by availability data polled directly from terminal systems") would tell integrators that there are two distinct trigger mechanisms and set expectations about timing differences between them.

### Issue 3 of 3
docs/api-docs/in-depth-guides/container-statuses.mdx:96
"The container has been delivered to the warehouse" is narrower than reality — containers are delivered to distribution centres, factories, retail stores, and other facility types, not only warehouses. The previous wording avoided this over-specification.

```suggestion
**Delivery confirmed** — The container has been delivered to its destination. This status is only set when delivery is [manually marked as delivered](https://help.terminal49.com/articles/4713318249-how-to-mark-containers-as-delivered) through the Terminal49 dashboard, because delivery date/time data is only available to the customer (Terminal49 does not have access to it).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["DEV-10071: refresh container statuses de..."](https://github.com/terminal49/api/commit/4a75116e2fd5f78584725c1cc81912205d3e02c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36978489)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->