### PR TITLE
fix(sdk): stop sending unsupported container/shipment filter keys + clamp page size + wire mapper includes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm ci
       - name: Build SDK
         run: npm run build
+      - name: Type-check SDK
+        run: npm run type-check
       - name: Generate SDK docs
         if: matrix.node-version == 24
         run: npm run docs
@@ -59,6 +61,10 @@ jobs:
         run: npm run build --workspace @terminal49/sdk
       - name: Build MCP
         run: npm run build --workspace @terminal49/mcp
+      - name: Type-check SDK + MCP
+        run: |
+          npm run type-check --workspace @terminal49/sdk
+          npm run type-check --workspace @terminal49/mcp
       - name: Test MCP
         run: npm run test --workspace @terminal49/mcp -- --run --coverage
       - name: Lint MCP (oxlint + oxfmt)

--- a/docs/sdk/reference/client/managers/classes/ShipmentManager.mdx
+++ b/docs/sdk/reference/client/managers/classes/ShipmentManager.mdx
@@ -58,7 +58,7 @@ description: "ShipmentManager class in the Terminal49 TypeScript SDK, used to li
 
 | Parameter | Type |
 | ------ | ------ |
-| `filters` | \{ `carrier?`: `string`; `include?`: [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\>; `includeContainers?`: `boolean`; `port?`: `string`; `status?`: `string`; `updatedAfter?`: `string`; \} \| `undefined` |
+| `filters` | \{ `carrier?`: `string`; `include?`: [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\>; `includeContainers?`: `boolean`; `number?`: `string`; `port?`: `string`; `status?`: `string`; `trackingStopped?`: `boolean`; `updatedAfter?`: `string`; \} \| `undefined` |
 | `options?` | `Omit`\<[`ListOptions`](/sdk/reference/types/options/interfaces/ListOptions), `"page"`\> |
 
 #### Returns
@@ -73,16 +73,18 @@ description: "ShipmentManager class in the Terminal49 TypeScript SDK, used to li
 
 #### Parameters
 
-| Parameter | Type |
-| ------ | ------ |
-| `filters` | \{ `carrier?`: `string`; `include?`: [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\>; `includeContainers?`: `boolean`; `port?`: `string`; `status?`: `string`; `updatedAfter?`: `string`; \} |
-| `filters.carrier?` | `string` |
-| `filters.include?` | [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\> |
-| `filters.includeContainers?` | `boolean` |
-| `filters.port?` | `string` |
-| `filters.status?` | `string` |
-| `filters.updatedAfter?` | `string` |
-| `options?` | [`ListOptions`](/sdk/reference/types/options/interfaces/ListOptions) |
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `filters` | \{ `carrier?`: `string`; `include?`: [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\>; `includeContainers?`: `boolean`; `number?`: `string`; `port?`: `string`; `status?`: `string`; `trackingStopped?`: `boolean`; `updatedAfter?`: `string`; \} | - |
+| `filters.carrier?` | `string` | - |
+| `filters.include?` | [`IncludeParam`](/sdk/reference/types/options/type-aliases/IncludeParam)\<[`ShipmentInclude`](/sdk/reference/types/options/type-aliases/ShipmentInclude)\> | - |
+| `filters.includeContainers?` | `boolean` | - |
+| `filters.number?` | `string` | Search shipments by the original tracking `request_number`. |
+| `filters.port?` | `string` | - |
+| `filters.status?` | `string` | - |
+| `filters.trackingStopped?` | `boolean` | Filter shipments by whether they are still tracking. Maps to the supported `filter[tracking_stopped]`. |
+| `filters.updatedAfter?` | `string` | - |
+| `options?` | [`ListOptions`](/sdk/reference/types/options/interfaces/ListOptions) | - |
 
 #### Returns
 

--- a/docs/sdk/reference/types/options/type-aliases/ContainerInclude.mdx
+++ b/docs/sdk/reference/types/options/type-aliases/ContainerInclude.mdx
@@ -5,4 +5,4 @@ description: "ContainerInclude type alias in the Terminal49 TypeScript SDK listi
 
 # Type Alias: ContainerInclude
 
-> **ContainerInclude** = `"shipment"` \| `"pod_terminal"` \| `"destination_terminal"` \| `"transport_events"`
+> **ContainerInclude** = `"shipment"` \| `"pod_terminal"` \| `"pickup_facility"` \| `"transport_events"`

--- a/sdks/typescript-sdk/src/client.filters.test.ts
+++ b/sdks/typescript-sdk/src/client.filters.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import { Terminal49Client } from './client.js';
+import {
+  buildContainerListQuery,
+  buildShipmentListQuery,
+  clampPageSize,
+  MAX_PAGE_SIZE,
+} from './client/query.js';
+
+const baseUrl = 'https://api.test/v2';
+
+/**
+ * Permissive fetch that records each call and always returns an empty
+ * JSON:API document, regardless of query string. Lets us assert on the
+ * emitted query keys without registering exact URLs.
+ */
+function createRecordingFetch() {
+  const calls: URL[] = [];
+  const fetchImpl = (async (input: Request | URL | string) => {
+    const urlString =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    calls.push(new URL(urlString));
+    return new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function makeClient(fetchImpl: typeof fetch) {
+  return new Terminal49Client({
+    apiToken: 'token-123',
+    apiBaseUrl: baseUrl,
+    fetchImpl,
+  });
+}
+
+describe('pure list-query builders', () => {
+  it('drops every unsupported container filter and reports them', () => {
+    const { query, unsupportedFilters } = buildContainerListQuery({
+      status: 'in_transit',
+      port: 'USLAX',
+      carrier: 'MAEU',
+      updatedAfter: '2024-01-01',
+    });
+
+    expect(query['filter[status]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[pod_locode]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[line_scac]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[updated_at]' as keyof typeof query]).toBeUndefined();
+    expect(unsupportedFilters.sort()).toEqual(
+      ['carrier', 'port', 'status', 'updatedAfter'].sort(),
+    );
+  });
+
+  it('keeps supported container keys (include) and reports nothing unsupported', () => {
+    const { query, unsupportedFilters } = buildContainerListQuery({
+      include: 'shipment,pod_terminal',
+    });
+    expect(query.include).toBe('shipment,pod_terminal');
+    expect(unsupportedFilters).toEqual([]);
+  });
+
+  it('drops unsupported shipment filters but keeps supported ones', () => {
+    const { query, unsupportedFilters } = buildShipmentListQuery({
+      status: 'in_transit',
+      port: 'USLAX',
+      carrier: 'MAEU',
+      updatedAfter: '2024-01-01',
+      trackingStopped: true,
+      number: 'TRK-1',
+      include: 'containers',
+    });
+
+    // unsupported keys are never emitted
+    expect(query['filter[status]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[pod_locode]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[line_scac]' as keyof typeof query]).toBeUndefined();
+    expect(query['filter[updated_at]' as keyof typeof query]).toBeUndefined();
+
+    // supported keys ARE emitted
+    expect(query['filter[tracking_stopped]']).toBe(true);
+    expect(query.number).toBe('TRK-1');
+    expect(query.include).toBe('containers');
+
+    expect(unsupportedFilters.sort()).toEqual(
+      ['carrier', 'port', 'status', 'updatedAfter'].sort(),
+    );
+  });
+
+  it('clamps page size to the API maximum and floors at 1', () => {
+    expect(clampPageSize(9999)).toBe(MAX_PAGE_SIZE);
+    expect(clampPageSize(MAX_PAGE_SIZE + 1)).toBe(MAX_PAGE_SIZE);
+    expect(clampPageSize(0)).toBe(1);
+    expect(clampPageSize(-5)).toBe(1);
+    expect(clampPageSize(25)).toBe(25);
+    expect(clampPageSize(undefined)).toBeUndefined();
+  });
+});
+
+describe('ContainerManager.list filter correctness', () => {
+  it('does NOT emit filter[*] keys for unsupported status/port/carrier/updatedAfter', async () => {
+    const { fetchImpl, calls } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    await client.listContainers({
+      status: 'in_transit',
+      port: 'USLAX',
+      carrier: 'MAEU',
+      updatedAfter: '2024-01-01',
+    });
+
+    const params = calls[0].searchParams;
+    expect(params.get('filter[status]')).toBeNull();
+    expect(params.get('filter[pod_locode]')).toBeNull();
+    expect(params.get('filter[line_scac]')).toBeNull();
+    expect(params.get('filter[updated_at]')).toBeNull();
+    // include (a supported key) is still emitted
+    expect(params.get('include')).toContain('shipment');
+  });
+
+  it('reports the dropped filters via unsupportedFilters on the mapped result', async () => {
+    const { fetchImpl } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    const result = (await client.listContainers(
+      { status: 'in_transit', port: 'USLAX' },
+      { format: 'mapped' },
+    )) as { unsupportedFilters?: string[] };
+
+    expect(result.unsupportedFilters?.sort()).toEqual(['port', 'status']);
+  });
+
+  it('clamps an over-large page size before sending', async () => {
+    const { fetchImpl, calls } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    await client.listContainers({}, { pageSize: 9999 });
+
+    expect(calls[0].searchParams.get('page[size]')).toBe(String(MAX_PAGE_SIZE));
+  });
+});
+
+describe('ShipmentManager.list filter correctness', () => {
+  it('does NOT emit filter[*] keys for unsupported status/port/carrier/updatedAfter', async () => {
+    const { fetchImpl, calls } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    await client.listShipments({
+      status: 'in_transit',
+      port: 'USLAX',
+      carrier: 'MAEU',
+      updatedAfter: '2024-01-01',
+    });
+
+    const params = calls[0].searchParams;
+    expect(params.get('filter[status]')).toBeNull();
+    expect(params.get('filter[pod_locode]')).toBeNull();
+    expect(params.get('filter[line_scac]')).toBeNull();
+    expect(params.get('filter[updated_at]')).toBeNull();
+  });
+
+  it('emits the supported filter[tracking_stopped] key when requested', async () => {
+    const { fetchImpl, calls } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    // trackingStopped is a manager-level filter (the wrapper keeps its
+    // historical signature), so exercise the manager directly.
+    await client.shipments.list({ trackingStopped: true });
+
+    expect(calls[0].searchParams.get('filter[tracking_stopped]')).toBe('true');
+  });
+
+  it('reports the dropped filters via unsupportedFilters on the mapped result', async () => {
+    const { fetchImpl } = createRecordingFetch();
+    const client = makeClient(fetchImpl);
+
+    const result = (await client.listShipments(
+      { carrier: 'MAEU', updatedAfter: '2024-01-01' },
+      { format: 'mapped' },
+    )) as { unsupportedFilters?: string[] };
+
+    expect(result.unsupportedFilters?.sort()).toEqual([
+      'carrier',
+      'updatedAfter',
+    ]);
+  });
+});

--- a/sdks/typescript-sdk/src/client.request.test.ts
+++ b/sdks/typescript-sdk/src/client.request.test.ts
@@ -78,16 +78,12 @@ describe('Terminal49Client request building', () => {
     expect(result.mapped?.[0]?.scac).toBe('MAEU');
   });
 
-  it('builds listShipments filters and pagination', async () => {
+  it('builds listShipments include + pagination and omits unsupported filters', async () => {
     const search = buildSearchParams([
       [
         'include',
         'containers,pod_terminal,port_of_lading,port_of_discharge,destination,destination_terminal',
       ],
-      ['filter[status]', 'in_transit'],
-      ['filter[pod_locode]', 'USLAX'],
-      ['filter[line_scac]', 'MAEU'],
-      ['filter[updated_at]', '2024-01-01'],
       ['page[number]', '2'],
       ['page[size]', '50'],
     ]);
@@ -102,23 +98,32 @@ describe('Terminal49Client request building', () => {
       fetchImpl,
     });
 
-    await client.listShipments(
+    const result = await client.listShipments(
       {
         status: 'in_transit',
         port: 'USLAX',
         carrier: 'MAEU',
         updatedAfter: '2024-01-01',
       },
-      { page: 2, pageSize: 50 },
+      { page: 2, pageSize: 50, format: 'mapped' },
     );
 
     const params = calls[0].url.searchParams;
-    expect(params.get('filter[status]')).toBe('in_transit');
-    expect(params.get('filter[pod_locode]')).toBe('USLAX');
-    expect(params.get('filter[line_scac]')).toBe('MAEU');
-    expect(params.get('filter[updated_at]')).toBe('2024-01-01');
+    // The v2 API does not support these filter[*] keys, so the SDK omits them
+    // instead of sending no-op params.
+    expect(params.get('filter[status]')).toBeNull();
+    expect(params.get('filter[pod_locode]')).toBeNull();
+    expect(params.get('filter[line_scac]')).toBeNull();
+    expect(params.get('filter[updated_at]')).toBeNull();
     expect(params.get('page[number]')).toBe('2');
     expect(params.get('page[size]')).toBe('50');
+    // ...and reports them back so callers know they were dropped.
+    expect(result.unsupportedFilters).toEqual([
+      'status',
+      'port',
+      'carrier',
+      'updatedAfter',
+    ]);
   });
 
   it('removes containers from include when includeContainers=false', async () => {
@@ -146,10 +151,7 @@ describe('Terminal49Client request building', () => {
   });
 
   it('accepts comma-separated listShipments include strings', async () => {
-    const search = buildSearchParams([
-      ['include', 'containers,pod_terminal'],
-      ['filter[status]', 'in_transit'],
-    ]);
+    const search = buildSearchParams([['include', 'containers,pod_terminal']]);
 
     const { fetchImpl, calls } = createMockFetch({
       [`/shipments?${search}`]: () => jsonResponse({ data: [] }),
@@ -166,15 +168,15 @@ describe('Terminal49Client request building', () => {
       include: 'containers,pod_terminal',
     });
 
-    expect(calls[0].url.searchParams.get('include')).toBe(
-      'containers,pod_terminal',
-    );
+    const params = calls[0].url.searchParams;
+    expect(params.get('include')).toBe('containers,pod_terminal');
+    // Unsupported filter is dropped rather than forwarded as a no-op.
+    expect(params.get('filter[status]')).toBeNull();
   });
 
-  it('builds listContainers filters and pagination with custom include', async () => {
+  it('builds listContainers include + pagination and omits unsupported filters', async () => {
     const search = buildSearchParams([
       ['include', 'shipment,pod_terminal,transport_events'],
-      ['filter[status]', 'in_transit'],
       ['page[number]', '3'],
       ['page[size]', '10'],
     ]);
@@ -189,28 +191,27 @@ describe('Terminal49Client request building', () => {
       fetchImpl,
     });
 
-    await client.listContainers(
+    const result = await client.listContainers(
       {
         status: 'in_transit',
         include: ['shipment', 'pod_terminal', 'transport_events'],
       },
-      { page: 3, pageSize: 10 },
+      { page: 3, pageSize: 10, format: 'mapped' },
     );
 
     const params = calls[0].url.searchParams;
     expect(params.get('include')).toBe(
       'shipment,pod_terminal,transport_events',
     );
-    expect(params.get('filter[status]')).toBe('in_transit');
+    // `filter[status]` is unsupported on /containers, so it is omitted.
+    expect(params.get('filter[status]')).toBeNull();
     expect(params.get('page[number]')).toBe('3');
     expect(params.get('page[size]')).toBe('10');
+    expect(result.unsupportedFilters).toEqual(['status']);
   });
 
   it('accepts comma-separated listContainers include strings', async () => {
-    const search = buildSearchParams([
-      ['include', 'shipment,pod_terminal'],
-      ['filter[status]', 'available'],
-    ]);
+    const search = buildSearchParams([['include', 'shipment,pod_terminal']]);
 
     const { fetchImpl, calls } = createMockFetch({
       [`/containers?${search}`]: () => jsonResponse({ data: [] }),
@@ -227,9 +228,10 @@ describe('Terminal49Client request building', () => {
       include: 'shipment,pod_terminal',
     });
 
-    expect(calls[0].url.searchParams.get('include')).toBe(
-      'shipment,pod_terminal',
-    );
+    const params = calls[0].url.searchParams;
+    expect(params.get('include')).toBe('shipment,pod_terminal');
+    // Unsupported filter is dropped rather than forwarded as a no-op.
+    expect(params.get('filter[status]')).toBeNull();
   });
 
   it('hits container raw events and refresh endpoints', async () => {

--- a/sdks/typescript-sdk/src/client/managers/containers.ts
+++ b/sdks/typescript-sdk/src/client/managers/containers.ts
@@ -6,8 +6,17 @@ import type {
   ListOptions,
 } from '../../types/options.js';
 import { mapContainerList, mapRoute, mapTransportEvents } from '../mappers.js';
-import { normalizeInclude, normalizeIncludeWithDefault } from '../query.js';
+import {
+  applyTypedPagination,
+  buildContainerListQuery,
+  normalizeInclude,
+} from '../query.js';
 import { BaseManager } from './base.js';
+
+const DEFAULT_CONTAINER_INCLUDES = [
+  'shipment',
+  'pod_terminal',
+] as const satisfies readonly ContainerInclude[];
 
 export class ContainerManager extends BaseManager {
   async get(
@@ -37,28 +46,21 @@ export class ContainerManager extends BaseManager {
     } = {},
     options?: ListOptions,
   ): Promise<any> {
-    const includeParam = normalizeIncludeWithDefault(filters.include, [
-      'shipment',
-      'pod_terminal',
-    ]);
-    const params: Record<string, string> = {};
-    if (includeParam) params.include = includeParam;
-    if (filters.status) params['filter[status]'] = filters.status;
-    if (filters.port) params['filter[pod_locode]'] = filters.port;
-    if (filters.carrier) params['filter[line_scac]'] = filters.carrier;
-    if (filters.updatedAfter)
-      params['filter[updated_at]'] = filters.updatedAfter;
-
-    this.applyPagination(params, options);
+    const { query, unsupportedFilters } = buildContainerListQuery(
+      filters,
+      DEFAULT_CONTAINER_INCLUDES,
+    );
+    applyTypedPagination(query, options);
 
     const raw = await this.transport.execute(() =>
       this.transport.client.GET('/containers', {
-        params: { query: params as any },
+        params: { query },
       }),
     );
-    return this.formatResult(raw, options?.format, (doc) =>
-      this.mapListResult(doc, mapContainerList),
-    );
+    return this.formatResult(raw, options?.format, (doc) => ({
+      ...this.mapListResult(doc, mapContainerList),
+      unsupportedFilters,
+    }));
   }
 
   iterate(

--- a/sdks/typescript-sdk/src/client/managers/shipments.ts
+++ b/sdks/typescript-sdk/src/client/managers/shipments.ts
@@ -6,7 +6,11 @@ import type {
   ShipmentInclude,
 } from '../../types/options.js';
 import { mapShipment, mapShipmentList } from '../mappers.js';
-import { normalizeInclude, normalizeIncludeWithDefault } from '../query.js';
+import {
+  applyTypedPagination,
+  buildShipmentListQuery,
+  normalizeIncludeWithDefault,
+} from '../query.js';
 import { BaseManager } from './base.js';
 
 const DEFAULT_SHIPMENT_INCLUDES = [
@@ -56,36 +60,34 @@ export class ShipmentManager extends BaseManager {
       port?: string;
       carrier?: string;
       updatedAfter?: string;
+      /** Filter shipments by whether they are still tracking. Maps to the supported `filter[tracking_stopped]`. */
+      trackingStopped?: boolean;
+      /** Search shipments by the original tracking `request_number`. */
+      number?: string;
       includeContainers?: boolean;
       include?: IncludeParam<ShipmentInclude>;
     } = {},
     options?: ListOptions,
   ): Promise<any> {
-    const params: Record<string, string> = {};
-    const includesStr = normalizeInclude(
-      filters.include ??
-        (filters.includeContainers === false
-          ? SHIPMENT_INCLUDES_WITHOUT_CONTAINERS
-          : DEFAULT_SHIPMENT_INCLUDES),
+    const defaultInclude =
+      filters.includeContainers === false
+        ? SHIPMENT_INCLUDES_WITHOUT_CONTAINERS
+        : DEFAULT_SHIPMENT_INCLUDES;
+    const { query, unsupportedFilters } = buildShipmentListQuery(
+      filters,
+      defaultInclude,
     );
-    if (includesStr) params.include = includesStr;
-
-    if (filters.status) params['filter[status]'] = filters.status;
-    if (filters.port) params['filter[pod_locode]'] = filters.port;
-    if (filters.carrier) params['filter[line_scac]'] = filters.carrier;
-    if (filters.updatedAfter)
-      params['filter[updated_at]'] = filters.updatedAfter;
-
-    this.applyPagination(params, options);
+    applyTypedPagination(query, options);
 
     const raw = await this.transport.execute(() =>
       this.transport.client.GET('/shipments', {
-        params: { query: params as any },
+        params: { query },
       }),
     );
-    return this.formatResult(raw, options?.format, (doc) =>
-      this.mapListResult(doc, mapShipmentList),
-    );
+    return this.formatResult(raw, options?.format, (doc) => ({
+      ...this.mapListResult(doc, mapShipmentList),
+      unsupportedFilters,
+    }));
   }
 
   iterate(

--- a/sdks/typescript-sdk/src/client/query.ts
+++ b/sdks/typescript-sdk/src/client/query.ts
@@ -1,8 +1,77 @@
-import type { ListOptions } from '../types/options.js';
+import type { paths } from '../generated/terminal49.js';
+import type {
+  ContainerInclude,
+  IncludeParam as IncludeParamOption,
+  ListOptions,
+  ShipmentInclude,
+} from '../types/options.js';
 
 export type IncludeParam<TInclude extends string> =
   | readonly TInclude[]
   | string;
+
+/**
+ * Maximum `page[size]` accepted by the Terminal49 v2 list endpoints. Values
+ * above this are silently truncated by the API, so the SDK clamps them to keep
+ * pagination cursors honest.
+ */
+export const MAX_PAGE_SIZE = 100;
+
+/** Typed query objects for the JSON:API list endpoints, sourced from the generated OpenAPI spec. */
+type ContainerListQuery = NonNullable<
+  paths['/containers']['get']['parameters']['query']
+>;
+type ShipmentListQuery = NonNullable<
+  paths['/shipments']['get']['parameters']['query']
+>;
+
+/** Filters accepted by {@link buildContainerListQuery}. Mirrors the public `containers.list` signature. */
+export interface ContainerListFilters {
+  status?: string;
+  port?: string;
+  carrier?: string;
+  updatedAfter?: string;
+  include?: IncludeParamOption<ContainerInclude>;
+}
+
+/** Filters accepted by {@link buildShipmentListQuery}. Mirrors the public `shipments.list` signature. */
+export interface ShipmentListFilters {
+  status?: string;
+  port?: string;
+  carrier?: string;
+  updatedAfter?: string;
+  trackingStopped?: boolean;
+  number?: string;
+  includeContainers?: boolean;
+  include?: IncludeParamOption<ShipmentInclude>;
+}
+
+/** Result of building a list query: the typed query plus any filters the API does not support. */
+export interface ListQueryResult<TQuery> {
+  query: TQuery;
+  unsupportedFilters: string[];
+}
+
+/**
+ * Filter keys the SDK historically forwarded as `filter[*]` query params but
+ * which the Terminal49 v2 API does NOT support on `/containers` or `/shipments`
+ * (verified against docs/openapi.json + the generated OpenAPI types). The API
+ * silently drops them, so we report them back instead of pretending they worked.
+ */
+const UNSUPPORTED_FILTER_KEYS = [
+  'status',
+  'port',
+  'carrier',
+  'updatedAfter',
+] as const;
+
+function collectUnsupportedFilters(
+  filters: Partial<Record<(typeof UNSUPPORTED_FILTER_KEYS)[number], unknown>>,
+): string[] {
+  return UNSUPPORTED_FILTER_KEYS.filter(
+    (key) => filters[key] !== undefined && filters[key] !== '',
+  );
+}
 
 export function normalizeInclude<TInclude extends string>(
   include?: IncludeParam<TInclude>,
@@ -25,6 +94,20 @@ export function normalizeIncludeWithDefault<TInclude extends string>(
   return normalizeInclude(include ?? defaultInclude);
 }
 
+/**
+ * Clamp a requested page size into the range the API actually honors: at least
+ * 1, at most {@link MAX_PAGE_SIZE}. Returns `undefined` when no size was given
+ * so the API's own default (30) applies.
+ */
+export function clampPageSize(pageSize?: number): number | undefined {
+  if (pageSize === undefined) return undefined;
+  if (!Number.isFinite(pageSize)) return undefined;
+  const floored = Math.floor(pageSize);
+  if (floored < 1) return 1;
+  if (floored > MAX_PAGE_SIZE) return MAX_PAGE_SIZE;
+  return floored;
+}
+
 export function applyPagination(
   params: Record<string, string>,
   options?: Pick<ListOptions, 'page' | 'pageSize'>,
@@ -33,9 +116,81 @@ export function applyPagination(
   if (options.page !== undefined) {
     params['page[number]'] = String(options.page);
   }
-  if (options.pageSize !== undefined) {
-    params['page[size]'] = String(options.pageSize);
+  const pageSize = clampPageSize(options.pageSize);
+  if (pageSize !== undefined) {
+    params['page[size]'] = String(pageSize);
   }
+}
+
+/** Query objects that carry numeric JSON:API pagination keys. */
+type PaginatedQuery = {
+  'page[number]'?: number;
+  'page[size]'?: number;
+};
+
+/**
+ * Apply pagination to a typed list query as numbers (matching the generated
+ * OpenAPI types), clamping `page[size]` to {@link MAX_PAGE_SIZE}.
+ */
+export function applyTypedPagination<TQuery extends PaginatedQuery>(
+  query: TQuery,
+  options?: Pick<ListOptions, 'page' | 'pageSize'>,
+): TQuery {
+  if (!options) return query;
+  if (options.page !== undefined) {
+    query['page[number]'] = options.page;
+  }
+  const pageSize = clampPageSize(options.pageSize);
+  if (pageSize !== undefined) {
+    query['page[size]'] = pageSize;
+  }
+  return query;
+}
+
+/**
+ * Build the typed `/containers` list query, mapping only filters the v2 API
+ * supports (`include`) and reporting the rest via `unsupportedFilters`.
+ */
+export function buildContainerListQuery(
+  filters: ContainerListFilters,
+  defaultInclude?: IncludeParamOption<ContainerInclude>,
+): ListQueryResult<ContainerListQuery> {
+  const query: ContainerListQuery = {};
+
+  const includeStr = normalizeIncludeWithDefault(
+    filters.include,
+    defaultInclude ?? [],
+  );
+  if (includeStr) query.include = includeStr;
+
+  return { query, unsupportedFilters: collectUnsupportedFilters(filters) };
+}
+
+/**
+ * Build the typed `/shipments` list query. Maps the supported filters
+ * (`include`, `number`, `filter[tracking_stopped]`) and reports unsupported
+ * ones via `unsupportedFilters`.
+ */
+export function buildShipmentListQuery(
+  filters: ShipmentListFilters,
+  defaultInclude?: IncludeParamOption<ShipmentInclude>,
+): ListQueryResult<ShipmentListQuery> {
+  const query: ShipmentListQuery = {};
+
+  const includeStr = normalizeIncludeWithDefault(
+    filters.include,
+    defaultInclude ?? [],
+  );
+  if (includeStr) query.include = includeStr;
+
+  if (filters.number !== undefined && filters.number !== '') {
+    query.number = filters.number;
+  }
+  if (filters.trackingStopped !== undefined) {
+    query['filter[tracking_stopped]'] = filters.trackingStopped;
+  }
+
+  return { query, unsupportedFilters: collectUnsupportedFilters(filters) };
 }
 
 export function copyStringParams(

--- a/sdks/typescript-sdk/src/types/options.ts
+++ b/sdks/typescript-sdk/src/types/options.ts
@@ -30,7 +30,7 @@ export type ShipmentInclude =
 export type ContainerInclude =
   | 'shipment'
   | 'pod_terminal'
-  | 'destination_terminal'
+  | 'pickup_facility'
   | 'transport_events';
 
 export type TrackingRequestInclude = 'shipment' | 'container';


### PR DESCRIPTION
## Summary

The Terminal49 v2 `/containers` and `/shipments` list endpoints do **not** support `filter[status]`, `filter[pod_locode]` (port), `filter[line_scac]` (carrier), or `filter[updated_at]` (updatedAfter) — verified against `docs/openapi.json` and the generated OpenAPI types. The SDK was silently forwarding these as `filter[*]` query keys, which the API drops, giving callers the false impression their filters applied.

This PR finishes that filter-correctness work:

- **Filter no-op fix:** typed query builders (`buildContainerListQuery` / `buildShipmentListQuery`) map only the supported keys (`include`; plus `number` and `filter[tracking_stopped]` for shipments) and report dropped keys via an additive `unsupportedFilters: string[]` on the mapped list result. The `as any` casts on the list GET query objects are removed so an unknown filter key now fails typecheck.
- **Page-size clamp:** `page[size]` is clamped to `[1, MAX_PAGE_SIZE=100]` via `clampPageSize` / `applyTypedPagination`.
- **Test reconciliation:** the 4 request-builder tests that asserted the OLD buggy behavior (that the unsupported `filter[*]` keys ARE emitted) are updated to the post-fix contract — handler URLs no longer register the unsupported keys, the tests assert those keys are NOT present on the emitted request, and they assert `result.unsupportedFilters` reports the dropped source keys (`status`/`port`/`carrier`/`updatedAfter`). `include` + `page[number]`/`page[size]` coverage is preserved.
- **Container include wiring (request side for DEV-10662, mapper side in #275):** `ContainerInclude` listed a nonexistent `destination_terminal` relationship; replaced with `pickup_facility`, the real container relationship per `docs/openapi.json` (container relationships: `shipment`, `pickup_facility`, `pod_terminal`, `transport_events`, `raw_events`). Container default includes remain sensible (`shipment`, `pod_terminal`).
  - `containers.route()` include is left as-is: the `/containers/{id}/route` endpoint is not present in `docs/openapi.json`, so nested JSON:API include support (`route_location.location`) cannot be verified against the spec, and the route mapper reads each leg's `port` relationship directly off the route_location.

Closes DEV-10658 (page-size cap). Implements the filter-no-op critical (full filter grammar tracked in DEV-10668) and wires the request-side includes for DEV-10662 (#275).

## Green gate

All commands run from the worktree root:

- `npm run build --workspace @terminal49/sdk` — pass
- `npm run build --workspace @terminal49/mcp` — pass
- `npm run type-check --workspace @terminal49/sdk` — pass
- `npm run type-check --workspace @terminal49/mcp` — pass
- `npm test --workspace @terminal49/sdk -- --run` — 61 passed, 2 skipped
- `npm run test --workspace @terminal49/mcp -- --run` — 77 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stops the SDK from forwarding unsupported `filter[*]` query parameters (`status`, `pod_locode`, `line_scac`, `updated_at`) to the Terminal49 v2 list endpoints, caps `page[size]` at 100, wires `pickup_facility` as the correct container include, and reports dropped filters via `unsupportedFilters` on mapped results.

- **Filter correctness:** `buildContainerListQuery` / `buildShipmentListQuery` now construct typed query objects from the generated OpenAPI spec, replacing the previous `Record<string, string>` approach with `as any` casts; unsupported filter keys are collected and returned as `unsupportedFilters` rather than being silently forwarded.
- **Page-size clamping:** `clampPageSize` floors at 1 and caps at `MAX_PAGE_SIZE = 100`, applied via the new `applyTypedPagination` helper; the old `applyPagination` (string-only) is retained for non-typed call sites.
- **Include fix:** `ContainerInclude` removes the nonexistent `destination_terminal` and adds `pickup_facility`, matching the actual container relationships in the OpenAPI spec.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The filter-correctness and page-size clamping changes are safe to ship; the core bug (sending no-op filter params to the API) is fixed for all callers regardless of format.

The `unsupportedFilters` diagnostic is computed in all code paths but only attached to the return value when `format: 'mapped'` is requested. With the SDK default `format: 'raw'`, `formatResult` returns before calling the mapper, so `unsupportedFilters` is silently discarded — callers in the default format receive an unfiltered list with no indication their filters were dropped.

`containers.ts` and `shipments.ts` — the `unsupportedFilters` plumbing through `formatResult` is worth a second look for the raw-format case.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| sdks/typescript-sdk/src/client/query.ts | Introduces typed query builders, `clampPageSize`, and `applyTypedPagination`; correctly isolates the four unsupported filter keys and reports them via `unsupportedFilters`. |
| sdks/typescript-sdk/src/client/managers/containers.ts | Switches to typed query builder; removes `as any` cast on the GET query; `unsupportedFilters` is only surfaced in `format: 'mapped'` mode. |
| sdks/typescript-sdk/src/client/managers/shipments.ts | Same typed-query-builder migration as containers; adds `trackingStopped` and `number` filter support; same `unsupportedFilters` surfacing limitation in raw format. |
| sdks/typescript-sdk/src/types/options.ts | Replaces the nonexistent `destination_terminal` include with `pickup_facility`, matching the actual container relationships in the OpenAPI spec. |
| sdks/typescript-sdk/src/client.filters.test.ts | New test file covering filter-correctness for both managers, page-size clamping, and `unsupportedFilters` reporting in mapped mode; assertions use `.sort()` for order-safety. |
| sdks/typescript-sdk/src/client.request.test.ts | Updated four tests to assert the post-fix contract; one assertion uses order-sensitive `toEqual` without `.sort()` on `unsupportedFilters`. |
| .github/workflows/ci.yml | Adds `npm run type-check` steps to both CI jobs to catch type regressions at the SDK and MCP workspace levels. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["caller: list(filters, options)"] --> B["buildContainerListQuery / buildShipmentListQuery"]
    B --> C{{"filter key supported?"}}
    C -- "include / number / tracking_stopped" --> D["add to typed query object"]
    C -- "status / port / carrier / updatedAfter" --> E["record in unsupportedFilters[]"]
    D --> F["applyTypedPagination(query, options)\nclamp page[size] to [1, 100]"]
    F --> G["transport.client.GET('/containers' or '/shipments', { query })"]
    G --> H["formatResult(raw, format, mapper)"]
    H --> I{{"format?"}}
    I -- "'raw' (default)" --> J["return raw API response\nunsupportedFilters LOST"]
    I -- "'mapped'" --> K["mapper(raw) → { items, links, meta, unsupportedFilters }"]
    I -- "'both'" --> L["{ raw, mapped: mapper(raw) }\nunsupportedFilters in mapped"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["caller: list(filters, options)"] --> B["buildContainerListQuery / buildShipmentListQuery"]
    B --> C{{"filter key supported?"}}
    C -- "include / number / tracking_stopped" --> D["add to typed query object"]
    C -- "status / port / carrier / updatedAfter" --> E["record in unsupportedFilters[]"]
    D --> F["applyTypedPagination(query, options)\nclamp page[size] to [1, 100]"]
    F --> G["transport.client.GET('/containers' or '/shipments', { query })"]
    G --> H["formatResult(raw, format, mapper)"]
    H --> I{{"format?"}}
    I -- "'raw' (default)" --> J["return raw API response\nunsupportedFilters LOST"]
    I -- "'mapped'" --> K["mapper(raw) → { items, links, meta, unsupportedFilters }"]
    I -- "'both'" --> L["{ raw, mapped: mapper(raw) }\nunsupportedFilters in mapped"]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fsdk-filter-correctness%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsdk-filter-correctness%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fmanagers%2Fcontainers.ts%3A60-63%0A**%60unsupportedFilters%60%20silently%20unavailable%20in%20the%20default%20%28%60raw%60%29%20format**%0A%0A%60unsupportedFilters%60%20is%20attached%20to%20the%20return%20value%20only%20inside%20the%20mapper%20callback%20passed%20to%20%60formatResult%60.%20When%20the%20caller%20uses%20the%20default%20format%20%28%60'raw'%60%29%2C%20%60formatResult%60%20returns%20the%20raw%20API%20response%20immediately%20and%20never%20calls%20the%20mapper%20%E2%80%94%20so%20%60unsupportedFilters%60%20is%20computed%20but%20then%20discarded.%20A%20caller%20who%20passes%20%60%7B%20status%3A%20'in_transit'%20%7D%60%20without%20specifying%20%60format%3A%20'mapped'%60%20will%20get%20an%20unfiltered%20list%20back%20with%20no%20indication%20that%20the%20filter%20was%20dropped.%20The%20same%20pattern%20applies%20in%20%60shipments.ts%60.%20Consider%20either%20always%20returning%20a%20wrapper%20object%20that%20includes%20%60unsupportedFilters%60%20alongside%20the%20raw%20response%2C%20or%20logging%20a%20warning%20when%20dropped%20filters%20are%20detected%20regardless%20of%20format.%0A%0A%23%23%23%20Issue%202%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient.request.test.ts%3A121-126%0AThe%20%60unsupportedFilters%60%20assertion%20uses%20%60toEqual%60%20without%20%60.sort%28%29%60%2C%20coupling%20the%20test%20to%20the%20iteration%20order%20of%20the%20internal%20%60UNSUPPORTED_FILTER_KEYS%60%20constant.%20If%20the%20order%20of%20that%20array%20ever%20changes%2C%20this%20test%20fails%20for%20a%20non-functional%20reason.%20The%20sibling%20test%20in%20%60client.filters.test.ts%60%20correctly%20sorts%20both%20sides%20before%20comparing.%0A%0A%60%60%60suggestion%0A%20%20%20%20expect%28result.unsupportedFilters%3F.slice%28%29.sort%28%29%29.toEqual%28%0A%20%20%20%20%20%20%5B'status'%2C%20'port'%2C%20'carrier'%2C%20'updatedAfter'%5D.sort%28%29%2C%0A%20%20%20%20%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asdks%2Ftypescript-sdk%2Fsrc%2Fclient%2Fquery.ts%3A37-47%0A**%60includeContainers%60%20in%20%60ShipmentListFilters%60%20is%20a%20no-op%20when%20calling%20the%20builder%20directly**%0A%0A%60ShipmentListFilters%60%20%28an%20exported%20interface%29%20includes%20%60includeContainers%3F%3A%20boolean%60%2C%20but%20%60buildShipmentListQuery%60%20never%20reads%20it.%20The%20field%20only%20has%20effect%20when%20the%20%60ShipmentManager%60%20computes%20%60defaultInclude%60%20before%20calling%20the%20builder.%20A%20caller%20who%20invokes%20the%20exported%20%60buildShipmentListQuery%28%7B%20includeContainers%3A%20false%20%7D%29%60%20directly%20will%20find%20the%20flag%20is%20a%20no-op%20%E2%80%94%20the%20builder%20will%20fall%20back%20to%20the%20empty-array%20default%2C%20not%20%60SHIPMENT_INCLUDES_WITHOUT_CONTAINERS%60.%20Consider%20either%20removing%20%60includeContainers%60%20from%20%60ShipmentListFilters%60%20or%20handling%20it%20inside%20the%20builder.%0A%0A&repo=terminal49%2Fapi&pr=278&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
sdks/typescript-sdk/src/client/managers/containers.ts:60-63
**`unsupportedFilters` silently unavailable in the default (`raw`) format**

`unsupportedFilters` is attached to the return value only inside the mapper callback passed to `formatResult`. When the caller uses the default format (`'raw'`), `formatResult` returns the raw API response immediately and never calls the mapper — so `unsupportedFilters` is computed but then discarded. A caller who passes `{ status: 'in_transit' }` without specifying `format: 'mapped'` will get an unfiltered list back with no indication that the filter was dropped. The same pattern applies in `shipments.ts`. Consider either always returning a wrapper object that includes `unsupportedFilters` alongside the raw response, or logging a warning when dropped filters are detected regardless of format.

### Issue 2 of 3
sdks/typescript-sdk/src/client.request.test.ts:121-126
The `unsupportedFilters` assertion uses `toEqual` without `.sort()`, coupling the test to the iteration order of the internal `UNSUPPORTED_FILTER_KEYS` constant. If the order of that array ever changes, this test fails for a non-functional reason. The sibling test in `client.filters.test.ts` correctly sorts both sides before comparing.

```suggestion
    expect(result.unsupportedFilters?.slice().sort()).toEqual(
      ['status', 'port', 'carrier', 'updatedAfter'].sort(),
    );
```

### Issue 3 of 3
sdks/typescript-sdk/src/client/query.ts:37-47
**`includeContainers` in `ShipmentListFilters` is a no-op when calling the builder directly**

`ShipmentListFilters` (an exported interface) includes `includeContainers?: boolean`, but `buildShipmentListQuery` never reads it. The field only has effect when the `ShipmentManager` computes `defaultInclude` before calling the builder. A caller who invokes the exported `buildShipmentListQuery({ includeContainers: false })` directly will find the flag is a no-op — the builder will fall back to the empty-array default, not `SHIPMENT_INCLUDES_WITHOUT_CONTAINERS`. Consider either removing `includeContainers` from `ShipmentListFilters` or handling it inside the builder.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(sdk): regenerate reference for filt..."](https://github.com/terminal49/api/commit/1df56a85c51d79e20ef3adaed92dc456cdb21545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39983182)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->