### PR TITLE
fix(mcp): annotate tools with readOnlyHint so reads aren't treated as edit tools

### DIFF
--- a/docs/mcp/home.mdx
+++ b/docs/mcp/home.mdx
@@ -110,7 +110,7 @@ Input and output recording is disabled by default. Leave `SENTRY_MCP_RECORD_INPU
 ## Tools reference
 
 <Note>
-Every tool is read-only except `track_container`, which creates a tracking request. `track_container` is idempotent—re-tracking a number that's already tracked returns the existing request instead of creating a duplicate.
+Every tool is read-only except `track_container`, which creates a tracking request. If a container for the number is already in your account, `track_container` returns it instead of creating a new request; otherwise it creates a tracking request, so repeated calls before a container links can create additional requests.
 </Note>
 
 ### `search_container`

--- a/docs/mcp/home.mdx
+++ b/docs/mcp/home.mdx
@@ -109,6 +109,10 @@ Input and output recording is disabled by default. Leave `SENTRY_MCP_RECORD_INPU
 
 ## Tools reference
 
+<Note>
+Every tool is read-only except `track_container`, which creates a tracking request. `track_container` is idempotent—re-tracking a number that's already tracked returns the existing request instead of creating a duplicate.
+</Note>
+
 ### `search_container`
 
 Find containers by container number, BL, booking, or your own reference. This is the fastest way to locate containers.

--- a/packages/mcp/src/annotations.test.ts
+++ b/packages/mcp/src/annotations.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createTerminal49McpServer } from './server.js';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+  flush: vi.fn().mockResolvedValue(true),
+  isInitialized: vi.fn(() => false),
+  wrapMcpServerWithSentry: vi.fn((server) => server),
+}));
+
+type ToolAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+function getRegisteredTools(): Record<
+  string,
+  { annotations?: ToolAnnotations }
+> {
+  const server = createTerminal49McpServer('token');
+  return (server as any)._registeredTools as Record<
+    string,
+    { annotations?: ToolAnnotations }
+  >;
+}
+
+describe('MCP tool annotations', () => {
+  const readOnlyTools = [
+    'search_container',
+    'get_container',
+    'get_container_route',
+    'get_container_transport_events',
+    'get_shipment_details',
+    'get_supported_shipping_lines',
+    'list_containers',
+    'list_shipments',
+    'list_tracking_requests',
+  ];
+
+  it('marks the nine read tools as read-only', () => {
+    const tools = getRegisteredTools();
+
+    for (const name of readOnlyTools) {
+      const annotations = tools[name]?.annotations;
+      expect(annotations, name).toBeDefined();
+      expect(annotations?.readOnlyHint, name).toBe(true);
+    }
+  });
+
+  it('marks track_container as a non-destructive idempotent write', () => {
+    const tools = getRegisteredTools();
+    const annotations = tools.track_container?.annotations;
+
+    expect(annotations).toBeDefined();
+    expect(annotations?.readOnlyHint).toBe(false);
+    expect(annotations?.destructiveHint).toBe(false);
+    expect(annotations?.idempotentHint).toBe(true);
+    expect(annotations?.openWorldHint).toBe(true);
+  });
+
+  it('marks get_supported_shipping_lines as a closed-world catalog', () => {
+    const tools = getRegisteredTools();
+    const annotations = tools.get_supported_shipping_lines?.annotations;
+
+    expect(annotations).toBeDefined();
+    expect(annotations?.readOnlyHint).toBe(true);
+    expect(annotations?.openWorldHint).toBe(false);
+  });
+
+  it('annotates every registered tool', () => {
+    const tools = getRegisteredTools();
+
+    for (const [name, tool] of Object.entries(tools)) {
+      expect(tool.annotations, name).toBeDefined();
+    }
+  });
+});

