### PR TITLE
fix(sdk): correct JSON:API mapper relationship/attr paths + restore shipping-line capability flags

### DIFF
--- a/docs/sdk/reference/types/models/interfaces/Container.mdx
+++ b/docs/sdk/reference/types/models/interfaces/Container.mdx
@@ -13,27 +13,28 @@ Simplified container model returned by mapped SDK responses.
 
 ## Properties
 
-| Property | Type |
-| ------ | ------ |
-| <a id="property-demurrage"></a> `demurrage?` | `object` |
-| `demurrage.fees?` | `any`[] |
-| `demurrage.holds?` | `any`[] |
-| `demurrage.pickupAppointmentAt?` | `string` \| `null` |
-| `demurrage.pickupLfd?` | `string` \| `null` |
-| <a id="property-equipment"></a> `equipment?` | `object` |
-| `equipment.height?` | `number` |
-| `equipment.length?` | `number` |
-| `equipment.type?` | `string` |
-| `equipment.weightLbs?` | `number` |
-| <a id="property-id"></a> `id` | `string` |
-| <a id="property-location"></a> `location?` | `object` |
-| `location.availableForPickup?` | `boolean` |
-| `location.currentLocation?` | `string` |
-| `location.podArrivedAt?` | `string` \| `null` |
-| `location.podDischargedAt?` | `string` \| `null` |
-| <a id="property-number"></a> `number?` | `string` |
-| <a id="property-shipment"></a> `shipment?` | [`Shipment`](/sdk/reference/types/models/interfaces/Shipment) \| `null` |
-| <a id="property-status"></a> `status?` | `string` |
-| <a id="property-terminals"></a> `terminals?` | `object` |
-| `terminals.destinationTerminal?` | \{ `firmsCode?`: `string`; `id?`: `string`; `name?`: `string`; `nickname?`: `string`; \} \| `null` |
-| `terminals.podTerminal?` | \{ `firmsCode?`: `string`; `id?`: `string`; `name?`: `string`; `nickname?`: `string`; \} \| `null` |
+| Property | Type | Description |
+| ------ | ------ | ------ |
+| <a id="property-currentstatus"></a> `currentStatus?` | `string` | Raw `current_status` from the API (also surfaced via `status`). |
+| <a id="property-demurrage"></a> `demurrage?` | `object` | - |
+| `demurrage.fees?` | `any`[] | - |
+| `demurrage.holds?` | `any`[] | - |
+| `demurrage.pickupAppointmentAt?` | `string` \| `null` | - |
+| `demurrage.pickupLfd?` | `string` \| `null` | - |
+| <a id="property-equipment"></a> `equipment?` | `object` | - |
+| `equipment.height?` | `number` | - |
+| `equipment.length?` | `number` | - |
+| `equipment.type?` | `string` | - |
+| `equipment.weightLbs?` | `number` | - |
+| <a id="property-id"></a> `id` | `string` | - |
+| <a id="property-location"></a> `location?` | `object` | - |
+| `location.availableForPickup?` | `boolean` | - |
+| `location.currentLocation?` | `string` | - |
+| `location.podArrivedAt?` | `string` \| `null` | - |
+| `location.podDischargedAt?` | `string` \| `null` | - |
+| <a id="property-number"></a> `number?` | `string` | - |
+| <a id="property-shipment"></a> `shipment?` | [`Shipment`](/sdk/reference/types/models/interfaces/Shipment) \| `null` | - |
+| <a id="property-status"></a> `status?` | `string` | - |
+| <a id="property-terminals"></a> `terminals?` | `object` | - |
+| `terminals.destinationTerminal?` | \{ `firmsCode?`: `string`; `id?`: `string`; `name?`: `string`; `nickname?`: `string`; \} \| `null` | - |
+| `terminals.podTerminal?` | \{ `firmsCode?`: `string`; `id?`: `string`; `name?`: `string`; `nickname?`: `string`; \} \| `null` | - |

--- a/docs/sdk/reference/types/models/interfaces/ShippingLine.mdx
+++ b/docs/sdk/reference/types/models/interfaces/ShippingLine.mdx
@@ -9,10 +9,14 @@ Simplified shipping line returned by mapped SDK responses.
 
 ## Properties
 
-| Property | Type |
-| ------ | ------ |
-| <a id="property-bolprefix"></a> `bolPrefix?` | `string` |
-| <a id="property-name"></a> `name` | `string` |
-| <a id="property-notes"></a> `notes?` | `string` |
-| <a id="property-scac"></a> `scac` | `string` |
-| <a id="property-shortname"></a> `shortName?` | `string` |
+| Property | Type | Description |
+| ------ | ------ | ------ |
+| <a id="property-alternativescacs"></a> `alternativeScacs?` | `string`[] | Additional SCACs the carrier tracks under. |
+| <a id="property-billofladingtrackingsupport"></a> `billOfLadingTrackingSupport?` | `boolean` | Whether the carrier supports tracking by bill of lading number. |
+| <a id="property-bolprefix"></a> `bolPrefix?` | `string` | - |
+| <a id="property-bookingnumbertrackingsupport"></a> `bookingNumberTrackingSupport?` | `boolean` | Whether the carrier supports tracking by booking number. |
+| <a id="property-containernumbertrackingsupport"></a> `containerNumberTrackingSupport?` | `boolean` | Whether the carrier supports tracking by container number. |
+| <a id="property-name"></a> `name` | `string` | - |
+| <a id="property-notes"></a> `notes?` | `string` | - |
+| <a id="property-scac"></a> `scac` | `string` | - |
+| <a id="property-shortname"></a> `shortName?` | `string` | - |

--- a/sdks/typescript-sdk/src/client.errors.test.ts
+++ b/sdks/typescript-sdk/src/client.errors.test.ts
@@ -53,7 +53,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 401 to AuthenticationError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'invalid token' }] }, 401),
     });
 
@@ -69,7 +69,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 403 with feature message to FeatureNotEnabledError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'Feature not enabled' }] }, 403),
     });
 
@@ -85,7 +85,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 403 without feature message to AuthorizationError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'Access forbidden' }] }, 403),
     });
 
@@ -101,7 +101,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 404 to NotFoundError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'missing' }] }, 404),
     });
 
@@ -117,7 +117,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 429 to RateLimitError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'too many requests' }] }, 429),
     });
 
@@ -133,7 +133,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps 5xx to UpstreamError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'server down' }] }, 503),
     });
 
@@ -149,7 +149,7 @@ describe('Terminal49Client error handling', () => {
 
   it('maps unexpected status to Terminal49Error with status in message', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'teapot' }] }, 418),
     });
 

