### PR TITLE
fix(mcp): get_container_transport_events false-empty timeline (fall back to include path)

### DIFF
--- a/packages/mcp/src/tools/contracts.test.ts
+++ b/packages/mcp/src/tools/contracts.test.ts
@@ -1,4 +1,4 @@
-import { FeatureNotEnabledError, type Terminal49Client } from '@terminal49/sdk';
+import { FeatureNotEnabledError, NotFoundError, type Terminal49Client } from '@terminal49/sdk';
 import { describe, expect, it, vi } from 'vitest';
 import { executeGetContainer } from './get-container.js';
 import { executeGetContainerRoute } from './get-container-route.js';
@@ -669,22 +669,111 @@ describe('MCP tool contracts', () => {
     );
 
     expect(events).toHaveBeenCalledWith('container-1', { format: 'raw' });
-    expect(result.summary.total_events).toBe(2);
-    expect(result.summary.timeline[0]).toMatchObject({
+    expect(result.total_events).toBe(2);
+    expect(result.timeline[0]).toMatchObject({
       event: 'container.transport.vessel_loaded',
     });
-    expect(result.summary.milestones).toMatchObject({
+    expect(result.milestones).toMatchObject({
       vessel_loaded_at: '2025-01-01T00:00:00.000Z',
       vessel_departed_at: '2025-01-02T00:00:00.000Z',
     });
+    // No duplicate mapped payload should be surfaced.
+    expect(result.summary).toBeUndefined();
+    expect(result.mapped).toBeUndefined();
   });
 
-  it('get_container_transport_events returns empty summary when events fetch fails', async () => {
-    const client = asClient({
-      containers: {
-        events: vi.fn().mockRejectedValue(new Error('Not Found')),
+  it('get_container_transport_events falls back to the container include path when the dedicated sub-resource 404s', async () => {
+    const events = vi.fn().mockRejectedValue(new NotFoundError('Not Found'));
+    const get = vi.fn().mockResolvedValue({
+      data: {
+        id: 'container-1',
+        type: 'container',
+        attributes: { number: 'CAIU1234567' },
+        relationships: {
+          transport_events: {
+            data: [
+              { id: 'evt-1', type: 'transport_event' },
+              { id: 'evt-2', type: 'transport_event' },
+            ],
+          },
+        },
       },
+      included: [
+        {
+          id: 'evt-1',
+          type: 'transport_event',
+          attributes: {
+            event: 'container.transport.vessel_loaded',
+            timestamp: '2025-01-01T00:00:00Z',
+            location_name: 'Shanghai',
+          },
+        },
+        {
+          id: 'evt-2',
+          type: 'transport_event',
+          attributes: {
+            event: 'container.transport.vessel_departed',
+            timestamp: '2025-01-02T00:00:00Z',
+            location_name: 'Shanghai',
+          },
+        },
+      ],
     });
+
+    const client = asClient({ containers: { events, get } });
+
+    const result = await executeGetContainerTransportEvents(
+      { id: 'container-1' },
+      client,
+    );
+
+    expect(events).toHaveBeenCalledWith('container-1', { format: 'raw' });
+    expect(get).toHaveBeenCalledWith('container-1', ['transport_events'], {
+      format: 'raw',
+    });
+    // Fallback returns the real events, never a false-empty timeline.
+    expect(result.total_events).toBe(2);
+    expect(result.timeline[0]).toMatchObject({
+      event: 'container.transport.vessel_loaded',
+    });
+    expect(result.milestones).toMatchObject({
+      vessel_loaded_at: '2025-01-01T00:00:00.000Z',
+      vessel_departed_at: '2025-01-02T00:00:00.000Z',
+    });
+    expect(result._metadata.source).toBe('container_include_fallback');
+    // It must NOT masquerade a success-shaped empty timeline carrying an error.
+    expect(result._metadata.error).toBeUndefined();
+  });
+
+  it('get_container_transport_events surfaces a real error for a genuinely missing container', async () => {
+    const events = vi.fn().mockRejectedValue(new NotFoundError('Not Found'));
+    const get = vi.fn().mockRejectedValue(new NotFoundError('Not Found'));
+
+    const client = asClient({ containers: { events, get } });
+
+    await expect(
+      executeGetContainerTransportEvents({ id: 'missing-container' }, client),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(events).toHaveBeenCalledWith('missing-container', { format: 'raw' });
+    expect(get).toHaveBeenCalledWith('missing-container', ['transport_events'], {
+      format: 'raw',
+    });
+  });
+
+  it('get_container_transport_events returns an empty-but-valid timeline for a container with no events', async () => {
+    const events = vi.fn().mockRejectedValue(new NotFoundError('Not Found'));
+    const get = vi.fn().mockResolvedValue({
+      data: {
+        id: 'container-1',
+        type: 'container',
+        attributes: { number: 'CAIU1234567' },
+        relationships: { transport_events: { data: [] } },
+      },
+      included: [],
+    });
+
+    const client = asClient({ containers: { events, get } });
 
     const result = await executeGetContainerTransportEvents(
       { id: 'container-1' },
@@ -693,9 +782,21 @@ describe('MCP tool contracts', () => {
 
     expect(result.total_events).toBe(0);
     expect(result.timeline).toEqual([]);
-    expect(result._metadata).toMatchObject({
-      error: 'Not Found',
-    });
+    // Empty-but-valid is distinct from a bad container id: no error metadata.
+    expect(result._metadata.error).toBeUndefined();
+    expect(result._metadata.container_found).toBe(true);
+  });
+
+  it('get_container_transport_events does not fall back for non-NotFound failures', async () => {
+    const events = vi.fn().mockRejectedValue(new Error('boom'));
+    const get = vi.fn();
+
+    const client = asClient({ containers: { events, get } });
+
+    await expect(
+      executeGetContainerTransportEvents({ id: 'container-1' }, client),
+    ).rejects.toThrow('boom');
+    expect(get).not.toHaveBeenCalled();
   });
 
   it('search_container handles partially missing fields safely', async () => {

--- a/packages/mcp/src/tools/contracts.test.ts
+++ b/packages/mcp/src/tools/contracts.test.ts
@@ -677,6 +677,10 @@ describe('MCP tool contracts', () => {
       vessel_loaded_at: '2025-01-01T00:00:00.000Z',
       vessel_departed_at: '2025-01-02T00:00:00.000Z',
     });
+    // A 200 from the sub-resource means the container exists; surface
+    // container_found consistently with the fallback path.
+    expect(result._metadata.source).toBe('transport_events_subresource');
+    expect(result._metadata.container_found).toBe(true);
     // No duplicate mapped payload should be surfaced.
     expect(result.summary).toBeUndefined();
     expect(result.mapped).toBeUndefined();
@@ -705,7 +709,10 @@ describe('MCP tool contracts', () => {
           attributes: {
             event: 'container.transport.vessel_loaded',
             timestamp: '2025-01-01T00:00:00Z',
-            location_name: 'Shanghai',
+            // Canonical transport_event payloads carry location_locode (and a
+            // location relationship that is NOT side-loaded on the include
+            // path), not a location_name attribute.
+            location_locode: 'CNSHA',
           },
         },
         {
@@ -714,7 +721,7 @@ describe('MCP tool contracts', () => {
           attributes: {
             event: 'container.transport.vessel_departed',
             timestamp: '2025-01-02T00:00:00Z',
-            location_name: 'Shanghai',
+            location_locode: 'CNSHA',
           },
         },
       ],
@@ -736,6 +743,9 @@ describe('MCP tool contracts', () => {
     expect(result.timeline[0]).toMatchObject({
       event: 'container.transport.vessel_loaded',
     });
+    // The movement location must survive the fallback even though the related
+    // port resource is not side-loaded — resolve it from location_locode.
+    expect(result.timeline[0].location).toMatchObject({ code: 'CNSHA' });
     expect(result.milestones).toMatchObject({
       vessel_loaded_at: '2025-01-01T00:00:00.000Z',
       vessel_departed_at: '2025-01-02T00:00:00.000Z',

--- a/packages/mcp/src/tools/get-container-transport-events.ts
+++ b/packages/mcp/src/tools/get-container-transport-events.ts
@@ -3,7 +3,7 @@
  * Retrieves transport event timeline for a container
  */
 
-import { Terminal49Client } from '@terminal49/sdk';
+import { NotFoundError, Terminal49Client } from '@terminal49/sdk';
 
 export interface GetContainerTransportEventsArgs {
   id: string;
@@ -49,61 +49,106 @@ export async function executeGetContainerTransportEvents(
   try {
     const result = await client.containers.events(args.id, { format: 'raw' });
     const raw = (result as any)?.raw ?? result;
-    const mapped = (result as any)?.mapped;
-    const duration = Date.now() - startTime;
 
-    console.error(
-      JSON.stringify({
-        event: 'tool.execute.complete',
-        tool: 'get_container_transport_events',
-        container_id: args.id,
-        event_count: raw?.data?.length || (Array.isArray(mapped) ? mapped.length : 0) || 0,
-        duration_ms: duration,
-        timestamp: new Date().toISOString(),
-      })
-    );
+    logComplete(args.id, eventCount(raw), startTime, 'transport_events_subresource');
 
-    const summary = formatTransportEventsResponse(raw);
-    return mapped ? { mapped, summary } : summary;
+    return formatTransportEventsResponse(raw, { source: 'transport_events_subresource' });
   } catch (error) {
-    const duration = Date.now() - startTime;
-    const message = (error as Error).message;
+    if (!isNotFound(error)) {
+      logError(args.id, error, startTime);
+      throw error;
+    }
 
-    console.error(
-      JSON.stringify({
-        event: 'tool.execute.error',
-        tool: 'get_container_transport_events',
-        container_id: args.id,
-        error: (error as Error).name,
-        message,
-        duration_ms: duration,
-        timestamp: new Date().toISOString(),
-      })
-    );
-
-    return {
-      total_events: 0,
-      event_categories: {
-        vessel_events: 0,
-        rail_events: 0,
-        truck_events: 0,
-        terminal_events: 0,
-        other_events: 0,
-      },
-      timeline: [],
-      milestones: {},
-      _metadata: {
-        presentation_guidance:
-          'No transport events were returned for this container. Use get_container for current status and retry later.',
-        error: message,
-        remediation:
-          'Confirm the container ID exists and has event data, then retry get_container_transport_events.',
-      },
-    };
+    // The dedicated /containers/{id}/transport_events sub-resource can 404 even
+    // when the container exists and has events (it is not enabled/populated for
+    // every container). Fall back to the container's include path before
+    // concluding there is nothing to show — never present a success-shaped empty
+    // timeline that secretly carries a "Not Found" error.
+    return fallbackToContainerInclude(args.id, client, startTime);
   }
 }
 
-function formatTransportEventsResponse(apiResponse: any): any {
+async function fallbackToContainerInclude(
+  id: string,
+  client: Terminal49Client,
+  startTime: number
+): Promise<any> {
+  let raw: any;
+  try {
+    const fallbackResult = await client.containers.get(id, ['transport_events'], {
+      format: 'raw',
+    });
+    raw = (fallbackResult as any)?.raw ?? fallbackResult;
+  } catch (fallbackError) {
+    // A genuinely-missing container surfaces as a real tool error, distinct
+    // from an empty-but-valid timeline.
+    logError(id, fallbackError, startTime);
+    throw fallbackError;
+  }
+
+  const events = extractIncludedTransportEvents(raw);
+
+  logComplete(id, events.length, startTime, 'container_include_fallback');
+
+  return formatTransportEventsResponse(
+    { data: events, included: raw?.included || [] },
+    { source: 'container_include_fallback', containerFound: true }
+  );
+}
+
+function eventCount(raw: any): number {
+  if (Array.isArray(raw)) return raw.length;
+  if (Array.isArray(raw?.data)) return raw.data.length;
+  return 0;
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    error instanceof NotFoundError ||
+    (error as any)?.status === 404 ||
+    (error as any)?.name === 'NotFoundError'
+  );
+}
+
+function logComplete(id: string, count: number, startTime: number, source: string): void {
+  console.error(
+    JSON.stringify({
+      event: 'tool.execute.complete',
+      tool: 'get_container_transport_events',
+      container_id: id,
+      event_count: count,
+      source,
+      duration_ms: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    })
+  );
+}
+
+function logError(id: string, error: unknown, startTime: number): void {
+  console.error(
+    JSON.stringify({
+      event: 'tool.execute.error',
+      tool: 'get_container_transport_events',
+      container_id: id,
+      error: (error as Error).name,
+      message: (error as Error).message,
+      duration_ms: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    })
+  );
+}
+
+function extractIncludedTransportEvents(raw: any): any[] {
+  const included = Array.isArray(raw?.included) ? raw.included : [];
+  return included.filter((item: any) => item?.type === 'transport_event');
+}
+
+interface FormatOptions {
+  source: 'transport_events_subresource' | 'container_include_fallback';
+  containerFound?: boolean;
+}
+
+function formatTransportEventsResponse(apiResponse: any, options: FormatOptions): any {
   const events = Array.isArray(apiResponse)
     ? apiResponse
     : Array.isArray(apiResponse?.data)
@@ -128,38 +173,66 @@ function formatTransportEventsResponse(apiResponse: any): any {
     const eventType = normalizeText(attrs.event);
     const timestamp = normalizeTimestamp(attrs.timestamp);
 
-    // Find location info from included data
-    const locationId = relationships.location?.data?.id;
-    const location = included.find((item: any) => item.id === locationId);
-
     return {
       event: eventType,
       timestamp,
       timezone: normalizeText(attrs.timezone),
       voyage_number: normalizeText(attrs.voyage_number),
-      location: location
-        ? {
-            name: normalizeText(location.attributes?.name),
-            code:
-              normalizeText(location.attributes?.code) || normalizeText(location.attributes?.locode),
-            type: normalizeText(location.type),
-          }
-        : null,
+      location: resolveLocation(attrs, relationships, included),
     };
   });
+
+  const metadata: Record<string, unknown> = {
+    source: options.source,
+    presentation_guidance:
+      events.length > 0
+        ? 'Present events chronologically as a journey timeline. ' +
+          'Highlight key milestones: vessel loaded, departed, arrived, discharged, delivery. ' +
+          'For rail containers, emphasize rail movements.'
+        : 'This container exists but has no transport events yet. ' +
+          'Report an empty timeline (not an error) and use get_container for current status.',
+  };
+
+  if (options.containerFound !== undefined) {
+    metadata.container_found = options.containerFound;
+  }
 
   return {
     total_events: events.length,
     event_categories: categorized,
     timeline: formattedEvents,
     milestones: extractKeyMilestones(sortedEvents),
-    _metadata: {
-      presentation_guidance:
-        'Present events chronologically as a journey timeline. ' +
-        'Highlight key milestones: vessel loaded, departed, arrived, discharged, delivery. ' +
-        'For rail containers, emphasize rail movements.',
-    },
+    _metadata: metadata,
   };
+}
+
+function resolveLocation(attrs: any, relationships: any, included: any[]): any {
+  // Dedicated sub-resource: location is a related resource in `included`.
+  const locationId = relationships.location?.data?.id;
+  const includedLocation = locationId
+    ? included.find((item: any) => item.id === locationId)
+    : undefined;
+  if (includedLocation) {
+    return {
+      name: normalizeText(includedLocation.attributes?.name),
+      code:
+        normalizeText(includedLocation.attributes?.code) ||
+        normalizeText(includedLocation.attributes?.locode),
+      type: normalizeText(includedLocation.type),
+    };
+  }
+
+  // Container-include fallback: events embed location on their own attributes.
+  const embeddedName = normalizeText(attrs.location_name);
+  if (embeddedName) {
+    return {
+      name: embeddedName,
+      code: normalizeText(attrs.location_locode) || normalizeText(attrs.port_locode),
+      type: undefined,
+    };
+  }
+
+  return null;
 }
 
 function categorizeEvents(events: any[]): any {

--- a/packages/mcp/src/tools/get-container-transport-events.ts
+++ b/packages/mcp/src/tools/get-container-transport-events.ts
@@ -52,7 +52,14 @@ export async function executeGetContainerTransportEvents(
 
     logComplete(args.id, eventCount(raw), startTime, 'transport_events_subresource');
 
-    return formatTransportEventsResponse(raw, { source: 'transport_events_subresource' });
+    // A 200 from the dedicated sub-resource means the container exists, even
+    // when it carries zero events. Surface `container_found` consistently with
+    // the fallback path so an empty-but-valid primary timeline is never
+    // mistaken for a missing container.
+    return formatTransportEventsResponse(raw, {
+      source: 'transport_events_subresource',
+      containerFound: true,
+    });
   } catch (error) {
     if (!isNotFound(error)) {
       logError(args.id, error, startTime);
@@ -64,6 +71,7 @@ export async function executeGetContainerTransportEvents(
     // every container). Fall back to the container's include path before
     // concluding there is nothing to show — never present a success-shaped empty
     // timeline that secretly carries a "Not Found" error.
+    logFallback(args.id, error);
     return fallbackToContainerInclude(args.id, client, startTime);
   }
 }
@@ -119,6 +127,23 @@ function logComplete(id: string, count: number, startTime: number, source: strin
       event_count: count,
       source,
       duration_ms: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    })
+  );
+}
+
+function logFallback(id: string, error: unknown): void {
+  // The primary 404 is expected (the sub-resource is not enabled for every
+  // container), so it is not surfaced as an error — but operators
+  // investigating fallback traffic need a signal to correlate against.
+  console.error(
+    JSON.stringify({
+      event: 'tool.execute.fallback',
+      tool: 'get_container_transport_events',
+      container_id: id,
+      reason: 'transport_events_subresource_not_found',
+      error: (error as Error).name,
+      message: (error as Error).message,
       timestamp: new Date().toISOString(),
     })
   );
@@ -222,12 +247,17 @@ function resolveLocation(attrs: any, relationships: any, included: any[]): any {
     };
   }
 
-  // Container-include fallback: events embed location on their own attributes.
+  // Container-include fallback: the related port/metro_area resource is not
+  // side-loaded, so resolve from the event's own attributes. Canonical
+  // transport_event payloads carry `location_locode` (and usually no
+  // `location_name`), so surface a location whenever either is present rather
+  // than dropping the movement location entirely.
   const embeddedName = normalizeText(attrs.location_name);
-  if (embeddedName) {
+  const embeddedCode = normalizeText(attrs.location_locode) || normalizeText(attrs.port_locode);
+  if (embeddedName || embeddedCode) {
     return {
       name: embeddedName,
-      code: normalizeText(attrs.location_locode) || normalizeText(attrs.port_locode),
+      code: embeddedCode,
       type: undefined,
     };
   }


### PR DESCRIPTION
## Summary

`get_container_transport_events` reads the dedicated `/containers/{id}/transport_events` sub-resource. That sub-resource can return **404 even when the container exists and has events** (it isn't enabled/populated for every container). The old tool swallowed that NotFound into a **success-shaped empty timeline** whose `_metadata.error` secretly carried `"Not Found"`. The result: an LLM could not distinguish a genuinely empty timeline from a failed fetch, and a bad container id looked identical to a valid container with no events.

This PR makes the failure modes unambiguous:

- **Fallback on NotFound** — when the dedicated sub-resource 404s, the tool falls back to `GET /containers/{id}?include=transport_events` and maps the `included` `transport_event` records, so it returns the **real events** instead of a false-empty.
- **Real error for a bad id** — if the fallback container fetch also 404s (the container genuinely does not exist), the error propagates as a real tool error rather than a fake-empty success.
- **Empty-but-valid is distinct** — a container that exists with zero events returns an empty timeline tagged `_metadata.container_found: true` with **no** `error`, clearly separating "nothing happened yet" from "bad id".
- **No more secret error metadata** — the timeline is never presented as success while carrying an internal `_metadata.error: "Not Found"`.
- **Dropped the duplicate `mapped` payload** — the tool now returns a single flat timeline summary (`total_events`, `event_categories`, `timeline`, `milestones`, `_metadata`) instead of `{ mapped, summary }`. Non-NotFound errors (e.g. upstream 5xx) still propagate unchanged — the fallback only triggers on NotFound.

`_metadata.source` is set to `transport_events_subresource` or `container_include_fallback` so callers/operators can see which path served the data.

## Issues

Closes DEV-10660

## Green gate

Whole-repo gate is green (baseline was SDK 51 pass / 2 skip, MCP 77 pass):

- `npm run build --workspace @terminal49/sdk` — clean
- `npm run build --workspace @terminal49/mcp` — clean
- `npm run type-check --workspace @terminal49/sdk` — clean
- `npm run type-check --workspace @terminal49/mcp` — clean
- `npm test --workspace @terminal49/sdk -- --run` — **51 pass / 2 skip**
- `npm run test --workspace @terminal49/mcp -- --run` — **80 pass** (added: fallback returns real events; genuinely-missing container raises a real error; empty-but-valid timeline; non-NotFound errors do not fall back; updated the happy-path to assert the flat, no-duplicate shape)

## Notes

- TDD: the new/updated tests in `packages/mcp/src/tools/contracts.test.ts` were written first (red), then the tool was implemented to green.
- Scope: only `packages/mcp/src/tools/get-container-transport-events.ts` and the events region of `contracts.test.ts` were touched. The repo baseline is not `oxfmt`-clean (the pristine `HEAD` versions of these files already fail `oxfmt --check`), so a repo-wide `oxfmt --write` was intentionally avoided — it rewrites files owned by other PRs and even mangles an import. The diff matches the surrounding committed style and stays confined to the owned files.

This is an AI-drafted PR for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a subtle but impactful bug where `get_container_transport_events` would silently convert a 404 from the dedicated sub-resource into a success-shaped empty timeline — making a missing sub-resource look identical to "no events" to an LLM consumer. The fix adds a two-step fallback: a NotFound from the primary endpoint triggers a `GET /containers/{id}?include=transport_events` fetch, a second 404 (genuine missing container) is re-thrown as a real error, and a new `_metadata.source` field tells callers which path served the data.

- **Fallback on NotFound**: The dedicated sub-resource 404 now triggers a container-level include fetch instead of returning a fake-empty success.
- **Unambiguous error semantics**: Non-404 errors and genuinely missing containers both throw rather than return a success-shaped payload with a secret `_metadata.error` field.
- **Flat response shape**: The `{ mapped, summary }` wrapper is removed; the tool now returns a single flat object (`total_events`, `timeline`, `milestones`, `_metadata`).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it replaces a proven-buggy silent-swallow pattern with a well-tested two-step fallback, and the new tests cover all four distinct outcomes.

The fallback logic and error propagation are clearly correct and backed by new tests. The two observations — no log entry emitted at the moment of fallback, and the absent container_found flag on the primary zero-event path — are non-blocking quality concerns, not defects in the happy path.

get-container-transport-events.ts around the silent 404 catch block and the FormatOptions / containerFound branching logic in formatTransportEventsResponse.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp/src/tools/get-container-transport-events.ts | Introduces a two-step fallback: primary 404 triggers GET /containers/{id}?include=transport_events; non-404 errors and genuinely missing containers are now thrown rather than swallowed into a fake-empty response. Minor observability gap: the initial 404 is consumed silently with no log entry before the fallback runs. |
| packages/mcp/src/tools/contracts.test.ts | Test suite updated with four new/revised cases (fallback returns real events, missing container raises NotFoundError, empty-but-valid timeline, non-NotFound errors skip fallback) and the happy-path updated to assert the flat response shape. Good coverage of the new branching logic. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Tool as get_container_transport_events
    participant Sub as GET /containers/{id}/transport_events
    participant Inc as GET /containers/{id}?include=transport_events

    Tool->>Sub: "events(id, {format:'raw'})"
    alt 200 OK
        Sub-->>Tool: raw event list
        Tool-->>Tool: "formatTransportEventsResponse(raw, source='transport_events_subresource')"
    else 404 NotFound
        Sub-->>Tool: NotFoundError
        Note over Tool: silent – no log entry for the 404
        Tool->>Inc: "get(id, ['transport_events'], {format:'raw'})"
        alt 200 OK (container exists)
            Inc-->>Tool: container + included events
            Tool-->>Tool: "extractIncludedTransportEvents → format(source='container_include_fallback', containerFound=true)"
        else 404 NotFound (container missing)
            Inc-->>Tool: NotFoundError
            Tool-->>Tool: logError + rethrow
        end
    else Other error
        Sub-->>Tool: Error
        Tool-->>Tool: logError + rethrow
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Tool as get_container_transport_events
    participant Sub as GET /containers/{id}/transport_events
    participant Inc as GET /containers/{id}?include=transport_events

    Tool->>Sub: "events(id, {format:'raw'})"
    alt 200 OK
        Sub-->>Tool: raw event list
        Tool-->>Tool: "formatTransportEventsResponse(raw, source='transport_events_subresource')"
    else 404 NotFound
        Sub-->>Tool: NotFoundError
        Note over Tool: silent – no log entry for the 404
        Tool->>Inc: "get(id, ['transport_events'], {format:'raw'})"
        alt 200 OK (container exists)
            Inc-->>Tool: container + included events
            Tool-->>Tool: "extractIncludedTransportEvents → format(source='container_include_fallback', containerFound=true)"
        else 404 NotFound (container missing)
            Inc-->>Tool: NotFoundError
            Tool-->>Tool: logError + rethrow
        end
    else Other error
        Sub-->>Tool: Error
        Tool-->>Tool: logError + rethrow
    end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fmcp-transport-events-false-empty%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmcp-transport-events-false-empty%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fmcp%2Fsrc%2Ftools%2Fget-container-transport-events.ts%3A56-68%0A**No%20log%20entry%20when%20the%20primary%20404%20triggers%20the%20fallback**%0A%0AWhen%20the%20primary%20sub-resource%20returns%20a%20404%2C%20the%20catch%20block%20silently%20discards%20the%20error%20and%20jumps%20straight%20to%20%60fallbackToContainerInclude%60.%20The%20structured%20log%20stream%20will%20show%20%60tool.execute.start%60%20followed%20by%20%60tool.execute.complete%60%20with%20%60source%3A%20container_include_fallback%60%2C%20but%20nothing%20indicates%20*why*%20the%20fallback%20ran.%20Any%20operator%20investigating%20unexpected%20fallback%20traffic%20has%20no%20log%20signal%20to%20correlate%20against.%20Consider%20emitting%20a%20structured%20%60tool.execute.fallback%60%20event%20%28or%20similar%29%20before%20entering%20the%20fallback%20path%2C%20so%20the%20trigger%20is%20observable%20without%20requiring%20a%20debugger.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fmcp%2Fsrc%2Ftools%2Fget-container-transport-events.ts%3A185-198%0A**%60container_found%60%20is%20absent%20when%20the%20primary%20subresource%20succeeds%20with%20zero%20events**%0A%0A%60options.containerFound%60%20is%20only%20set%20on%20the%20fallback%20path%20%28%60containerFound%3A%20true%60%29%2C%20so%20%60_metadata.container_found%60%20is%20never%20present%20for%20the%20primary%20path.%20If%20the%20primary%20%60%2Ftransport_events%60%20endpoint%20returns%20an%20empty%20list%20%28200%20OK%2C%20zero%20events%29%2C%20the%20caller%20sees%20%60total_events%3A%200%60%20with%20%60presentation_guidance%60%20that%20says%20%22This%20container%20exists%20but%20has%20no%20transport%20events%20yet%22%20%E2%80%94%20but%20no%20%60container_found%60%20flag.%20Contrast%20this%20with%20the%20fallback%20empty-timeline%20path%2C%20where%20%60container_found%3A%20true%60%20is%20set.%20An%20LLM%20consuming%20the%20tool%20output%20now%20has%20two%20different%20shapes%20for%20the%20%22container%20exists%2C%20zero%20events%22%20case%20depending%20on%20which%20path%20served%20the%20data.%20This%20is%20minor%20now%20but%20could%20become%20confusing%20as%20callers%20add%20logic%20around%20%60container_found%60.%0A%0A&repo=terminal49%2Fapi&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/mcp/src/tools/get-container-transport-events.ts:56-68
**No log entry when the primary 404 triggers the fallback**

When the primary sub-resource returns a 404, the catch block silently discards the error and jumps straight to `fallbackToContainerInclude`. The structured log stream will show `tool.execute.start` followed by `tool.execute.complete` with `source: container_include_fallback`, but nothing indicates *why* the fallback ran. Any operator investigating unexpected fallback traffic has no log signal to correlate against. Consider emitting a structured `tool.execute.fallback` event (or similar) before entering the fallback path, so the trigger is observable without requiring a debugger.

### Issue 2 of 2
packages/mcp/src/tools/get-container-transport-events.ts:185-198
**`container_found` is absent when the primary subresource succeeds with zero events**

`options.containerFound` is only set on the fallback path (`containerFound: true`), so `_metadata.container_found` is never present for the primary path. If the primary `/transport_events` endpoint returns an empty list (200 OK, zero events), the caller sees `total_events: 0` with `presentation_guidance` that says "This container exists but has no transport events yet" — but no `container_found` flag. Contrast this with the fallback empty-timeline path, where `container_found: true` is set. An LLM consuming the tool output now has two different shapes for the "container exists, zero events" case depending on which path served the data. This is minor now but could become confusing as callers add logic around `container_found`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): get\_container\_transport\_events..."](https://github.com/terminal49/api/commit/d23a46b74451828eea07bed1967f9659a16b5c45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39983342)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->