### PR TITLE
Fix/publish sdk GitHub hosted runner

### DIFF
--- a/.github/workflows/publish_typescript_sdk.yml
+++ b/.github/workflows/publish_typescript_sdk.yml
@@ -16,14 +16,14 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ${{ (startsWith(vars.CI_RUNNER_SMALL, 'blacksmith-') && vars.CI_RUNNER_SMALL) || 'blacksmith-2vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Resolve release tag
         id: release-tag
         run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: useblacksmith/checkout@v1
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.release-tag.outputs.tag }}
 

--- a/.github/workflows/release_please_sdk.yml
+++ b/.github/workflows/release_please_sdk.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs['sdks/typescript-sdk--tag_name'] }}
-        run: gh workflow run publish_typescript_sdk.yml --ref main -f tag="$RELEASE_TAG"
+        run: gh workflow run publish_typescript_sdk.yml --repo "$GITHUB_REPOSITORY" --ref main -f tag="$RELEASE_TAG"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "sdks/typescript-sdk": "0.3.0"
+  "sdks/typescript-sdk": "0.3.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17366,7 +17366,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/node": "^10.55.0",
-        "@terminal49/sdk": "0.3.0",
+        "@terminal49/sdk": "0.3.1",
         "zod": "~4.3.6"
       },
       "devDependencies": {
@@ -17670,7 +17670,7 @@
     },
     "sdks/typescript-sdk": {
       "name": "@terminal49/sdk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "jsona": "^1.12.1",
         "openapi-fetch": "^0.15.2"
@@ -17688,7 +17688,7 @@
         "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "sdks/typescript-sdk/node_modules/@vitest/expect": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/node": "^10.55.0",
-    "@terminal49/sdk": "0.3.0",
+    "@terminal49/sdk": "0.3.1",
     "zod": "~4.3.6"
   },
   "devDependencies": {

--- a/sdks/typescript-sdk/CHANGELOG.md
+++ b/sdks/typescript-sdk/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `@terminal49/sdk` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1](https://github.com/Terminal49/API/compare/sdk-v-v0.3.0...sdk-v-v0.3.1) (2026-07-02)
+
+
+### Bug Fixes
+
+* **sdk:** correct JSON:API mapper relationship/attr paths + restore shipping-line capability flags ([#275](https://github.com/Terminal49/API/issues/275)) ([c7e748a](https://github.com/Terminal49/API/commit/c7e748a900844142b520de0c46ab9077e7585bb0))
+* **sdk:** request timeout, network-error normalization, idempotent-only retries, Retry-After, bounded iterate ([#274](https://github.com/Terminal49/API/issues/274)) ([e9ac7a8](https://github.com/Terminal49/API/commit/e9ac7a81aaa90e60a4190d60d8bfd4c6a1035484))
+* **sdk:** stop sending unsupported container/shipment filter keys + clamp page size + wire mapper includes ([#278](https://github.com/Terminal49/API/issues/278)) ([a019b5d](https://github.com/Terminal49/API/commit/a019b5da41124f35b39c9ae4107bc023ebd9ea2b))
+
 ## [0.3.0](https://github.com/Terminal49/API/compare/sdk-v-v0.2.0...sdk-v-v0.3.0) (2026-05-29)
 
 

--- a/sdks/typescript-sdk/package-lock.json
+++ b/sdks/typescript-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terminal49/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@terminal49/sdk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "jsona": "^1.12.1",
         "openapi-fetch": "^0.15.2"

--- a/sdks/typescript-sdk/package-lock.json
+++ b/sdks/typescript-sdk/package-lock.json
@@ -21,10 +21,10 @@
         "typedoc": "^0.28.19",
         "typedoc-plugin-markdown": "^4.11.0",
         "typescript": "^5.6.3",
-        "vitest": "^4.0.13"
+        "vitest": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/sdks/typescript-sdk/package.json
+++ b/sdks/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terminal49/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Terminal49 TypeScript SDK (JSON:API, openapi-fetch)",
   "type": "module",
   "repository": {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the TypeScript SDK publish pipeline by migrating the publish job from a Blacksmith self-hosted runner to a standard GitHub-hosted `ubuntu-24.04` runner and swapping `useblacksmith/checkout@v1` for `actions/checkout@v4`. It also adds `--repo "$GITHUB_REPOSITORY"` to the `gh workflow run` dispatch in the release-please workflow to ensure the correct repository is targeted.

- **Workflow runner migration** (`publish_typescript_sdk.yml`): Replaces Blacksmith runner and its custom checkout action with standard GitHub-hosted equivalents. The `npm publish` step does not explicitly set `NODE_AUTH_TOKEN`, which `actions/setup-node` requires when `registry-url` is configured; on Blacksmith this may have been machine-level but it will need to be wired via secrets on the GitHub-hosted runner.
- **Release dispatch fix** (`release_please_sdk.yml`): `--repo "$GITHUB_REPOSITORY"` is added to `gh workflow run`, making the dispatch repo-explicit and more robust.
- **SDK version bump to 0.3.1**: `engines.node` is raised from `>=18` to `>=20` in a patch release, which is technically a backward-incompatible change under semver.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The workflow runner migration is directionally correct, but the publish step is missing NODE_AUTH_TOKEN, which will likely cause npm publish to fail with an auth error on the new GitHub-hosted runner.

The npm publish step does not wire NODE_AUTH_TOKEN from secrets, yet actions/setup-node with registry-url depends on that variable to write valid npm credentials. On a Blacksmith runner the token may have been injected at the machine level; on GitHub-hosted it won't be, so the very thing this PR is trying to fix (publishing the SDK) would still fail. The engine-bump semver concern is minor by comparison.

`publish_typescript_sdk.yml` — specifically the Publish step at line 69 where NODE_AUTH_TOKEN needs to be explicitly passed from a repository secret.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish_typescript_sdk.yml | Migrates publish job from Blacksmith self-hosted runner to GitHub-hosted `ubuntu-24.04` and swaps `useblacksmith/checkout@v1` for `actions/checkout@v4`. The `npm publish` step still lacks an explicit `NODE_AUTH_TOKEN` env var, which `actions/setup-node` requires when `registry-url` is set. |
| .github/workflows/release_please_sdk.yml | Adds `--repo "$GITHUB_REPOSITORY"` to `gh workflow run`, ensuring the dispatch always targets the correct repo regardless of execution context. Still uses Blacksmith runner (consistent with its existing pattern, separate from the publish fix). |
| sdks/typescript-sdk/package.json | Bumps version to 0.3.1, updates `engines.node` from `>=18` to `>=20`, and upgrades vitest to `^4.1.0`. The engine bump drops Node 18 support, which is a backward-incompatible change being shipped as a patch release. |
| .release-please-manifest.json | Updates version manifest from 0.3.0 to 0.3.1, consistent with the SDK version bump. |
| packages/mcp/package.json | Updates `@terminal49/sdk` dependency from `0.3.0` to `0.3.1` to track the new SDK release. |
| sdks/typescript-sdk/CHANGELOG.md | Adds 0.3.1 changelog section listing three bug-fix PRs: JSON:API mapper paths, timeout/retry normalization, and filter key/page-size clamping. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub (push to main)
    participant RP as release_please_sdk.yml
    participant RPAction as release-please-action
    participant GHWorkflow as GitHub API
    participant PUB as publish_typescript_sdk.yml
    participant NPM as npmjs.org

    GH->>RP: "push to main (sdks/typescript-sdk/**)"
    RP->>RPAction: "googleapis/release-please-action@v5"
    RPAction-->>RP: "release_created=true, tag_name=sdk-v-v0.3.1"
    RP->>GHWorkflow: "gh workflow run publish_typescript_sdk.yml --repo GITHUB_REPOSITORY --ref main -f tag=sdk-v-v0.3.1"
    GHWorkflow->>PUB: trigger workflow_dispatch
    PUB->>PUB: "Checkout @ tag (actions/checkout@v4)"
    PUB->>PUB: "Setup Node 24 (actions/setup-node@v6)"
    PUB->>PUB: Verify tag matches SDK version
    PUB->>PUB: npm ci + npm run build + npm test
    PUB->>NPM: npm publish --access public (requires NODE_AUTH_TOKEN)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub (push to main)
    participant RP as release_please_sdk.yml
    participant RPAction as release-please-action
    participant GHWorkflow as GitHub API
    participant PUB as publish_typescript_sdk.yml
    participant NPM as npmjs.org

    GH->>RP: "push to main (sdks/typescript-sdk/**)"
    RP->>RPAction: "googleapis/release-please-action@v5"
    RPAction-->>RP: "release_created=true, tag_name=sdk-v-v0.3.1"
    RP->>GHWorkflow: "gh workflow run publish_typescript_sdk.yml --repo GITHUB_REPOSITORY --ref main -f tag=sdk-v-v0.3.1"
    GHWorkflow->>PUB: trigger workflow_dispatch
    PUB->>PUB: "Checkout @ tag (actions/checkout@v4)"
    PUB->>PUB: "Setup Node 24 (actions/setup-node@v6)"
    PUB->>PUB: Verify tag matches SDK version
    PUB->>PUB: npm ci + npm run build + npm test
    PUB->>NPM: npm publish --access public (requires NODE_AUTH_TOKEN)
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/publish_typescript_sdk.yml`, line 69-72 ([link](https://github.com/terminal49/api/blob/2f589f7b6b51bdb24835a48f28796d58b13875e7/.github/workflows/publish_typescript_sdk.yml#L69-L72)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `NODE_AUTH_TOKEN` on publish step**

   `actions/setup-node` with `registry-url` writes an `.npmrc` that resolves the auth token from `${NODE_AUTH_TOKEN}` at publish time. Without an explicit `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on this step, `npm publish` will exit with a 401/ENEEDAUTH error on the GitHub-hosted runner. On a self-hosted Blacksmith runner this may have been pre-configured at the machine level, so the move to GitHub-hosted exposes this gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/publish_typescript_sdk.yml
   Line: 69-72

   Comment:
   **Missing `NODE_AUTH_TOKEN` on publish step**

   `actions/setup-node` with `registry-url` writes an `.npmrc` that resolves the auth token from `${NODE_AUTH_TOKEN}` at publish time. Without an explicit `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on this step, `npm publish` will exit with a 401/ENEEDAUTH error on the GitHub-hosted runner. On a self-hosted Blacksmith runner this may have been pre-configured at the machine level, so the move to GitHub-hosted exposes this gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish_typescript_sdk.yml%0ALine%3A%2069-72%0A%0AComment%3A%0A**Missing%20%60NODE_AUTH_TOKEN%60%20on%20publish%20step**%0A%0A%60actions%2Fsetup-node%60%20with%20%60registry-url%60%20writes%20an%20%60.npmrc%60%20that%20resolves%20the%20auth%20token%20from%20%60%24%7BNODE_AUTH_TOKEN%7D%60%20at%20publish%20time.%20Without%20an%20explicit%20%60env%3A%20NODE_AUTH_TOKEN%3A%20%24%7B%7B%20secrets.NPM_TOKEN%20%7D%7D%60%20on%20this%20step%2C%20%60npm%20publish%60%20will%20exit%20with%20a%20401%2FENEEDAUTH%20error%20on%20the%20GitHub-hosted%20runner.%20On%20a%20self-hosted%20Blacksmith%20runner%20this%20may%20have%20been%20pre-configured%20at%20the%20machine%20level%2C%20so%20the%20move%20to%20GitHub-hosted%20exposes%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=terminal49%2Fapi&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>


2. `sdks/typescript-sdk/package.json`, line 42-44 ([link](https://github.com/terminal49/api/blob/2f589f7b6b51bdb24835a48f28796d58b13875e7/sdks/typescript-sdk/package.json#L42-L44)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Engine bump shipped as a patch release**

   Requiring `>=20` (up from `>=18`) drops Node 18 support, which is a backward-incompatible change. Under semver this should be a minor or major version bump, not `0.3.0 → 0.3.1`. Any consumer still running Node 18 in CI will see npm engine warnings or failures from a release they expect to be safe to adopt without changes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdks/typescript-sdk/package.json
   Line: 42-44

   Comment:
   **Engine bump shipped as a patch release**

   Requiring `>=20` (up from `>=18`) drops Node 18 support, which is a backward-incompatible change. Under semver this should be a minor or major version bump, not `0.3.0 → 0.3.1`. Any consumer still running Node 18 in CI will see npm engine warnings or failures from a release they expect to be safe to adopt without changes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20sdks%2Ftypescript-sdk%2Fpackage.json%0ALine%3A%2042-44%0A%0AComment%3A%0A**Engine%20bump%20shipped%20as%20a%20patch%20release**%0A%0ARequiring%20%60%3E%3D20%60%20%28up%20from%20%60%3E%3D18%60%29%20drops%20Node%2018%20support%2C%20which%20is%20a%20backward-incompatible%20change.%20Under%20semver%20this%20should%20be%20a%20minor%20or%20major%20version%20bump%2C%20not%20%600.3.0%20%E2%86%92%200.3.1%60.%20Any%20consumer%20still%20running%20Node%2018%20in%20CI%20will%20see%20npm%20engine%20warnings%20or%20failures%20from%20a%20release%20they%20expect%20to%20be%20safe%20to%20adopt%20without%20changes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=terminal49%2Fapi&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-sdk-github-hosted-runner%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish_typescript_sdk.yml%3A69-72%0A**Missing%20%60NODE_AUTH_TOKEN%60%20on%20publish%20step**%0A%0A%60actions%2Fsetup-node%60%20with%20%60registry-url%60%20writes%20an%20%60.npmrc%60%20that%20resolves%20the%20auth%20token%20from%20%60%24%7BNODE_AUTH_TOKEN%7D%60%20at%20publish%20time.%20Without%20an%20explicit%20%60env%3A%20NODE_AUTH_TOKEN%3A%20%24%7B%7B%20secrets.NPM_TOKEN%20%7D%7D%60%20on%20this%20step%2C%20%60npm%20publish%60%20will%20exit%20with%20a%20401%2FENEEDAUTH%20error%20on%20the%20GitHub-hosted%20runner.%20On%20a%20self-hosted%20Blacksmith%20runner%20this%20may%20have%20been%20pre-configured%20at%20the%20machine%20level%2C%20so%20the%20move%20to%20GitHub-hosted%20exposes%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Asdks%2Ftypescript-sdk%2Fpackage.json%3A42-44%0A**Engine%20bump%20shipped%20as%20a%20patch%20release**%0A%0ARequiring%20%60%3E%3D20%60%20%28up%20from%20%60%3E%3D18%60%29%20drops%20Node%2018%20support%2C%20which%20is%20a%20backward-incompatible%20change.%20Under%20semver%20this%20should%20be%20a%20minor%20or%20major%20version%20bump%2C%20not%20%600.3.0%20%E2%86%92%200.3.1%60.%20Any%20consumer%20still%20running%20Node%2018%20in%20CI%20will%20see%20npm%20engine%20warnings%20or%20failures%20from%20a%20release%20they%20expect%20to%20be%20safe%20to%20adopt%20without%20changes.%0A%0A&repo=terminal49%2Fapi&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/publish_typescript_sdk.yml:69-72
**Missing `NODE_AUTH_TOKEN` on publish step**

`actions/setup-node` with `registry-url` writes an `.npmrc` that resolves the auth token from `${NODE_AUTH_TOKEN}` at publish time. Without an explicit `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on this step, `npm publish` will exit with a 401/ENEEDAUTH error on the GitHub-hosted runner. On a self-hosted Blacksmith runner this may have been pre-configured at the machine level, so the move to GitHub-hosted exposes this gap.

### Issue 2 of 2
sdks/typescript-sdk/package.json:42-44
**Engine bump shipped as a patch release**

Requiring `>=20` (up from `>=18`) drops Node 18 support, which is a backward-incompatible change. Under semver this should be a minor or major version bump, not `0.3.0 → 0.3.1`. Any consumer still running Node 18 in CI will see npm engine warnings or failures from a release they expect to be safe to adopt without changes.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: publish sdk on github-hosted runner"](https://github.com/terminal49/api/commit/2f589f7b6b51bdb24835a48f28796d58b13875e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41520786)</sub>

<!-- /greptile_comment -->