### PR TITLE
chore(dependabot): security updates only; consolidate npm config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,61 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot configuration — see
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Policy: SECURITY UPDATES ONLY. Routine version bumps are disabled
+# (open-pull-requests-limit: 0), so Dependabot does not open PRs just to chase
+# new minor/patch releases. It still opens PRs that resolve a security advisory
+# — grouped into one PR per ecosystem (the repo "Grouped security updates"
+# setting + the security-updates groups below).
+#
+# One npm entry at the root covers all workspaces (packages/*, sdks/*); the
+# previous per-directory entries are consolidated to avoid duplicate PR streams.
+version: 2
 
-  version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
-  updates:
-    - package-ecosystem: "npm"
-      directory: "/"
-      schedule:
-        interval: "weekly"
-      groups:
-        npm-minor-patch:
-          update-types:
-            - "minor"
-            - "patch"
-      ignore:
-        # @modelcontextprotocol/sdk 1.29 only type-checks against zod 4.3.x;
-        # zod 4.4 breaks the MCP server build. Hold zod on 4.3 until the SDK
-        # declares 4.4 support. See packages/mcp/package.json (~4.3.6 pin).
-        - dependency-name: "zod"
-          update-types:
-            - "version-update:semver-minor"
-            - "version-update:semver-major"
-
-    - package-ecosystem: "npm"
-      directory: "/packages/mcp"
-      schedule:
-        interval: "weekly"
-      groups:
-        mcp-minor-patch:
-          update-types:
-            - "minor"
-            - "patch"
-      ignore:
-        # zod 4.4 breaks the @modelcontextprotocol/sdk 1.29 type check (see above).
-        - dependency-name: "zod"
-          update-types:
-            - "version-update:semver-minor"
-            - "version-update:semver-major"
-
-    - package-ecosystem: "npm"
-      directory: "/sdks/typescript-sdk"
-      schedule:
-        interval: "weekly"
-      groups:
-        sdk-minor-patch:
-          update-types:
-            - "minor"
-            - "patch"
-
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-        interval: "weekly"
-      groups:
-        actions-minor-patch:
-          update-types:
-            - "minor"
-            - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why
Dependabot was opening a large number of PRs. Causes: routine minor/patch version bumps, the same dependency duplicated across three `directory:` entries (`/`, `/packages/mcp`, `/sdks/typescript-sdk`), and ungrouped security updates. Per the decision to **only take security updates** (not chase routine minors):

## Change
- **`open-pull-requests-limit: 0`** on the npm and github-actions entries → disables routine version-update PRs. Per GitHub's docs, **security updates are not limited by this** and continue to flow.
- **Consolidated the three npm directory entries into one root `/` entry.** The repo uses npm workspaces (`packages/*`, `sdks/*`), so the root manifest covers all packages (`packages/mcp` no longer has a standalone lockfile; the SDK's is cache-only and installs from root). This removes the duplicate per-directory PR streams.
- **Security updates are grouped** (`applies-to: security-updates`, `patterns: ["*"]`) into one PR per ecosystem, complementing the repo's already-enabled "Grouped security updates" setting.

The earlier zod version-ignore is now redundant (no version updates), but zod stays pinned to `~4.3.6` in `packages/mcp` for MCP SDK type compatibility.

## Effect
- No more routine minor/patch Dependabot PRs.
- Security-advisory PRs still arrive, grouped.
- On the next Dependabot run, the existing open **version-update** PRs (typescript 6, vite, vitest, etc.) will be auto-closed; security PRs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the Dependabot configuration to security-only updates, eliminating the volume of routine minor/patch PRs by setting `open-pull-requests-limit: 0` (which GitHub docs confirm does not suppress security-advisory PRs). It also consolidates three separate npm directory entries into a single root `/` entry, relying on the repo's existing npm workspaces (`packages/*`, `sdks/*`) to give Dependabot visibility over all workspace dependencies.

- Sets `open-pull-requests-limit: 0` for both `npm` and `github-actions` ecosystems, disabling routine version bumps while preserving security update PRs per GitHub's documented behavior.
- Replaces three `npm` directory entries (`/`, `/packages/mcp`, `/sdks/typescript-sdk`) with one root entry backed by npm workspaces; adds `applies-to: security-updates` groups to batch security PRs into one PR per ecosystem.
- Removes the `zod` ignore rule, which was redundant: the rule only filtered `version-update:semver-minor/major` update types, and those are now entirely suppressed by the limit; security updates for zod were never blocked by that rule in either the old or new config.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only affects how Dependabot opens PRs and does not touch application code or CI workflows.

The config correctly uses open-pull-requests-limit: 0 (documented GitHub behavior) to suppress routine bumps while keeping security PRs flowing. The workspace consolidation is valid given the root package.json declares workspaces for packages/* and sdks/*. The removed zod ignore was genuinely redundant: it only filtered version-update:semver-minor/major update types, which are now fully suppressed by the limit, and it never blocked security-advisory updates for zod in either the old or new config.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Rewrites Dependabot config to security-updates-only mode; consolidates three npm directory entries into one root workspace entry; adds grouped security-update config for npm and github-actions. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot weekly schedule fires] --> B{Update type?}
    B -->|Routine minor/patch| C[open-pull-requests-limit: 0\nPR blocked — no PR opened]
    B -->|Security advisory| D[Limit does not apply\nPR allowed]
    D --> E{Ecosystem}
    E -->|npm| F[npm-security group\napplies-to: security-updates\npatterns: *\nOne grouped PR for all npm pkgs]
    E -->|github-actions| G[actions-security group\napplies-to: security-updates\npatterns: *\nOne grouped PR for all actions]
    F --> H[Covers all workspaces\npackages/* + sdks/* via root /]
    G --> I[Covers .github/workflows/]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dependabot weekly schedule fires] --> B{Update type?}
    B -->|Routine minor/patch| C[open-pull-requests-limit: 0\nPR blocked — no PR opened]
    B -->|Security advisory| D[Limit does not apply\nPR allowed]
    D --> E{Ecosystem}
    E -->|npm| F[npm-security group\napplies-to: security-updates\npatterns: *\nOne grouped PR for all npm pkgs]
    E -->|github-actions| G[actions-security group\napplies-to: security-updates\npatterns: *\nOne grouped PR for all actions]
    F --> H[Covers all workspaces\npackages/* + sdks/* via root /]
    G --> I[Covers .github/workflows/]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(dependabot): security updates only..."](https://github.com/terminal49/api/commit/6eb3d4cb3ad6e2b7b9a8dd39061778334962874d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38963735)</sub>

<!-- /greptile_comment -->