### PR TITLE
fix(mcp): pin zod to 4.3.x for MCP SDK compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,14 @@
           update-types:
             - "minor"
             - "patch"
+      ignore:
+        # @modelcontextprotocol/sdk 1.29 only type-checks against zod 4.3.x;
+        # zod 4.4 breaks the MCP server build. Hold zod on 4.3 until the SDK
+        # declares 4.4 support. See packages/mcp/package.json (~4.3.6 pin).
+        - dependency-name: "zod"
+          update-types:
+            - "version-update:semver-minor"
+            - "version-update:semver-major"
 
     - package-ecosystem: "npm"
       directory: "/packages/mcp"
@@ -25,6 +33,12 @@
           update-types:
             - "minor"
             - "patch"
+      ignore:
+        # zod 4.4 breaks the @modelcontextprotocol/sdk 1.29 type check (see above).
+        - dependency-name: "zod"
+          update-types:
+            - "version-update:semver-minor"
+            - "version-update:semver-major"
 
     - package-ecosystem: "npm"
       directory: "/sdks/typescript-sdk"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16654,7 +16654,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/node": "^10.55.0",
         "@terminal49/sdk": "0.3.0",
-        "zod": "^4.3.6"
+        "zod": "~4.3.6"
       },
       "devDependencies": {
         "@types/node": "^24.10.13",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/node": "^10.55.0",
     "@terminal49/sdk": "0.3.0",
-    "zod": "^4.3.6"
+    "zod": "~4.3.6"
   },
   "devDependencies": {
     "@types/node": "^24.10.13",


### PR DESCRIPTION
## Problem
Dependabot preview builds are failing. The `npm-minor-patch` group bumped `zod` `4.3.6 → 4.4.3`, which breaks the MCP server's TypeScript build:
`Type 'ZodOptional<ZodString>' is not assignable to type 'AnySchema'` across `packages/mcp/src/server.ts`.

Root cause: `@modelcontextprotocol/sdk@1.29.0` declares `zod` as `^3.25 || ^4.0`, but its generated types are only compatible with zod **4.3.x**. zod 4.4 changed internal schema types, so the SDK's `registerTool` inputSchema typing rejects 4.4 schemas. 1.29 is the latest SDK — there's no newer version that supports zod 4.4.

`main` itself is unaffected (the lockfile pins zod 4.3.6 and CI/Vercel use `npm ci`), but the `^4.3.6` range allows a fresh install to pull the broken 4.4.

## Fix
- Pin `zod` to `~4.3.6` in `packages/mcp/package.json` (4.3.x patches allowed, 4.4 blocked).
- Add a Dependabot `ignore` for `zod` minor/major bumps (root + `/packages/mcp` npm groups) so it stops re-proposing the breaking bump.

Revisit (allow zod 4.4) once `@modelcontextprotocol/sdk` declares real 4.4 support.

## Verify
- `npm run build --workspace @terminal49/mcp` — tsc clean, zod locked at 4.3.6
- MCP lint + tests pass (6 files)
- `dependabot.yml` valid YAML with both ignore rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Pins `zod` to `~4.3.6` in `packages/mcp/package.json` (restricting to 4.3.x patches) and adds Dependabot ignore rules to stop the bot from re-proposing the breaking 4.4 bump, fixing TypeScript build failures caused by a zod 4.4 internal type change that is incompatible with `@modelcontextprotocol/sdk` 1.29.

- `packages/mcp/package.json`: range changed from `^4.3.6` (any 4.x ≥ 4.3.6) to `~4.3.6` (4.3.x only), closing the window that allowed a fresh `npm install` to pull zod 4.4.
- `.github/dependabot.yml`: `ignore` entries added for `zod` `semver-minor` and `semver-major` in both the root npm group and the `/packages/mcp` group; patch updates (4.3.7, etc.) remain unblocked and consistent with the `~` pin.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to a version range tightening and Dependabot config with no runtime behaviour impact.

The ^ to ~ change in packages/mcp/package.json is a minimal, correct constraint that closes the exact window that caused the build failure. The Dependabot ignore rules are correctly scoped to semver-minor and semver-major, allowing 4.3.x patch updates to continue flowing. The lockfile update is consistent. No logic, data, or auth paths are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp/package.json | Narrows zod range from ^4.3.6 (allows 4.4+) to ~4.3.6 (4.3.x patches only) to stay compatible with @modelcontextprotocol/sdk 1.29. |
| .github/dependabot.yml | Adds ignore rules for zod semver-minor/semver-major in both the root npm group and the /packages/mcp group, preventing Dependabot from re-proposing the breaking 4.4 bump. |
| package-lock.json | Lockfile updated to reflect the new ~4.3.6 zod range in the packages/mcp workspace entry. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot proposes zod bump] --> B{semver-minor or semver-major?}
    B -- Yes --> C[Ignored by dependabot.yml rule in Root and packages/mcp]
    B -- No patch only --> D[PR created for zod 4.3.x patch]
    D --> E[npm install resolves tilde 4.3.6 stays within 4.3.x]
    E --> F[MCP SDK 1.29 type-checks pass]
    C --> G[zod 4.4 never installed build stays green]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dependabot proposes zod bump] --> B{semver-minor or semver-major?}
    B -- Yes --> C[Ignored by dependabot.yml rule in Root and packages/mcp]
    B -- No patch only --> D[PR created for zod 4.3.x patch]
    D --> E[npm install resolves tilde 4.3.6 stays within 4.3.x]
    E --> F[MCP SDK 1.29 type-checks pass]
    C --> G[zod 4.4 never installed build stays green]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): pin zod to 4.3.x for MCP SDK c..."](https://github.com/terminal49/api/commit/e3234836ec38fbb5a35dd76419bf951ad7696230) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38959962)</sub>

<!-- /greptile_comment -->