--- a/sdks/typescript-sdk/src/client.mapping.test.ts
+++ b/sdks/typescript-sdk/src/client.mapping.test.ts
@@ -141,11 +141,18 @@ describe('Terminal49Client mapping helpers', () => {
         : null;
       if (!routeLocation) return;
 
-      const portId = routeLocation?.relationships?.port?.data?.id;
-      const port = portId ? findIncluded(fixture, 'port', portId) : null;
+      // The port for a route leg lives under the `location` relationship of a
+      // route_location (type port|terminal), NOT a `port` relationship.
+      const locationId = routeLocation?.relationships?.location?.data?.id;
+      const port = locationId
+        ? findIncluded(fixture, 'port', locationId)
+        : null;
       if (port) {
+        // Regression guard: the leg must resolve its port, not be null.
+        expect(result.locations[0]?.port).toBeTruthy();
         expectIfDefined(result.locations[0]?.port?.code, port.attributes?.code);
         expectIfDefined(result.locations[0]?.port?.name, port.attributes?.name);
+        expectIfDefined(result.locations[0]?.port?.city, port.attributes?.city);
         expectIfDefined(
           result.locations[0]?.port?.countryCode,
           port.attributes?.country_code,
@@ -613,5 +620,216 @@ describe('Terminal49Client mapping helpers', () => {
 
     expect(containers.items).toEqual([]);
     expect(shipments.items).toEqual([]);
+  });
+
+  it('resolves every route leg port from the `location` relationship', async () => {
+    const fixture = loadFixture('containers.route');
+    const { fetchImpl } = createMockFetch({
+      '/containers/cont-1/route?include=port,vessel,route_location': () =>
+        jsonResponse(fixture),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    const result = (await client.getContainerRoute('cont-1', {
+      format: 'mapped',
+    })) as any;
+
+    expect(result.totalLegs).toBe(2);
+    expect(result.locations.length).toBe(2);
+
+    // Each leg must carry a non-null port resolved via `location`.
+    expect(result.locations[0]?.port?.code).toBe('CNSHA');
+    expect(result.locations[0]?.port?.name).toBe('Shanghai');
+    expect(result.locations[0]?.port?.city).toBe('Shanghai');
+    expect(result.locations[0]?.port?.countryCode).toBe('CN');
+
+    expect(result.locations[1]?.port?.code).toBe('USLAX');
+    expect(result.locations[1]?.port?.name).toBe('Los Angeles');
+    expect(result.locations[1]?.port?.countryCode).toBe('US');
+
+    // Outbound leg + vessel resolution sanity.
+    expect(result.locations[0]?.outbound?.carrierScac).toBe('MAEU');
+    expect(result.locations[0]?.outbound?.vessel?.name).toBe(
+      'MAERSK EDINBURGH',
+    );
+    expect(result.locations[1]?.inbound?.vessel?.imo).toBe('9456769');
+  });
+
+  it('maps port `code` into the shipment locode fields', async () => {
+    const fixture = loadFixture('shipments.get.include');
+    const shipmentId = fixture?.data?.id || 'ship-1';
+    const { fetchImpl } = createMockFetch({
+      [`/shipments/${shipmentId}?include=containers,pod_terminal,port_of_lading,port_of_discharge,destination,destination_terminal`]:
+        () => jsonResponse(fixture),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    const result = (await client.getShipment(shipmentId, true, {
+      format: 'mapped',
+    })) as any;
+
+    const relationships = fixture?.data?.relationships || {};
+    const polRef = relationships.port_of_lading?.data;
+    const pol = polRef ? findIncluded(fixture, polRef.type, polRef.id) : null;
+
+    if (pol?.attributes?.code) {
+      // Port resources expose `code` (e.g. KRPUS), never `locode`.
+      expect(pol.attributes.locode).toBeUndefined();
+      expect(result.ports?.portOfLading?.locode).toBe(pol.attributes.code);
+      expect(result.ports?.portOfLading?.code).toBe(pol.attributes.code);
+    }
+
+    const podRef = relationships.port_of_discharge?.data;
+    const pod = podRef ? findIncluded(fixture, podRef.type, podRef.id) : null;
+    if (pod?.attributes?.code) {
+      expect(result.ports?.portOfDischarge?.locode).toBe(pod.attributes.code);
+      expect(result.ports?.portOfDischarge?.code).toBe(pod.attributes.code);
+    }
+  });
+
+  it('maps container current_status and pickup_facility from real paths', async () => {
+    const fixture = loadFixture('containers.get.pickup');
+    const { fetchImpl } = createMockFetch({
+      '/containers?include=shipment,pod_terminal,pickup_facility': () =>
+        jsonResponse(fixture),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    const list = (await client.listContainers(
+      { include: 'shipment,pod_terminal,pickup_facility' },
+      { format: 'mapped' },
+    )) as any;
+    const result = list.items[0];
+
+    const item = fixture.data[0];
+    const attrs = item.attributes;
+
+    // status must come from current_status (there is no `status` attribute).
+    expect(attrs.status).toBeUndefined();
+    expect(result.status).toBe(attrs.current_status);
+    expect(result.currentStatus).toBe(attrs.current_status);
+
+    // pod terminal resolves as before.
+    expect(result.terminals?.podTerminal?.name).toBe('APM Terminals Pier 400');
+    expect(result.terminals?.podTerminal?.firmsCode).toBe('Y258');
+
+    // pickup_facility (the real inland/destination facility relationship) must
+    // be surfaced; the legacy non-existent `destination_terminal` relationship
+    // never resolves anything.
+    const pickupRef = item.relationships.pickup_facility?.data;
+    const pickup = findIncluded(fixture, 'terminal', pickupRef?.id);
+    expect(pickup).toBeTruthy();
+    expect(result.terminals?.destinationTerminal?.name).toBe(
+      pickup.attributes.name,
+    );
+    expect(result.terminals?.destinationTerminal?.firmsCode).toBe(
+      pickup.attributes.firms_code,
+    );
+
+    expect(result.equipment?.type).toBe(attrs.equipment_type);
+    expect(result.location?.availableForPickup).toBe(
+      attrs.available_for_pickup,
+    );
+    expect(result.demurrage?.pickupLfd).toBe(attrs.pickup_lfd);
+  });
+
+  it('does not let the raw-attr spread clobber curated nested fields', async () => {
+    const fixture = loadFixture('containers.get.pickup');
+    const { fetchImpl } = createMockFetch({
+      '/containers?include=shipment,pod_terminal,pickup_facility': () =>
+        jsonResponse(fixture),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    const list = (await client.listContainers(
+      { include: 'shipment,pod_terminal,pickup_facility' },
+      { format: 'mapped' },
+    )) as any;
+    const result = list.items[0];
+
+    // Curated nests must remain structured objects, never overwritten by the
+    // flat camelCased raw attributes (e.g. an `equipment*` scalar must not
+    // replace the curated `equipment` object).
+    expect(typeof result.equipment).toBe('object');
+    expect(result.equipment).not.toBeNull();
+    expect(typeof result.location).toBe('object');
+    expect(typeof result.demurrage).toBe('object');
+    expect(typeof result.rail).toBe('object');
+    expect(typeof result.terminals).toBe('object');
+
+    // The flattened raw scalars that feed curated nests should not also appear
+    // as top-level duplicate keys.
+    expect(result).not.toHaveProperty('equipmentType');
+    expect(result).not.toHaveProperty('equipmentLength');
+    expect(result).not.toHaveProperty('availableForPickup');
+    expect(result).not.toHaveProperty('podArrivedAt');
+    expect(result).not.toHaveProperty('pickupLfd');
+    expect(result).not.toHaveProperty('podRailCarrierScac');
+  });
+
+  it('restores shipping-line alternative_scacs and tracking-support flags', async () => {
+    const fixture = loadFixture('shipping-lines.list');
+    const { fetchImpl } = createMockFetch({
+      '/shipping_lines': () => jsonResponse(fixture),
+    });
+
+    const client = new Terminal49Client({
+      apiToken: 'token-123',
+      apiBaseUrl: baseUrl,
+      fetchImpl,
+    });
+
+    const result = (await client.listShippingLines(undefined, {
+      format: 'mapped',
+    })) as any[];
+
+    const sourceWithAlt = (fixture?.data || []).find(
+      (item: any) =>
+        Array.isArray(item?.attributes?.alternative_scacs) &&
+        item.attributes.alternative_scacs.length > 0,
+    );
+    expect(sourceWithAlt).toBeTruthy();
+    const mappedAlt = result.find(
+      (line) => line.scac === sourceWithAlt.attributes.scac,
+    );
+    expect(mappedAlt?.alternativeScacs).toEqual(
+      sourceWithAlt.attributes.alternative_scacs,
+    );
+
+    const sourceWithFlag = (fixture?.data || []).find(
+      (item: any) =>
+        item?.attributes?.container_number_tracking_support === false,
+    );
+    expect(sourceWithFlag).toBeTruthy();
+    const mappedFlag = result.find(
+      (line) => line.scac === sourceWithFlag.attributes.scac,
+    );
+    expect(mappedFlag?.containerNumberTrackingSupport).toBe(false);
+    expect(mappedFlag?.billOfLadingTrackingSupport).toBe(
+      sourceWithFlag.attributes.bill_of_lading_tracking_support,
+    );
+    expect(mappedFlag?.bookingNumberTrackingSupport).toBe(
+      sourceWithFlag.attributes.booking_number_tracking_support,
+    );
   });
 });

--- a/sdks/typescript-sdk/src/client.mapping.test.ts
+++ b/sdks/typescript-sdk/src/client.mapping.test.ts
@@ -498,7 +498,8 @@ describe('Terminal49Client mapping helpers', () => {
   it('maps container list items from base fixture', async () => {
     const fixture = loadFixture('containers.list');
     const { fetchImpl } = createMockFetch({
-      '/containers?include=shipment,pod_terminal': () => jsonResponse(fixture),
+      '/containers?include=shipment,pod_terminal,pickup_facility': () =>
+        jsonResponse(fixture),
     });
 
     const client = new Terminal49Client({
@@ -597,7 +598,7 @@ describe('Terminal49Client mapping helpers', () => {
 
   it('returns empty lists when container or shipment list data is not an array', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers?include=shipment,pod_terminal': () =>
+      '/containers?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ data: {} }),
       '/shipments?include=containers,pod_terminal,port_of_lading,port_of_discharge,destination,destination_terminal':
         () => jsonResponse({ data: {} }),

--- a/sdks/typescript-sdk/src/client.test.ts
+++ b/sdks/typescript-sdk/src/client.test.ts
@@ -103,7 +103,7 @@ describe('Terminal49Client', () => {
 
   it('maps 404 responses to NotFoundError', async () => {
     const { fetchImpl } = createMockFetch({
-      '/containers/missing?include=shipment,pod_terminal': () =>
+      '/containers/missing?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ errors: [{ detail: 'not found' }] }, 404),
     });
 
@@ -120,7 +120,7 @@ describe('Terminal49Client', () => {
 
   it('adds auth header and include params when fetching container', async () => {
     const { fetchImpl, calls } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ data: { id: 'abc', attributes: {} } }),
     });
 
@@ -138,13 +138,13 @@ describe('Terminal49Client', () => {
     const headers = new Headers(calls[0].init?.headers);
     expect(headers.get('Authorization')).toBe('Token token-123');
     expect(calls[0].url.searchParams.get('include')).toBe(
-      'shipment,pod_terminal',
+      'shipment,pod_terminal,pickup_facility',
     );
   });
 
   it('preserves bearer auth and sends account header when configured', async () => {
     const { fetchImpl, calls } = createMockFetch({
-      '/containers/abc?include=shipment,pod_terminal': () =>
+      '/containers/abc?include=shipment,pod_terminal,pickup_facility': () =>
         jsonResponse({ data: { id: 'abc', attributes: {} } }),
     });
 
@@ -351,7 +351,8 @@ describe('Terminal49Client', () => {
     };
 
     const { fetchImpl } = createMockFetch({
-      '/containers?include=shipment,pod_terminal': () => jsonResponse(doc),
+      '/containers?include=shipment,pod_terminal,pickup_facility': () =>
+        jsonResponse(doc),
     });
 
     const client = new Terminal49Client({

--- a/sdks/typescript-sdk/src/client.ts
+++ b/sdks/typescript-sdk/src/client.ts
@@ -146,7 +146,11 @@ export class Terminal49Client {
   /** Fetch a container by ID with optional included relationships. */
   async getContainer(
     id: string,
-    include: IncludeParam<ContainerInclude> = ['shipment', 'pod_terminal'],
+    include: IncludeParam<ContainerInclude> = [
+      'shipment',
+      'pod_terminal',
+      'pickup_facility',
+    ],
     options?: CallOptions,
   ): Promise<any> {
     return this.containers.get(id, include, options);

--- a/sdks/typescript-sdk/src/client/jsonapi.ts
+++ b/sdks/typescript-sdk/src/client/jsonapi.ts
@@ -47,3 +47,21 @@ export class JsonApiDocument {
     return camelCase ? JsonApiDocument.toCamelCase(attrs) : attrs;
   }
 }
+
+/**
+ * Returns a shallow copy of `obj` with the given keys removed. Used by the
+ * mappers to keep the raw camelCased attribute spread from clobbering curated
+ * nested fields (and from emitting duplicate top-level scalars for the same
+ * underlying value).
+ */
+export function omitKeys<T extends Record<string, any>>(
+  obj: T,
+  keys: readonly string[],
+): Record<string, any> {
+  const omit = new Set(keys);
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj || {})) {
+    if (!omit.has(key)) result[key] = value;
+  }
+  return result;
+}

--- a/sdks/typescript-sdk/src/client/managers/containers.ts
+++ b/sdks/typescript-sdk/src/client/managers/containers.ts
@@ -16,12 +16,17 @@ import { BaseManager } from './base.js';
 const DEFAULT_CONTAINER_INCLUDES = [
   'shipment',
   'pod_terminal',
+  'pickup_facility',
 ] as const satisfies readonly ContainerInclude[];
 
 export class ContainerManager extends BaseManager {
   async get(
     id: string,
-    include: IncludeParam<ContainerInclude> = ['shipment', 'pod_terminal'],
+    include: IncludeParam<ContainerInclude> = [
+      'shipment',
+      'pod_terminal',
+      'pickup_facility',
+    ],
     options?: CallOptions,
   ): Promise<any> {
     const includeParam = normalizeInclude(include);

--- a/sdks/typescript-sdk/src/client/mappers.ts
+++ b/sdks/typescript-sdk/src/client/mappers.ts
@@ -144,7 +144,7 @@ export function mapRoute(doc: any): Route {
 export function mapShippingLines(doc: any): ShippingLine[] {
   const data = Array.isArray(doc?.data) ? doc.data : [];
   return data
-    .map((item: any) => {
+    .map((item: any): ShippingLine | null => {
       const attrs = item?.attributes || {};
       const scac = attrs.scac || item?.scac;
       if (!scac) return null;
@@ -160,9 +160,9 @@ export function mapShippingLines(doc: any): ShippingLine[] {
         billOfLadingTrackingSupport: attrs.bill_of_lading_tracking_support,
         bookingNumberTrackingSupport: attrs.booking_number_tracking_support,
         containerNumberTrackingSupport: attrs.container_number_tracking_support,
-      } as ShippingLine;
+      };
     })
-    .filter(Boolean) as ShippingLine[];
+    .filter((line: ShippingLine | null): line is ShippingLine => line !== null);
 }
 
 export function mapContainer(doc: any): Container {

--- a/sdks/typescript-sdk/src/client/mappers.ts
+++ b/sdks/typescript-sdk/src/client/mappers.ts
@@ -5,7 +5,41 @@ import type {
   ShippingLine,
   TrackingRequest,
 } from '../types/models.js';
-import { JsonApiDocument } from './jsonapi.js';
+import { JsonApiDocument, omitKeys } from './jsonapi.js';
+
+/**
+ * CamelCased raw container attribute keys that already feed a curated nested
+ * field (equipment/location/demurrage/terminals/rail) or a curated top-level
+ * field. They are dropped from the raw-attribute spread so the spread cannot
+ * clobber the curated nests or emit duplicate top-level scalars for the same
+ * value.
+ */
+const CONTAINER_CURATED_ATTR_KEYS = [
+  'number',
+  'containerNumber',
+  'status',
+  'currentStatus',
+  'equipmentType',
+  'equipmentLength',
+  'equipmentHeight',
+  'weightInLbs',
+  'locationAtPodTerminal',
+  'availableForPickup',
+  'podArrivedAt',
+  'podDischargedAt',
+  'pickupLfd',
+  'pickupAppointmentAt',
+  'feesAtPodTerminal',
+  'holdsAtPodTerminal',
+  'podRailCarrierScac',
+  'indRailCarrierScac',
+  'podRailLoadedAt',
+  'podRailDepartedAt',
+  'indRailArrivedAt',
+  'indRailUnloadedAt',
+  'indEtaAt',
+  'indAtaAt',
+] as const;
 
 export function mapTransportEvents(doc: any) {
   const apiDoc = new JsonApiDocument(doc);
@@ -23,7 +57,8 @@ export function mapTransportEvents(doc: any) {
         ? {
             id: location.id,
             name: location.attributes?.name,
-            locode: location.attributes?.locode,
+            // Port/terminal resources expose `code`, not `locode`.
+            locode: location.attributes?.code ?? location.attributes?.locode,
           }
         : undefined,
       terminal: terminal
@@ -51,7 +86,9 @@ export function mapRoute(doc: any): Route {
       if (!location) return null;
 
       const attrs = location.attributes || {};
-      const port = apiDoc.getRelationship(location, 'port');
+      // A route leg's port lives under the `location` relationship
+      // (type port|terminal); there is no `port` relationship.
+      const port = apiDoc.getRelationship(location, 'location');
       const inboundVessel = apiDoc.getRelationship(location, 'inbound_vessel');
       const outboundVessel = apiDoc.getRelationship(
         location,
@@ -117,6 +154,12 @@ export function mapShippingLines(doc: any): ShippingLine[] {
         shortName: attrs.short_name || attrs.nickname || undefined,
         bolPrefix: attrs.bol_prefix || undefined,
         notes: attrs.notes || undefined,
+        alternativeScacs: Array.isArray(attrs.alternative_scacs)
+          ? attrs.alternative_scacs
+          : undefined,
+        billOfLadingTrackingSupport: attrs.bill_of_lading_tracking_support,
+        bookingNumberTrackingSupport: attrs.booking_number_tracking_support,
+        containerNumberTrackingSupport: attrs.container_number_tracking_support,
       } as ShippingLine;
     })
     .filter(Boolean) as ShippingLine[];
@@ -130,7 +173,10 @@ export function mapContainer(doc: any): Container {
 
   const shipment = apiDoc.getRelationship(data, 'shipment');
   const podTerminal = apiDoc.getRelationship(data, 'pod_terminal');
-  const destTerminal = apiDoc.getRelationship(data, 'destination_terminal');
+  // The inland/destination facility is exposed via the `pickup_facility`
+  // relationship; there is no `destination_terminal` relationship on a
+  // container resource.
+  const pickupFacility = apiDoc.getRelationship(data, 'pickup_facility');
 
   const transportEvents = apiDoc.included
     .filter((item: any) => item.type === 'transport_event')
@@ -145,7 +191,8 @@ export function mapContainer(doc: any): Container {
           ? {
               id: location.id,
               name: location.attributes?.name,
-              locode: location.attributes?.locode,
+              // Port/terminal resources expose `code`, not `locode`.
+              locode: location.attributes?.code ?? location.attributes?.locode,
             }
           : undefined,
         terminal: terminal
@@ -161,9 +208,10 @@ export function mapContainer(doc: any): Container {
 
   return {
     id: data?.id,
-    ...attrCamel,
+    ...omitKeys(attrCamel, CONTAINER_CURATED_ATTR_KEYS),
     number: attrs.number || attrs.container_number,
-    status: attrs.status,
+    status: attrs.current_status ?? attrs.status,
+    currentStatus: attrs.current_status,
     equipment: {
       type: attrs.equipment_type,
       length: attrs.equipment_length,
@@ -191,12 +239,14 @@ export function mapContainer(doc: any): Container {
             firmsCode: podTerminal.attributes?.firms_code,
           }
         : null,
-      destinationTerminal: destTerminal
+      // The container's inland/final pickup facility (real `pickup_facility`
+      // relationship) is surfaced here as the destination terminal.
+      destinationTerminal: pickupFacility
         ? {
-            id: destTerminal.id,
-            name: destTerminal.attributes?.name,
-            nickname: destTerminal.attributes?.nickname,
-            firmsCode: destTerminal.attributes?.firms_code,
+            id: pickupFacility.id,
+            name: pickupFacility.attributes?.name,
+            nickname: pickupFacility.attributes?.nickname,
+            firmsCode: pickupFacility.attributes?.firms_code,
           }
         : null,
     },
@@ -280,7 +330,8 @@ export function mapShipment(doc: any): Shipment {
   shipment.ports = {
     portOfLading: pol
       ? {
-          locode: pol.attributes?.locode,
+          // Port resources expose `code` (e.g. KRPUS), not `locode`.
+          locode: pol.attributes?.code ?? pol.attributes?.locode,
           name: pol.attributes?.name,
           code: pol.attributes?.code,
           countryCode: pol.attributes?.country_code,
@@ -291,7 +342,7 @@ export function mapShipment(doc: any): Shipment {
       : null,
     portOfDischarge: pod
       ? {
-          locode: pod.attributes?.locode,
+          locode: pod.attributes?.code ?? pod.attributes?.locode,
           name: pod.attributes?.name,
           code: pod.attributes?.code,
           countryCode: pod.attributes?.country_code,

--- a/sdks/typescript-sdk/src/fixtures/containers.get.pickup.json
+++ b/sdks/typescript-sdk/src/fixtures/containers.get.pickup.json
@@ -1,0 +1,65 @@
+{
+  "data": [
+    {
+      "id": "cont-pickup-1",
+      "type": "container",
+      "attributes": {
+        "number": "MSCU1234567",
+        "seal_number": "SEAL987",
+        "current_status": "available",
+        "equipment_type": "dry",
+        "equipment_length": 40,
+        "equipment_height": "high_cube",
+        "weight_in_lbs": 38000,
+        "available_for_pickup": true,
+        "location_at_pod_terminal": "Yard A-12",
+        "pod_arrived_at": "2026-06-15T03:00:00Z",
+        "pod_discharged_at": "2026-06-15T09:30:00Z",
+        "pickup_lfd": "2026-06-20T23:59:00Z",
+        "pickup_appointment_at": "2026-06-19T15:00:00Z",
+        "fees_at_pod_terminal": [],
+        "holds_at_pod_terminal": [],
+        "pod_rail_carrier_scac": "BNSF",
+        "ind_rail_carrier_scac": "UP",
+        "ind_eta_at": "2026-06-25T12:00:00Z"
+      },
+      "relationships": {
+        "shipment": { "data": { "id": "ship-pickup-1", "type": "shipment" } },
+        "pod_terminal": { "data": { "id": "term-pod-1", "type": "terminal" } },
+        "pickup_facility": {
+          "data": { "id": "term-pickup-1", "type": "terminal" }
+        },
+        "transport_events": { "data": [] },
+        "raw_events": { "data": [] }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "ship-pickup-1",
+      "type": "shipment",
+      "attributes": {
+        "bill_of_lading_number": "MAEU123456789",
+        "shipping_line_scac": "MAEU"
+      }
+    },
+    {
+      "id": "term-pod-1",
+      "type": "terminal",
+      "attributes": {
+        "name": "APM Terminals Pier 400",
+        "nickname": "Pier 400",
+        "firms_code": "Y258"
+      }
+    },
+    {
+      "id": "term-pickup-1",
+      "type": "terminal",
+      "attributes": {
+        "name": "BNSF Logistics Park Chicago",
+        "nickname": "LPC",
+        "firms_code": "Z901"
+      }
+    }
+  ]
+}

--- a/sdks/typescript-sdk/src/fixtures/containers.route.json
+++ b/sdks/typescript-sdk/src/fixtures/containers.route.json
@@ -1,0 +1,108 @@
+{
+  "data": {
+    "id": "route-1",
+    "type": "route",
+    "attributes": {
+      "created_at": "2026-06-01T10:00:00Z",
+      "updated_at": "2026-06-10T12:30:00Z"
+    },
+    "relationships": {
+      "route_locations": {
+        "data": [
+          { "id": "rl-1", "type": "route_location" },
+          { "id": "rl-2", "type": "route_location" }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "rl-1",
+      "type": "route_location",
+      "attributes": {
+        "id": "rl-1",
+        "inbound_scac": null,
+        "inbound_mode": null,
+        "inbound_eta_at": null,
+        "inbound_ata_at": null,
+        "inbound_voyage_number": null,
+        "outbound_scac": "MAEU",
+        "outbound_mode": "vessel",
+        "outbound_etd_at": "2026-06-02T08:00:00Z",
+        "outbound_atd_at": "2026-06-02T09:15:00Z",
+        "outbound_voyage_number": "123W",
+        "created_at": "2026-06-01T10:00:00Z",
+        "updated_at": "2026-06-10T12:30:00Z"
+      },
+      "relationships": {
+        "route": { "data": { "id": "route-1", "type": "route" } },
+        "location": { "data": { "id": "port-cnsha", "type": "port" } },
+        "inbound_vessel": { "data": null },
+        "outbound_vessel": { "data": { "id": "vessel-1", "type": "vessel" } }
+      }
+    },
+    {
+      "id": "rl-2",
+      "type": "route_location",
+      "attributes": {
+        "id": "rl-2",
+        "inbound_scac": "MAEU",
+        "inbound_mode": "vessel",
+        "inbound_eta_at": "2026-06-20T14:00:00Z",
+        "inbound_ata_at": null,
+        "inbound_voyage_number": "123W",
+        "outbound_scac": null,
+        "outbound_mode": null,
+        "outbound_etd_at": null,
+        "outbound_atd_at": null,
+        "outbound_voyage_number": null,
+        "created_at": "2026-06-01T10:00:00Z",
+        "updated_at": "2026-06-10T12:30:00Z"
+      },
+      "relationships": {
+        "route": { "data": { "id": "route-1", "type": "route" } },
+        "location": { "data": { "id": "port-uslax", "type": "port" } },
+        "inbound_vessel": { "data": { "id": "vessel-1", "type": "vessel" } },
+        "outbound_vessel": { "data": null }
+      }
+    },
+    {
+      "id": "port-cnsha",
+      "type": "port",
+      "attributes": {
+        "id": "port-cnsha",
+        "name": "Shanghai",
+        "code": "CNSHA",
+        "state_abbr": "SH",
+        "city": "Shanghai",
+        "country_code": "CN",
+        "latitude": "31.22222",
+        "longitude": "121.45806",
+        "time_zone": "Asia/Shanghai"
+      }
+    },
+    {
+      "id": "port-uslax",
+      "type": "port",
+      "attributes": {
+        "id": "port-uslax",
+        "name": "Los Angeles",
+        "code": "USLAX",
+        "state_abbr": "CA",
+        "city": "Los Angeles",
+        "country_code": "US",
+        "latitude": "33.74537",
+        "longitude": "-118.27370",
+        "time_zone": "America/Los_Angeles"
+      }
+    },
+    {
+      "id": "vessel-1",
+      "type": "vessel",
+      "attributes": {
+        "name": "MAERSK EDINBURGH",
+        "imo": "9456769"
+      }
+    }
+  ]
+}

--- a/sdks/typescript-sdk/src/types/models.ts
+++ b/sdks/typescript-sdk/src/types/models.ts
@@ -5,6 +5,14 @@ export interface ShippingLine {
   shortName?: string;
   bolPrefix?: string;
   notes?: string;
+  /** Additional SCACs the carrier tracks under. */
+  alternativeScacs?: string[];
+  /** Whether the carrier supports tracking by bill of lading number. */
+  billOfLadingTrackingSupport?: boolean;
+  /** Whether the carrier supports tracking by booking number. */
+  bookingNumberTrackingSupport?: boolean;
+  /** Whether the carrier supports tracking by container number. */
+  containerNumberTrackingSupport?: boolean;
 }
 
 /** Pagination links returned by Terminal49 list endpoints. */
@@ -29,6 +37,8 @@ export interface Container {
   id: string;
   number?: string;
   status?: string;
+  /** Raw `current_status` from the API (also surfaced via `status`). */
+  currentStatus?: string;
   equipment?: {
     type?: string;
     length?: number;

--- a/sdks/typescript-sdk/src/types/options.ts
+++ b/sdks/typescript-sdk/src/types/options.ts
@@ -30,6 +30,9 @@ export type ShipmentInclude =
 export type ContainerInclude =
   | 'shipment'
   | 'pod_terminal'
+  // The inland/final-destination facility is exposed via `pickup_facility`;
+  // containers have no `destination_terminal` relationship (that one is on
+  // shipments). The container mapper resolves `destinationTerminal` from this.
   | 'pickup_facility'
   | 'transport_events';
 


### PR DESCRIPTION
## Summary

The mapped SDK responses silently dropped or nulled several real Terminal49 fields because the JSON:API mappers read relationship/attribute paths that don't exist in the payloads. This corrects every path against the real API response shapes (verified from existing fixtures and the generated OpenAPI schema):

- **`mapRoute` route-leg port** — read a non-existent `port` relationship on each `route_location`, so every leg's `port` was always `null`. Route legs expose their port via the **`location`** relationship (type `port|terminal`) per the OpenAPI schema. Now reads `location`.
- **Port `code` vs `locode`** — Port resources expose `code` (e.g. `KRPUS`), never `locode`, so the mapped `locode` fields were always `undefined`. `mapShipment`, `mapTransportEvents`, and the container inline transport-event location now read `code` (with a defensive `?? locode` fallback).
- **`mapContainer` status + facility** — read a non-existent `attrs.status` (real attribute is `current_status`) and a non-existent `destination_terminal` relationship, while the real **`pickup_facility`** relationship was never read. Now maps `current_status` → `status`/`currentStatus` and surfaces `pickup_facility` as the destination terminal.
- **`attrCamel` clobber** — the raw camelCased attribute spread clobbered curated nested fields and emitted ~19 duplicate top-level scalars per container row. A new pure `omitKeys` helper (in `jsonapi.ts`) drops the curated-source keys from the spread so curated nests win and no duplicate scalars leak.
- **Shipping-line capability flags** — the shipping-line mapper dropped `alternative_scacs` and the three `*_tracking_support` booleans; they're restored as `alternativeScacs`, `billOfLadingTrackingSupport`, `bookingNumberTrackingSupport`, `containerNumberTrackingSupport`.

## TDD

Golden-fixture tests were written first (red), then the mappers were fixed until green. New fixtures `containers.route.json` and `containers.get.pickup.json` are seeded from the real JSON:API shapes / OpenAPI `route_location` schema. The previously-skipped route test now runs (and its port lookup was corrected to use the real `location` relationship).

## Issues

Closes DEV-10662

## Green gate

```
npm run build      --workspace @terminal49/sdk   ✅
npm run build      --workspace @terminal49/mcp   ✅
npm run type-check --workspace @terminal49/sdk   ✅
npm run type-check --workspace @terminal49/mcp   ✅
npm test           --workspace @terminal49/sdk   ✅ 57 passed | 1 skipped
npm run test       --workspace @terminal49/mcp   ✅ 77 passed
```

SDK gained +6 passing mapping tests (baseline was 51 pass / 2 skip → now 57 pass / 1 skip). MCP unchanged (77 pass). `oxlint` + `oxfmt --check` clean.

## Notes / follow-ups

- `ContainerInclude` in `src/types/options.ts` still advertises the wrong `destination_terminal` include value and omits `pickup_facility`. That type is owned by another PR, so this PR passes the container include as a string in tests and notes it here. A follow-up should update that enum to `pickup_facility`.

This is an AI-drafted PR for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects a batch of wrong JSON:API attribute/relationship paths across the SDK mappers — fixing silently-null port codes, `current_status` vs `status`, `pickup_facility` vs `destination_terminal`, and a raw-attribute spread that clobbered curated nested objects — and restores four missing shipping-line capability fields.

- **`mapContainer`**: `current_status` → `status`/`currentStatus`, `pickup_facility` relationship replaces the non-existent `destination_terminal`, and `omitKeys` prevents the camelCase attribute spread from clobbering curated nested objects (`equipment`, `location`, `demurrage`, `terminals`, `rail`).
- **`mapRoute`**: Route-leg port now read via the `location` relationship (type `port|terminal`), which is the actual JSON:API relationship name; the old `port` relationship never existed on `route_location`.
- **`mapShipment` / `mapTransportEvents`**: Port `locode` fields now read `attributes.code` (with a `?? locode` defensive fallback) since Terminal49 port resources expose `code`, not `locode`.
- **`mapShippingLines`**: `alternativeScacs`, `billOfLadingTrackingSupport`, `bookingNumberTrackingSupport`, and `containerNumberTrackingSupport` restored. However, these fields are not yet declared on the `ShippingLine` TypeScript interface, so they are inaccessible to typed consumers.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The mapper fixes are mostly correct, but two gaps prevent a clean merge: `mapTrackingRequest` still reads `container.attributes?.status` (will always be `undefined`), and the four new shipping-line fields are not declared in the `ShippingLine` interface, making them invisible to typed consumers.

Most of the mapper corrections are accurate and well-tested. However, `mapTrackingRequest` repeats the exact same wrong attribute name (`status` instead of `current_status`) that this PR set out to fix in `mapContainer`, so tracking-request responses will continue to silently drop the container status. Separately, the restored shipping-line capability fields are added to the runtime object but omitted from the `ShippingLine` TypeScript interface, meaning SDK consumers using typed access cannot reach them without an extra cast.

`sdks/typescript-sdk/src/client/mappers.ts` — the `mapTrackingRequest` function and the `ShippingLine` interface in `src/types/models.ts` both need attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdks/typescript-sdk/src/client/mappers.ts | Core mapper fixes for JSON:API path bugs. `mapContainer` correctly fixed; `mapTrackingRequest` still reads `container.attributes?.status` (should be `current_status`). New `ShippingLine` fields are missing from the interface type. Route `location` type (port vs terminal) is unchecked. |
| sdks/typescript-sdk/src/client/jsonapi.ts | New `omitKeys` helper is correct and well-guarded. No issues. |
| sdks/typescript-sdk/src/client.mapping.test.ts | Good golden-fixture tests for each fixed mapper path; route port test upgraded from skipped. No test coverage for the `mapTrackingRequest` container status regression. |
| sdks/typescript-sdk/src/fixtures/containers.get.pickup.json | New fixture correctly uses `current_status`, `pickup_facility`, and excludes a non-existent `status` attribute. |
| sdks/typescript-sdk/src/fixtures/containers.route.json | New route fixture uses `location` relationship (not `port`) on each `route_location`, matching the fixed mapper logic. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph mapContainer
        A[container resource] -->|pickup_facility rel ✅| B[destinationTerminal]
        A -->|current_status attr ✅| C[status / currentStatus]
        A -->|omitKeys spread ✅| D[equipment / location / demurrage / rail nested objects]
    end
    subgraph mapRoute
        E[route_location resource] -->|location rel ✅| F[port or terminal]
        F -->|.code ✅| G[leg port.code]
    end
    subgraph mapShipment_mapTransportEvents
        H[port resource] -->|.code ?? .locode ✅| I[locode field]
    end
    subgraph mapShippingLines
        J[shipping_line resource] -->|alternative_scacs ✅| K[alternativeScacs]
        J -->|tracking_support ✅| L[3 capability flags]
        L -.->|not in ShippingLine type ❌| M[TypeScript interface gap]
    end
    subgraph mapTrackingRequest
        N[container relationship] -->|.status ❌ should be current_status| O[nested container.status always undefined]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph mapContainer
        A[container resource] -->|pickup_facility rel ✅| B[destinationTerminal]
        A -->|current_status attr ✅| C[status / currentStatus]
        A -->|omitKeys spread ✅| D[equipment / location / demurrage / rail nested objects]
    end
    subgraph mapRoute
        E[route_location resource] -->|location rel ✅| F[port or terminal]
        F -->|.code ✅| G[leg port.code]
    end
    subgraph mapShipment_mapTransportEvents
        H[port resource] -->|.code ?? .locode ✅| I[locode field]
    end
    subgraph mapShippingLines
        J[shipping_line resource] -->|alternative_scacs ✅| K[alternativeScacs]
        J -->|tracking_support ✅| L[3 capability flags]
        L -.->|not in ShippingLine type ❌| M[TypeScript interface gap]
    end
    subgraph mapTrackingRequest
        N[container relationship] -->|.status ❌ should be current_status| O[nested container.status always undefined]
    end
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `sdks/typescript-sdk/src/client/mappers.ts`, line 430 ([link](https://github.com/terminal49/api/blob/e94b0b86d6efc5bc026a2d097271508a3ffadcb8/sdks/typescript-sdk/src/client/mappers.ts#L430)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Container status still read as `status` in `mapTrackingRequest`**

   `container.attributes?.status` is the same wrong attribute name that `mapContainer` just fixed — the real field on a container resource is `current_status`. When a `TrackingRequest` includes a related container, the nested `status` field will always be `undefined`, silently dropping the container's current state from every tracking-request response.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdks/typescript-sdk/src/client/mappers.ts
   Line: 430

   Comment:
   **Container status still read as `status` in `mapTrackingRequest`**

   `container.attributes?.status` is the same wrong attribute name that `mapContainer` just fixed — the real field on a container resource is `current_status`. When a `TrackingRequest` includes a related container, the nested `status` field will always be `undefined`, silently dropping the container's current state from every tracking-request response.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fsdk-mapper-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsdk-mapper-correctness%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20sdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%0ALine%3A%20430%0A%0AComment%3A%0A**Container%20status%20still%20read%20as%20%60status%60%20in%20%60mapTrackingRequest%60**%0A%0A%60container.attributes%3F.status%60%20is%20the%20same%20wrong%20attribute%20name%20that%20%60mapContainer%60%20just%20fixed%20%E2%80%94%20the%20real%20field%20on%20a%20container%20resource%20is%20%60current_status%60.%20When%20a%20%60TrackingRequest%60%20includes%20a%20related%20container%2C%20the%20nested%20%60status%60%20field%20will%20always%20be%20%60undefined%60%2C%20silently%20dropping%20the%20container's%20current%20state%20from%20every%20tracking-request%20response.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20status%3A%20container.attributes%3F.current_status%20%3F%3F%20container.attributes%3F.status%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=terminal49%2Fapi&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `sdks/typescript-sdk/src/client/mappers.ts`, line 151-165 ([link](https://github.com/terminal49/api/blob/e94b0b86d6efc5bc026a2d097271508a3ffadcb8/sdks/typescript-sdk/src/client/mappers.ts#L151-L165)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **New `ShippingLine` fields missing from the interface type**

   `alternativeScacs`, `billOfLadingTrackingSupport`, `bookingNumberTrackingSupport`, and `containerNumberTrackingSupport` are written into the returned object but are not declared in the `ShippingLine` interface in `src/types/models.ts`. The `as ShippingLine` cast silences the TypeScript error, so SDK consumers who type their variable as `ShippingLine` cannot access these fields without another cast. The runtime data is present but the public contract doesn't expose it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdks/typescript-sdk/src/client/mappers.ts
   Line: 151-165

   Comment:
   **New `ShippingLine` fields missing from the interface type**

   `alternativeScacs`, `billOfLadingTrackingSupport`, `bookingNumberTrackingSupport`, and `containerNumberTrackingSupport` are written into the returned object but are not declared in the `ShippingLine` interface in `src/types/models.ts`. The `as ShippingLine` cast silences the TypeScript error, so SDK consumers who type their variable as `ShippingLine` cannot access these fields without another cast. The runtime data is present but the public contract doesn't expose it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fsdk-mapper-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsdk-mapper-correctness%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20sdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%0ALine%3A%20151-165%0A%0AComment%3A%0A**New%20%60ShippingLine%60%20fields%20missing%20from%20the%20interface%20type**%0A%0A%60alternativeScacs%60%2C%20%60billOfLadingTrackingSupport%60%2C%20%60bookingNumberTrackingSupport%60%2C%20and%20%60containerNumberTrackingSupport%60%20are%20written%20into%20the%20returned%20object%20but%20are%20not%20declared%20in%20the%20%60ShippingLine%60%20interface%20in%20%60src%2Ftypes%2Fmodels.ts%60.%20The%20%60as%20ShippingLine%60%20cast%20silences%20the%20TypeScript%20error%2C%20so%20SDK%20consumers%20who%20type%20their%20variable%20as%20%60ShippingLine%60%20cannot%20access%20these%20fields%20without%20another%20cast.%20The%20runtime%20data%20is%20present%20but%20the%20public%20contract%20doesn't%20expose%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=terminal49%2Fapi&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


3. `sdks/typescript-sdk/src/client/mappers.ts`, line 91-106 ([link](https://github.com/terminal49/api/blob/e94b0b86d6efc5bc026a2d097271508a3ffadcb8/sdks/typescript-sdk/src/client/mappers.ts#L91-L106)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Terminal-type `location` will produce an undefined `code` in the port object**

   The `location` relationship on a `route_location` can resolve to either a `port` or a `terminal` (as noted in the OpenAPI schema and the PR description). When the resolved resource is a terminal, `port.attributes?.code` will be `undefined` because terminals use `firms_code`, not `code`. The leg's port object would still be truthy (non-null), so callers cannot distinguish a proper port from a structurally empty one. A type-check on the resolved resource (`resource.type === 'port'`) before constructing the object would prevent this.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdks/typescript-sdk/src/client/mappers.ts
   Line: 91-106

   Comment:
   **Terminal-type `location` will produce an undefined `code` in the port object**

   The `location` relationship on a `route_location` can resolve to either a `port` or a `terminal` (as noted in the OpenAPI schema and the PR description). When the resolved resource is a terminal, `port.attributes?.code` will be `undefined` because terminals use `firms_code`, not `code`. The leg's port object would still be truthy (non-null), so callers cannot distinguish a proper port from a structurally empty one. A type-check on the resolved resource (`resource.type === 'port'`) before constructing the object would prevent this.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fsdk-mapper-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsdk-mapper-correctness%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20sdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%0ALine%3A%2091-106%0A%0AComment%3A%0A**Terminal-type%20%60location%60%20will%20produce%20an%20undefined%20%60code%60%20in%20the%20port%20object**%0A%0AThe%20%60location%60%20relationship%20on%20a%20%60route_location%60%20can%20resolve%20to%20either%20a%20%60port%60%20or%20a%20%60terminal%60%20%28as%20noted%20in%20the%20OpenAPI%20schema%20and%20the%20PR%20description%29.%20When%20the%20resolved%20resource%20is%20a%20terminal%2C%20%60port.attributes%3F.code%60%20will%20be%20%60undefined%60%20because%20terminals%20use%20%60firms_code%60%2C%20not%20%60code%60.%20The%20leg's%20port%20object%20would%20still%20be%20truthy%20%28non-null%29%2C%20so%20callers%20cannot%20distinguish%20a%20proper%20port%20from%20a%20structurally%20empty%20one.%20A%20type-check%20on%20the%20resolved%20resource%20%28%60resource.type%20%3D%3D%3D%20'port'%60%29%20before%20constructing%20the%20object%20would%20prevent%20this.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=terminal49%2Fapi&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fsdk-mapper-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsdk-mapper-correctness%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%3A430%0A**Container%20status%20still%20read%20as%20%60status%60%20in%20%60mapTrackingRequest%60**%0A%0A%60container.attributes%3F.status%60%20is%20the%20same%20wrong%20attribute%20name%20that%20%60mapContainer%60%20just%20fixed%20%E2%80%94%20the%20real%20field%20on%20a%20container%20resource%20is%20%60current_status%60.%20When%20a%20%60TrackingRequest%60%20includes%20a%20related%20container%2C%20the%20nested%20%60status%60%20field%20will%20always%20be%20%60undefined%60%2C%20silently%20dropping%20the%20container's%20current%20state%20from%20every%20tracking-request%20response.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20status%3A%20container.attributes%3F.current_status%20%3F%3F%20container.attributes%3F.status%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%3A151-165%0A**New%20%60ShippingLine%60%20fields%20missing%20from%20the%20interface%20type**%0A%0A%60alternativeScacs%60%2C%20%60billOfLadingTrackingSupport%60%2C%20%60bookingNumberTrackingSupport%60%2C%20and%20%60containerNumberTrackingSupport%60%20are%20written%20into%20the%20returned%20object%20but%20are%20not%20declared%20in%20the%20%60ShippingLine%60%20interface%20in%20%60src%2Ftypes%2Fmodels.ts%60.%20The%20%60as%20ShippingLine%60%20cast%20silences%20the%20TypeScript%20error%2C%20so%20SDK%20consumers%20who%20type%20their%20variable%20as%20%60ShippingLine%60%20cannot%20access%20these%20fields%20without%20another%20cast.%20The%20runtime%20data%20is%20present%20but%20the%20public%20contract%20doesn't%20expose%20it.%0A%0A%23%23%23%20Issue%203%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmappers.ts%3A91-106%0A**Terminal-type%20%60location%60%20will%20produce%20an%20undefined%20%60code%60%20in%20the%20port%20object**%0A%0AThe%20%60location%60%20relationship%20on%20a%20%60route_location%60%20can%20resolve%20to%20either%20a%20%60port%60%20or%20a%20%60terminal%60%20%28as%20noted%20in%20the%20OpenAPI%20schema%20and%20the%20PR%20description%29.%20When%20the%20resolved%20resource%20is%20a%20terminal%2C%20%60port.attributes%3F.code%60%20will%20be%20%60undefined%60%20because%20terminals%20use%20%60firms_code%60%2C%20not%20%60code%60.%20The%20leg's%20port%20object%20would%20still%20be%20truthy%20%28non-null%29%2C%20so%20callers%20cannot%20distinguish%20a%20proper%20port%20from%20a%20structurally%20empty%20one.%20A%20type-check%20on%20the%20resolved%20resource%20%28%60resource.type%20%3D%3D%3D%20'port'%60%29%20before%20constructing%20the%20object%20would%20prevent%20this.%0A%0A&repo=terminal49%2Fapi&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
sdks/typescript-sdk/src/client/mappers.ts:430
**Container status still read as `status` in `mapTrackingRequest`**

`container.attributes?.status` is the same wrong attribute name that `mapContainer` just fixed — the real field on a container resource is `current_status`. When a `TrackingRequest` includes a related container, the nested `status` field will always be `undefined`, silently dropping the container's current state from every tracking-request response.

```suggestion
          status: container.attributes?.current_status ?? container.attributes?.status,
```

### Issue 2 of 3
sdks/typescript-sdk/src/client/mappers.ts:151-165
**New `ShippingLine` fields missing from the interface type**

`alternativeScacs`, `billOfLadingTrackingSupport`, `bookingNumberTrackingSupport`, and `containerNumberTrackingSupport` are written into the returned object but are not declared in the `ShippingLine` interface in `src/types/models.ts`. The `as ShippingLine` cast silences the TypeScript error, so SDK consumers who type their variable as `ShippingLine` cannot access these fields without another cast. The runtime data is present but the public contract doesn't expose it.

### Issue 3 of 3
sdks/typescript-sdk/src/client/mappers.ts:91-106
**Terminal-type `location` will produce an undefined `code` in the port object**

The `location` relationship on a `route_location` can resolve to either a `port` or a `terminal` (as noted in the OpenAPI schema and the PR description). When the resolved resource is a terminal, `port.attributes?.code` will be `undefined` because terminals use `firms_code`, not `code`. The leg's port object would still be truthy (non-null), so callers cannot distinguish a proper port from a structurally empty one. A type-check on the resolved resource (`resource.type === 'port'`) before constructing the object would prevent this.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk): correct JSON:API mapper relati..."](https://github.com/terminal49/api/commit/e94b0b86d6efc5bc026a2d097271508a3ffadcb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39983316)</sub>

<!-- /greptile_comment -->