--- a/packages/mcp/src/annotations.test.ts
+++ b/packages/mcp/src/annotations.test.ts
@@ -39,6 +39,10 @@ describe('MCP tool annotations', () => {
     'list_tracking_requests',
   ];
 
+  // get_supported_shipping_lines is a closed-world catalog; the other read
+  // tools query live shipment data and should be open-world.
+  const closedWorldReadTools = ['get_supported_shipping_lines'];
+
   it('marks the nine read tools as read-only', () => {
     const tools = getRegisteredTools();
 
@@ -46,17 +50,21 @@ describe('MCP tool annotations', () => {
       const annotations = tools[name]?.annotations;
       expect(annotations, name).toBeDefined();
       expect(annotations?.readOnlyHint, name).toBe(true);
+
+      if (!closedWorldReadTools.includes(name)) {
+        expect(annotations?.openWorldHint, name).toBe(true);
+      }
     }
   });
 
-  it('marks track_container as a non-destructive idempotent write', () => {
+  it('marks track_container as a non-destructive non-idempotent write', () => {
     const tools = getRegisteredTools();
     const annotations = tools.track_container?.annotations;
 
     expect(annotations).toBeDefined();
     expect(annotations?.readOnlyHint).toBe(false);
     expect(annotations?.destructiveHint).toBe(false);
-    expect(annotations?.idempotentHint).toBe(true);
+    expect(annotations?.idempotentHint).toBe(false);
     expect(annotations?.openWorldHint).toBe(true);
   });
 
@@ -71,6 +79,18 @@ describe('MCP tool annotations', () => {
 
   it('annotates every registered tool', () => {
     const tools = getRegisteredTools();
+
+    // Guard against the SDK renaming/restructuring `_registeredTools`: if the
+    // map ever resolves to undefined or empty, the per-tool loop below would
+    // pass vacuously. Assert it actually contains the tools we expect first.
+    expect(
+      tools,
+      '_registeredTools is empty - SDK internals may have changed',
+    ).toBeTruthy();
+    expect(
+      Object.keys(tools).length,
+      '_registeredTools is empty - SDK internals may have changed',
+    ).toBeGreaterThanOrEqual(readOnlyTools.length + 1);
 
     for (const [name, tool] of Object.entries(tools)) {
       expect(tool.annotations, name).toBeDefined();

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -673,7 +673,7 @@ export function createTerminal49McpServer(
         'Track a container, bill of lading, or booking number. ' +
         'Uses inference to choose the carrier/type when possible, creates a tracking request, ' +
         'and returns detailed container information.',
-      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
       inputSchema: {
         number: z.string().optional().describe('Container, bill of lading, or booking number to track'),
         numberType: z

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -633,6 +633,7 @@ export function createTerminal49McpServer(
         'booking number, bill of lading, or reference number. ' +
         'This is the fastest way to find container information. ' +
         'Examples: CAIU2885402, MAEU123456789, or any reference number.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         query: z.string().min(1).describe('Search query - can be a container number, booking number, BL number, or reference number'),
         intent: toolIntentSchema,
@@ -672,6 +673,7 @@ export function createTerminal49McpServer(
         'Track a container, bill of lading, or booking number. ' +
         'Uses inference to choose the carrier/type when possible, creates a tracking request, ' +
         'and returns detailed container information.',
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
       inputSchema: {
         number: z.string().optional().describe('Container, bill of lading, or booking number to track'),
         numberType: z
@@ -714,6 +716,7 @@ export function createTerminal49McpServer(
         'Get container information with flexible data loading. Returns core container data (status, location, equipment, dates) ' +
         'plus optional related data. Choose includes based on user question and container state. ' +
         'Response includes metadata hints to guide follow-up queries.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: z.string().uuid().describe('The Terminal49 container ID (UUID format)'),
         include: z
@@ -749,6 +752,7 @@ export function createTerminal49McpServer(
         'Get detailed shipment information including routing, BOL, containers, and port details. ' +
         'Use this when user asks about a shipment (vs a specific container). ' +
         'Returns: Bill of Lading, shipping line, port details, vessel info, ETAs, container list.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: z.string().uuid().describe('The Terminal49 shipment ID (UUID format)'),
         include_containers: z.boolean().optional().default(true).describe('Include list of containers in this shipment. Default: true'),
@@ -777,6 +781,7 @@ export function createTerminal49McpServer(
         '(vessel loaded, departed, arrived, discharged, rail movements, delivery). ' +
         'Use this for questions about journey history, "what happened", timeline analysis, rail tracking. ' +
         'More efficient than get_container with transport_events when you only need event data.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: z.string().uuid().describe('The Terminal49 container ID (UUID format)'),
         intent: toolIntentSchema,
@@ -802,6 +807,7 @@ export function createTerminal49McpServer(
         'Get list of shipping lines (carriers) supported by Terminal49 for container tracking. ' +
         'Returns SCAC codes, full names, and common abbreviations. ' +
         'Use this when user asks which carriers are supported or to validate a carrier name.',
+      annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: {
         search: z.string().optional().describe('Optional: Filter by carrier name or SCAC code'),
         intent: toolIntentSchema,
@@ -841,6 +847,7 @@ export function createTerminal49McpServer(
         'Shows complete multi-leg journey (origin → transshipment ports → destination). ' +
         'NOTE: This is a paid feature and may not be available for all accounts. ' +
         'Use for questions about routing, transshipments, or detailed vessel itinerary.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         id: z.string().uuid().describe('The Terminal49 container ID (UUID format)'),
         intent: toolIntentSchema,
@@ -917,6 +924,7 @@ export function createTerminal49McpServer(
       description:
         'List shipments with optional filters and pagination. ' +
         'Use for queries like "show recent shipments" or "shipments for a carrier".',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         status: z.string().optional().describe('Filter by shipment status'),
         port: z.string().optional().describe('Filter by POD port LOCODE'),
@@ -951,6 +959,7 @@ export function createTerminal49McpServer(
       description:
         'List containers with optional filters and pagination. ' +
         'Use for queries like "containers at port" or "latest updates".',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         status: z.string().optional().describe('Filter by container status'),
         port: z.string().optional().describe('Filter by POD port LOCODE'),
@@ -985,6 +994,7 @@ export function createTerminal49McpServer(
       description:
         'List tracking requests with optional filters and pagination. ' +
         'Useful for monitoring recent tracking activity.',
+      annotations: { readOnlyHint: true, openWorldHint: true },
       inputSchema: {
         filters: z
           .record(z.string(), z.string())


### PR DESCRIPTION
## Root cause

The Terminal49 MCP tools were registered via `server.registerTool(name, config, handler)` **without an `annotations` field**. With no [MCP `ToolAnnotations`](https://modelcontextprotocol.io/specification/server/tools#tool-annotations), clients have no read-only signal and default to treating every tool as mutating/destructive. This mis-categorizes the 9 read-only lookups as edit/write operations, adding unnecessary confirmation friction and making the read tools look as risky as a write.

## The fix

Add an `annotations` field to all 10 tool registrations in `packages/mcp/src/server.ts`. **No tool behavior, schemas, or handlers changed — annotations only.** The MCP SDK (`@modelcontextprotocol/sdk` ^1.29.0) supports `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` on the `registerTool` config object.

### Categorization

**Read-only** — `{ readOnlyHint: true, openWorldHint: true }` (9 tools, but one differs on open-world, see below):
- `search_container`
- `get_container`
- `get_container_route`
- `get_container_transport_events`
- `get_shipment_details`
- `list_containers`
- `list_shipments`
- `list_tracking_requests`

**Read-only, bounded catalog** — `{ readOnlyHint: true, openWorldHint: false }`:
- `get_supported_shipping_lines` — the supported-carriers catalog is closed/enumerable, so `openWorldHint: false`.

**Write (the only one)** — `{ readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true }`:
- `track_container` — a **create**, not destructive, and **idempotent**: re-tracking the same number returns the existing tracking request rather than creating a duplicate.

So: **9 read-only tools + 1 non-destructive idempotent write (`track_container`)**.

## Tests & docs

- New regression test `packages/mcp/src/annotations.test.ts` builds the server via `createTerminal49McpServer('token')`, reads `(server as any)._registeredTools`, and asserts each tool's hints (the 9 reads are `readOnlyHint===true`; `track_container` is `readOnlyHint===false`, `destructiveHint===false`, `idempotentHint===true`; `get_supported_shipping_lines` is `openWorldHint===false`).
- `docs/mcp/home.mdx` gets a `<Note>` at the top of the **Tools reference** section clarifying that every tool is read-only except `track_container`, which creates a tracking request and is idempotent.

## Green gate

All gates pass:

```
build  @terminal49/sdk   ✓
build  @terminal49/mcp   ✓
type-check @terminal49/sdk ✓
type-check @terminal49/mcp ✓
test   @terminal49/sdk    51 passed | 2 skipped
test   @terminal49/mcp    81 passed  (was 77; +4 from annotations.test.ts)
oxlint @terminal49/mcp    clean
```

(Baseline was SDK 51 pass / 2 skip, MCP 77 pass.)

## Notes

- `server.ts` is also touched by open PR #276 (`fix/mcp-server-list-and-polish`). Both branch off `main`; expect a small merge coordination on `server.ts` between this PR and #276. The diff here is intentionally minimal (one `annotations:` line per tool) to keep that merge trivial. Note: `oxfmt --check` reports pre-existing formatting issues on `server.ts` that also exist unchanged on `main` (running `--write` would rewrite ~700 lines and conflict with #276), so formatting was deliberately left untouched; the added lines match existing style and `oxlint` is clean.
- Production-readiness follow-up to DEV-10647 (Linear sub-task pending re-auth — to be linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds MCP `ToolAnnotations` to all 10 tool registrations in `packages/mcp/src/server.ts` so clients can correctly distinguish read-only lookups from the single write operation (`track_container`). No tool handlers, schemas, or runtime behaviour are changed.

- **`server.ts`**: One `annotations:` field added per `registerTool` call — 9 tools marked `readOnlyHint: true`, `track_container` marked `readOnlyHint: false, destructiveHint: false, idempotentHint: true`, and `get_supported_shipping_lines` additionally marked `openWorldHint: false`.
- **`annotations.test.ts`**: New regression test file that introspects `_registeredTools` (SDK internal) to assert each tool's hint values, with separate cases for the idempotent write and the closed-world catalog.
- **`docs/mcp/home.mdx`**: Adds a `<Note>` clarifying the read-only vs write split at the top of the Tools reference section.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive metadata only; no handlers, schemas, or API calls are touched.

The production change in `server.ts` is minimal and correct: every tool gets an `annotations` block matching the PR categorisation. The only concerns are in the test file: it couples itself to the SDK private `_registeredTools` field, and the bulk read-only loop omits `openWorldHint: true` assertions for the eight open-world tools, leaving a gap a future regression could slip through undetected.

packages/mcp/src/annotations.test.ts — private SDK field access and incomplete `openWorldHint` coverage.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/mcp/src/server.ts | Adds one `annotations` line per tool registration (10 tools total). No handler, schema, or behavior changes. All 9 read-only tools correctly get `readOnlyHint: true`; `track_container` correctly gets `readOnlyHint: false, destructiveHint: false, idempotentHint: true`; `get_supported_shipping_lines` correctly gets `openWorldHint: false`. |
| packages/mcp/src/annotations.test.ts | New regression test asserting annotation hints on all 10 tools. Relies on `(server as any)._registeredTools` — a private SDK internal — which could silently break on SDK upgrades. The bulk read-only test also omits `openWorldHint` assertions for the 8 open-world tools. |
| docs/mcp/home.mdx | Adds a `<Note>` callout above the tools reference clarifying read-only vs write behaviour. Documentation-only change, accurate and concise. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Client([MCP Client]) --> |calls tool| Dispatch{Tool annotation\nreadOnlyHint?}

    Dispatch -->|true| ReadPath[Read-only path\nNo confirmation needed]
    Dispatch -->|false| WriteCheck{destructiveHint?}

    WriteCheck -->|false + idempotentHint:true| IdempotentWrite[Non-destructive\nidempotent write\ntrack_container]
    WriteCheck -->|true| DestructiveWrite[Destructive write\nConfirmation required]

    ReadPath --> ReadTools["9 read tools:\nsearch_container / get_container / get_container_route\nget_container_transport_events / get_shipment_details\nget_supported_shipping_lines openWorldHint:false\nlist_containers / list_shipments / list_tracking_requests"]

    IdempotentWrite --> TrackAPI[Terminal49 API\nPOST /tracking_requests\nreturns existing if duplicate]
    ReadTools --> ReadAPI[Terminal49 API\nGET endpoints]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Client([MCP Client]) --> |calls tool| Dispatch{Tool annotation\nreadOnlyHint?}

    Dispatch -->|true| ReadPath[Read-only path\nNo confirmation needed]
    Dispatch -->|false| WriteCheck{destructiveHint?}

    WriteCheck -->|false + idempotentHint:true| IdempotentWrite[Non-destructive\nidempotent write\ntrack_container]
    WriteCheck -->|true| DestructiveWrite[Destructive write\nConfirmation required]

    ReadPath --> ReadTools["9 read tools:\nsearch_container / get_container / get_container_route\nget_container_transport_events / get_shipment_details\nget_supported_shipping_lines openWorldHint:false\nlist_containers / list_shipments / list_tracking_requests"]

    IdempotentWrite --> TrackAPI[Terminal49 API\nPOST /tracking_requests\nreturns existing if duplicate]
    ReadTools --> ReadAPI[Terminal49 API\nGET endpoints]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fmcp-tool-annotations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmcp-tool-annotations%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fmcp%2Fsrc%2Fannotations.test.ts%3A23-26%0A**Fragile%20private-field%20access**%20%E2%80%94%20%60_registeredTools%60%20is%20an%20undocumented%20internal%20of%20%60%40modelcontextprotocol%2Fsdk%60.%20If%20a%20future%20SDK%20version%20renames%20or%20restructures%20this%20map%20%28e.g.%20to%20%60_tools%60%20or%20moves%20hints%20into%20a%20nested%20%60definition%60%20object%29%2C%20every%20assertion%20in%20this%20file%20will%20silently%20pass%20against%20%60undefined%60%20rather%20than%20failing%20loudly%2C%20defeating%20the%20regression%20intent.%20Consider%20pinning%20the%20exact%20SDK%20minor%20version%20in%20the%20test%20package%20and%20adding%20a%20guard%20like%20%60expect%28Object.keys%28tools%29.length%29.toBeGreaterThan%280%29%60%20%E2%80%94%20which%20already%20exists%20in%20the%20%22annotates%20every%20registered%20tool%22%20case%20%E2%80%94%20or%20opening%20a%20tracking%20issue%20for%20when%20%60McpServer%60%20exposes%20a%20public%20%60getRegisteredTools%28%29%60%20surface.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fmcp%2Fsrc%2Fannotations.test.ts%3A42-50%0A**%60openWorldHint%60%20not%20asserted%20for%20the%208%20open-world%20read%20tools**%20%E2%80%94%20the%20loop%20checks%20%60readOnlyHint%3A%20true%60%20but%20not%20%60openWorldHint%3A%20true%60.%20If%20a%20future%20edit%20accidentally%20sets%20%60openWorldHint%3A%20false%60%20on%2C%20say%2C%20%60list_shipments%60%2C%20this%20test%20won't%20catch%20it%3B%20only%20%60get_supported_shipping_lines%60%20gets%20its%20%60openWorldHint%60%20explicitly%20verified%20%28in%20a%20separate%20case%29.%20Adding%20%60expect%28annotations%3F.openWorldHint%2C%20name%29.toBe%28true%29%60%20to%20this%20loop%20for%20the%20non-catalog%20tools%20would%20close%20the%20gap%2C%20or%20excluding%20%60get_supported_shipping_lines%60%20from%20this%20array%20and%20asserting%20%60openWorldHint%3A%20true%60%20for%20the%20remaining%20eight%20here%20would%20make%20the%20intent%20clearer.%0A%0A&repo=terminal49%2Fapi&pr=280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/mcp/src/annotations.test.ts:23-26
**Fragile private-field access** — `_registeredTools` is an undocumented internal of `@modelcontextprotocol/sdk`. If a future SDK version renames or restructures this map (e.g. to `_tools` or moves hints into a nested `definition` object), every assertion in this file will silently pass against `undefined` rather than failing loudly, defeating the regression intent. Consider pinning the exact SDK minor version in the test package and adding a guard like `expect(Object.keys(tools).length).toBeGreaterThan(0)` — which already exists in the "annotates every registered tool" case — or opening a tracking issue for when `McpServer` exposes a public `getRegisteredTools()` surface.

### Issue 2 of 2
packages/mcp/src/annotations.test.ts:42-50
**`openWorldHint` not asserted for the 8 open-world read tools** — the loop checks `readOnlyHint: true` but not `openWorldHint: true`. If a future edit accidentally sets `openWorldHint: false` on, say, `list_shipments`, this test won't catch it; only `get_supported_shipping_lines` gets its `openWorldHint` explicitly verified (in a separate case). Adding `expect(annotations?.openWorldHint, name).toBe(true)` to this loop for the non-catalog tools would close the gap, or excluding `get_supported_shipping_lines` from this array and asserting `openWorldHint: true` for the remaining eight here would make the intent clearer.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): annotate tools with readOnlyHi..."](https://github.com/terminal49/api/commit/4cabef2745f7734f9d16b54e5cb1e49fd665a590) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40061090)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->