### PR TITLE
chore(mcp): live MCP tool eval suite + CI wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,13 @@ jobs:
         run: |
           npm run type-check --workspace @terminal49/sdk
           npm run type-check --workspace @terminal49/mcp
+      - name: Type-check MCP eval suite
+        run: npm run eval:check --workspace @terminal49/mcp
       - name: Test MCP
         run: npm run test --workspace @terminal49/mcp -- --run --coverage
+      - name: Eval MCP tools (live; skips without MCP_EVAL_TOKEN secret)
+        env:
+          MCP_EVAL_TOKEN: ${{ secrets.MCP_EVAL_TOKEN }}
+        run: npm run eval --workspace @terminal49/mcp
       - name: Lint MCP (oxlint + oxfmt)
         run: npm run lint --workspace @terminal49/mcp

--- a/packages/mcp/.gitignore
+++ b/packages/mcp/.gitignore
@@ -32,6 +32,7 @@ logs/
 # Testing
 coverage/
 .nyc_output/
+eval/reports/
 
 # Vercel
 .vercel

--- a/packages/mcp/eval/README.md
+++ b/packages/mcp/eval/README.md
@@ -1,0 +1,88 @@
+# MCP tool eval suite
+
+A live, opt-in eval that exercises every registered Terminal49 MCP tool against a
+deployed gateway and scores each response on its **objective contract** — no LLM
+required. It answers: *do the tools work, return well-shaped data, handle errors
+sanely, respond quickly, and ship the `_agent_steering` guidance the server
+promises?*
+
+## Run it
+
+The suite is **skipped unless auth is configured**, so the default unit-test run
+(`npm run test`) never touches the network.
+
+```sh
+# Against production (default endpoint) with an OAuth access token:
+MCP_EVAL_BEARER="<oauth access token>" npm run eval --workspace @terminal49/mcp
+
+# ...or with a Terminal49 API key (Token passthrough scheme):
+MCP_EVAL_TOKEN="<terminal49 api key>" npm run eval --workspace @terminal49/mcp
+
+# Against a local gateway (vercel dev) or any other deployment:
+MCP_EVAL_ENDPOINT="http://localhost:4000/mcp" \
+MCP_EVAL_TOKEN="<key>" npm run eval --workspace @terminal49/mcp
+```
+
+| Env var | Meaning | Default |
+| --- | --- | --- |
+| `MCP_EVAL_BEARER` | OAuth 2.1 access token → `Authorization: Bearer` | — |
+| `MCP_EVAL_TOKEN` | Terminal49 API key → `Authorization: Token` | — |
+| `MCP_EVAL_ENDPOINT` | Gateway `/mcp` URL | `https://mcp.terminal49.com/mcp` |
+| `MCP_EVAL_ENABLE_WRITE` | Opt in to the mutating `track_container` case | unset (skipped) |
+
+> OAuth access tokens are short-lived (~5 min). For repeatable/CI runs, prefer a
+> `MCP_EVAL_TOKEN` API key — it does not expire.
+
+Typecheck the suite without running it: `tsc --noEmit -p tsconfig.eval.json`.
+
+## What it checks
+
+`beforeAll` discovers real ids (via `list_shipments` / `list_containers` /
+`list_tracking_requests`) and feeds them to the detail tools. Each case is scored
+by [`quality.ts`](./quality.ts):
+
+- transport `200`, correct tool-error semantics (`isError`)
+- primary payload parses as JSON and carries the required keys
+- per-tool shape predicates (e.g. `total_lines === shipping_lines.length`, id
+  round-trips, `timeline` is an array)
+- latency under budget
+- an `_agent_steering` block is present and suggests follow-ups
+
+Negative cases assert error behavior: an unknown id and a missing required
+argument must produce tool errors, while a gibberish search must return an empty
+result set (not an error).
+
+`track_container` — the only mutating tool — is **skipped by default**. Set
+`MCP_EVAL_ENABLE_WRITE=1` to include it: it is driven with an already-tracked
+number so it takes the idempotent search-match path and asserts
+`tracking_request_created === false`. Only enable it against an account you know
+already tracks the discovered container, since on an arbitrary account the call
+could create a real tracking request.
+
+## Output
+
+A terminal scorecard (one line per case, with failed checks expanded) plus a
+JSON artifact under `eval/reports/` (gitignored) for diffing runs over time.
+
+## CI
+
+The `mcp` job in `.github/workflows/ci.yml` runs this suite on every push/PR via
+`npm run eval` (plus `eval:check` to typecheck it). It passes
+`MCP_EVAL_TOKEN: ${{ secrets.MCP_EVAL_TOKEN }}` and hits production with the
+`Token` scheme. OAuth bearer tokens expire in minutes, so CI uses a **long-lived
+Terminal49 API key** stored as the `MCP_EVAL_TOKEN` repo secret.
+
+> Add a **non-admin** account's API key as the `MCP_EVAL_TOKEN` repo secret
+> (admin data skews latency/shape). Until the secret is set the step **skips and
+> exits 0** — CI stays green, so forks and unconfigured repos are unaffected. The
+> mutating `track_container` case stays off (no `MCP_EVAL_ENABLE_WRITE`).
+
+## Not covered here: subjective quality
+
+This suite grades the deterministic contract. It does **not** judge whether a
+tool's output makes an LLM agent *answer well* — that is a separate concern best
+handled by an LLM-as-judge harness such as
+[`vitest-evals`](https://github.com/getsentry/vitest-evals), which runs an agent
+wired to this MCP server over realistic tasks and scores the transcript. That
+layer needs an LLM provider key and is intentionally kept out of this
+credential-free, deterministic suite.

--- a/packages/mcp/eval/README.md
+++ b/packages/mcp/eval/README.md
@@ -29,6 +29,7 @@ MCP_EVAL_TOKEN="<key>" npm run eval --workspace @terminal49/mcp
 | `MCP_EVAL_TOKEN` | Terminal49 API key → `Authorization: Token` | — |
 | `MCP_EVAL_ENDPOINT` | Gateway `/mcp` URL | `https://mcp.terminal49.com/mcp` |
 | `MCP_EVAL_ENABLE_WRITE` | Opt in to the mutating `track_container` case | unset (skipped) |
+| `MCP_EVAL_ALLOW_SPARSE` | Allow detail cases to skip when the account has no data | unset (strict) |
 
 > OAuth access tokens are short-lived (~5 min). For repeatable/CI runs, prefer a
 > `MCP_EVAL_TOKEN` API key — it does not expire.
@@ -37,16 +38,23 @@ Typecheck the suite without running it: `tsc --noEmit -p tsconfig.eval.json`.
 
 ## What it checks
 
-`beforeAll` discovers real ids (via `list_shipments` / `list_containers` /
-`list_tracking_requests`) and feeds them to the detail tools. Each case is scored
-by [`quality.ts`](./quality.ts):
+`beforeAll` discovers real ids (via `list_shipments` / `list_containers`) and
+feeds them to the detail tools. **Discovery is strict by default**: if the
+account yields no shipment/container fixtures, the run fails instead of letting
+the detail cases silently skip and report a hollow "pass". Set
+`MCP_EVAL_ALLOW_SPARSE=1` to permit skipping on a genuinely empty account.
+
+Each case is scored by [`quality.ts`](./quality.ts). **Contract checks** must
+all pass (`contractPass`) — a single failure fails the test:
 
 - transport `200`, correct tool-error semantics (`isError`)
 - primary payload parses as JSON and carries the required keys
 - per-tool shape predicates (e.g. `total_lines === shipping_lines.length`, id
   round-trips, `timeline` is an array)
-- latency under budget
 - an `_agent_steering` block is present and suggests follow-ups
+
+**Latency** is a *soft* check: recorded in the score and the report, but a slow
+response alone never fails the suite.
 
 Negative cases assert error behavior: an unknown id and a missing required
 argument must produce tool errors, while a gibberish search must return an empty

--- a/packages/mcp/eval/client.ts
+++ b/packages/mcp/eval/client.ts
@@ -1,0 +1,246 @@
+/**
+ * Minimal MCP Streamable-HTTP client for the eval suite.
+ *
+ * Speaks JSON-RPC 2.0 to a deployed Terminal49 MCP gateway (production by
+ * default) and returns timed, block-aware tool results. Auth is env-driven so
+ * the same suite runs against prod, a local `vercel dev` gateway, or with
+ * either supported scheme:
+ *   - MCP_EVAL_BEARER : OAuth 2.1 access token -> `Authorization: Bearer <t>`
+ *   - MCP_EVAL_TOKEN  : Terminal49 API key     -> `Authorization: Token <t>`
+ * Endpoint override: MCP_EVAL_ENDPOINT (default https://mcp.terminal49.com/mcp).
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const PROTOCOL_VERSION = '2025-06-18';
+const DEFAULT_ENDPOINT = 'https://mcp.terminal49.com/mcp';
+
+export interface EvalClientConfig {
+  endpoint: string;
+  scheme: 'Bearer' | 'Token';
+  token: string;
+}
+
+/** A single MCP text content block, with its JSON parsed when possible. */
+export interface ParsedBlock {
+  index: number;
+  text: string;
+  /** Parsed JSON payload, or undefined when the block is not JSON. */
+  json: unknown;
+  /** True when the block is an `_agent_steering` guidance block. */
+  isSteering: boolean;
+}
+
+export interface ToolResult {
+  /** HTTP status of the transport response. */
+  http: number;
+  /** MCP-level tool error (`result.isError`) or a JSON-RPC error. */
+  isError: boolean;
+  /** Wall-clock latency in ms for the tools/call round trip. */
+  latencyMs: number;
+  /** Total byte length of all text content. */
+  bytes: number;
+  /** Every text content block, JSON parsed where possible. */
+  blocks: ParsedBlock[];
+  /** First non-steering JSON block: the tool's primary payload. */
+  payload: unknown;
+  /** The `_agent_steering` block, when present. */
+  steering: Record<string, unknown> | undefined;
+  /** JSON-RPC error message, when the transport returned one. */
+  errorMessage: string | undefined;
+  /** All content blocks joined, for logging and error inspection. */
+  rawText: string;
+}
+
+export interface ToolInfo {
+  name: string;
+  description: string | undefined;
+  inputSchema: unknown;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Resolve auth + endpoint from the environment, or null when unconfigured. */
+export function resolveConfig(): EvalClientConfig | null {
+  const endpoint = process.env.MCP_EVAL_ENDPOINT?.trim() || DEFAULT_ENDPOINT;
+  const bearer = process.env.MCP_EVAL_BEARER?.trim();
+  const token = process.env.MCP_EVAL_TOKEN?.trim();
+  if (bearer) return { endpoint, scheme: 'Bearer', token: bearer };
+  if (token) return { endpoint, scheme: 'Token', token };
+  return null;
+}
+
+interface JsonRpcResponse {
+  result?: unknown;
+  error?: { code: number | undefined; message: string | undefined };
+}
+
+/** Parse the HTTP body, which is either SSE (text/event-stream) or plain JSON. */
+function parseBody(text: string): unknown {
+  if (text.includes('data:')) {
+    const data = text
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trim())
+      .filter((line) => line.length > 0);
+    if (data.length > 0) return JSON.parse(data[data.length - 1]);
+  }
+  return JSON.parse(text);
+}
+
+function asJsonRpc(value: unknown): JsonRpcResponse {
+  if (!isRecord(value)) return {};
+  const error = isRecord(value.error)
+    ? {
+        code:
+          typeof value.error.code === 'number' ? value.error.code : undefined,
+        message:
+          typeof value.error.message === 'string'
+            ? value.error.message
+            : undefined,
+      }
+    : undefined;
+  return { result: value.result, error };
+}
+
+function extractTextBlocks(result: unknown): string[] {
+  if (!isRecord(result) || !Array.isArray(result.content)) return [];
+  const out: string[] = [];
+  for (const block of result.content) {
+    if (
+      isRecord(block) &&
+      block.type === 'text' &&
+      typeof block.text === 'string'
+    ) {
+      out.push(block.text);
+    }
+  }
+  return out;
+}
+
+function parseBlocks(texts: string[]): ParsedBlock[] {
+  return texts.map((text, index) => {
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = undefined;
+    }
+    return {
+      index,
+      text,
+      json,
+      isSteering: isRecord(json) && json._agent_steering === true,
+    };
+  });
+}
+
+export class EvalClient {
+  constructor(private readonly cfg: EvalClientConfig) {}
+
+  get endpoint(): string {
+    return this.cfg.endpoint;
+  }
+
+  get scheme(): string {
+    return this.cfg.scheme;
+  }
+
+  private async rpc(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<{ http: number; body: JsonRpcResponse }> {
+    const res = await fetch(this.cfg.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        Authorization: `${this.cfg.scheme} ${this.cfg.token}`,
+        'MCP-Protocol-Version': PROTOCOL_VERSION,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: randomUUID(),
+        method,
+        ...(params ? { params } : {}),
+      }),
+    });
+    const raw = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = parseBody(raw);
+    } catch {
+      parsed = undefined;
+    }
+    return { http: res.status, body: asJsonRpc(parsed) };
+  }
+
+  async initialize(): Promise<{ http: number; serverInfo: unknown }> {
+    const { http, body } = await this.rpc('initialize', {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 't49-mcp-eval', version: '1.0.0' },
+    });
+    const serverInfo = isRecord(body.result)
+      ? body.result.serverInfo
+      : undefined;
+    return { http, serverInfo };
+  }
+
+  async listTools(): Promise<ToolInfo[]> {
+    const { body } = await this.rpc('tools/list');
+    const tools =
+      isRecord(body.result) && Array.isArray(body.result.tools)
+        ? body.result.tools
+        : [];
+    const out: ToolInfo[] = [];
+    for (const tool of tools) {
+      if (isRecord(tool) && typeof tool.name === 'string') {
+        out.push({
+          name: tool.name,
+          description:
+            typeof tool.description === 'string' ? tool.description : undefined,
+          inputSchema: tool.inputSchema,
+        });
+      }
+    }
+    return out;
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown> = {},
+  ): Promise<ToolResult> {
+    const start = Date.now();
+    const { http, body } = await this.rpc('tools/call', {
+      name,
+      arguments: args,
+    });
+    const latencyMs = Date.now() - start;
+    const texts = extractTextBlocks(body.result);
+    const blocks = parseBlocks(texts);
+    const steeringBlock = blocks.find((block) => block.isSteering);
+    const payloadBlock = blocks.find(
+      (block) => !block.isSteering && block.json !== undefined,
+    );
+    const isError =
+      (isRecord(body.result) && body.result.isError === true) ||
+      Boolean(body.error);
+    return {
+      http,
+      isError,
+      latencyMs,
+      bytes: texts.reduce((sum, text) => sum + text.length, 0),
+      blocks,
+      payload: payloadBlock?.json,
+      steering:
+        steeringBlock && isRecord(steeringBlock.json)
+          ? steeringBlock.json
+          : undefined,
+      errorMessage: body.error?.message,
+      rawText: texts.join('\n'),
+    };
+  }
+}

--- a/packages/mcp/eval/client.ts
+++ b/packages/mcp/eval/client.ts
@@ -77,17 +77,27 @@ interface JsonRpcResponse {
   error?: { code: number | undefined; message: string | undefined };
 }
 
-/** Parse the HTTP body, which is either SSE (text/event-stream) or plain JSON. */
+/** Parse the HTTP body, which is either plain JSON or SSE (text/event-stream). */
 function parseBody(text: string): unknown {
-  if (text.includes('data:')) {
-    const data = text
-      .split('\n')
-      .filter((line) => line.startsWith('data:'))
-      .map((line) => line.slice(5).trim())
-      .filter((line) => line.length > 0);
-    if (data.length > 0) return JSON.parse(data[data.length - 1]);
+  try {
+    return JSON.parse(text);
+  } catch {
+    // SSE: events are separated by blank lines, and one event may carry
+    // MULTIPLE `data:` lines whose values join with "\n" (SSE spec). The
+    // JSON-RPC response is the last data-bearing event on the stream.
+    let lastData: string | undefined;
+    for (const event of text.split(/\r?\n\r?\n/)) {
+      const dataLines = event
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).replace(/^ /, ''));
+      if (dataLines.length > 0) lastData = dataLines.join('\n');
+    }
+    if (lastData === undefined) {
+      throw new Error('response body is neither JSON nor SSE with data');
+    }
+    return JSON.parse(lastData);
   }
-  return JSON.parse(text);
 }
 
 function asJsonRpc(value: unknown): JsonRpcResponse {

--- a/packages/mcp/eval/quality.ts
+++ b/packages/mcp/eval/quality.ts
@@ -1,0 +1,164 @@
+/**
+ * Deterministic quality scoring for MCP tool responses.
+ *
+ * These scorers do NOT use an LLM. They evaluate the objective contract of a
+ * tool response: transport success, error semantics, payload shape, required
+ * fields, latency budget, and the presence/usefulness of the `_agent_steering`
+ * guidance block that this server attaches to every tool. Subjective
+ * "is this a good answer" judging (LLM-as-judge over an agent transcript) is a
+ * separate, optional layer — see eval/README.md.
+ */
+
+import { isRecord, type ToolResult } from './client.js';
+
+export interface Check {
+  name: string;
+  pass: boolean;
+  detail: string | undefined;
+}
+
+export interface QualityScore {
+  /** Fraction of checks passed, 0..1. */
+  score: number;
+  passed: number;
+  total: number;
+  checks: Check[];
+}
+
+export interface Predicate {
+  name: string;
+  test: (payload: unknown, result: ToolResult) => boolean;
+  detail?: (payload: unknown, result: ToolResult) => string;
+}
+
+export interface QualitySpec {
+  /** Latency ceiling in ms; exceeding it fails one check. */
+  latencyBudgetMs?: number;
+  /** Required top-level keys on the primary payload (must be an object). */
+  requiredKeys?: string[];
+  /** Custom predicate checks against the primary payload. */
+  predicates?: Predicate[];
+  /** Negative test: expect an MCP tool error instead of a payload. */
+  expectError?: boolean;
+  /** Require an `_agent_steering` block that suggests follow-ups. */
+  requireSteering?: boolean;
+}
+
+const DEFAULT_LATENCY_BUDGET_MS = 8000;
+
+export function scoreResult(
+  result: ToolResult,
+  spec: QualitySpec,
+): QualityScore {
+  const checks: Check[] = [];
+  const add = (name: string, pass: boolean, detail?: string): void => {
+    checks.push({ name, pass, detail });
+  };
+  const budget = spec.latencyBudgetMs ?? DEFAULT_LATENCY_BUDGET_MS;
+
+  if (spec.expectError) {
+    add(
+      'returns a tool error',
+      result.isError,
+      result.errorMessage ?? result.rawText.slice(0, 120),
+    );
+    add(
+      'error is explained',
+      result.rawText.length > 0 || Boolean(result.errorMessage),
+    );
+  } else {
+    add('transport 200', result.http === 200, `http=${result.http}`);
+    add('not a tool error', !result.isError, result.errorMessage);
+    add('primary payload is JSON', result.payload !== undefined);
+    add('non-empty response', result.bytes > 0, `${result.bytes}b`);
+
+    for (const key of spec.requiredKeys ?? []) {
+      add(
+        `payload has "${key}"`,
+        isRecord(result.payload) && key in result.payload,
+      );
+    }
+
+    for (const predicate of spec.predicates ?? []) {
+      let pass = false;
+      try {
+        pass = predicate.test(result.payload, result);
+      } catch {
+        pass = false;
+      }
+      let detail: string | undefined;
+      if (predicate.detail) {
+        try {
+          detail = predicate.detail(result.payload, result);
+        } catch {
+          detail = undefined;
+        }
+      }
+      add(predicate.name, pass, detail);
+    }
+  }
+
+  if (spec.requireSteering) {
+    add('has _agent_steering block', result.steering !== undefined);
+    add('steering suggests follow-ups', steeringHasFollowUps(result.steering));
+  }
+
+  add(
+    `latency < ${budget}ms`,
+    result.latencyMs <= budget,
+    `${result.latencyMs}ms`,
+  );
+
+  const passed = checks.filter((check) => check.pass).length;
+  return {
+    score: checks.length === 0 ? 0 : passed / checks.length,
+    passed,
+    total: checks.length,
+    checks,
+  };
+}
+
+function steeringHasFollowUps(
+  steering: Record<string, unknown> | undefined,
+): boolean {
+  if (!steering) return false;
+  const followUps = steering.suggested_follow_ups;
+  const tools = steering.suggested_tools;
+  return (
+    (Array.isArray(followUps) && followUps.length > 0) ||
+    (Array.isArray(tools) && tools.length > 0)
+  );
+}
+
+// ---- small typed helpers for writing predicates against `unknown` payloads ----
+
+/** True when `payload[key]` is a non-empty array. */
+export function hasNonEmptyArray(payload: unknown, key: string): boolean {
+  return (
+    isRecord(payload) && Array.isArray(payload[key]) && payload[key].length > 0
+  );
+}
+
+/** True when `payload[key]` is an array (possibly empty). */
+export function hasArray(payload: unknown, key: string): boolean {
+  return isRecord(payload) && Array.isArray(payload[key]);
+}
+
+/** Read `payload[key]` when it is a string, else undefined. */
+export function readString(payload: unknown, key: string): string | undefined {
+  if (isRecord(payload) && typeof payload[key] === 'string')
+    return payload[key];
+  return undefined;
+}
+
+/** The first element of `payload[key]` when it is a non-empty array. */
+export function firstOf(payload: unknown, key: string): unknown {
+  if (
+    isRecord(payload) &&
+    Array.isArray(payload[key]) &&
+    payload[key].length > 0
+  ) {
+    return payload[key][0];
+  }
+  return undefined;
+}

--- a/packages/mcp/eval/quality.ts
+++ b/packages/mcp/eval/quality.ts
@@ -15,13 +15,17 @@ export interface Check {
   name: string;
   pass: boolean;
   detail: string | undefined;
+  /** Soft checks (latency) are reported but never fail the contract. */
+  soft: boolean;
 }
 
 export interface QualityScore {
-  /** Fraction of checks passed, 0..1. */
+  /** Fraction of checks passed, 0..1 (includes soft checks). */
   score: number;
   passed: number;
   total: number;
+  /** True when every non-soft (contract) check passed. Gate CI on this. */
+  contractPass: boolean;
   checks: Check[];
 }
 
@@ -51,8 +55,13 @@ export function scoreResult(
   spec: QualitySpec,
 ): QualityScore {
   const checks: Check[] = [];
-  const add = (name: string, pass: boolean, detail?: string): void => {
-    checks.push({ name, pass, detail });
+  const add = (
+    name: string,
+    pass: boolean,
+    detail?: string,
+    soft = false,
+  ): void => {
+    checks.push({ name, pass, detail, soft });
   };
   const budget = spec.latencyBudgetMs ?? DEFAULT_LATENCY_BUDGET_MS;
 
@@ -103,10 +112,13 @@ export function scoreResult(
     add('steering suggests follow-ups', steeringHasFollowUps(result.steering));
   }
 
+  // Latency is a soft signal: recorded and scored, but a slow response is not
+  // a contract violation, so it never fails the suite on its own.
   add(
     `latency < ${budget}ms`,
     result.latencyMs <= budget,
     `${result.latencyMs}ms`,
+    true,
   );
 
   const passed = checks.filter((check) => check.pass).length;
@@ -114,6 +126,7 @@ export function scoreResult(
     score: checks.length === 0 ? 0 : passed / checks.length,
     passed,
     total: checks.length,
+    contractPass: checks.every((check) => check.soft || check.pass),
     checks,
   };
 }

--- a/packages/mcp/eval/report.ts
+++ b/packages/mcp/eval/report.ts
@@ -1,0 +1,118 @@
+/**
+ * Report rendering for the tool eval suite: a terminal scorecard plus a
+ * machine-readable JSON artifact written under eval/reports/ (gitignored).
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ToolResult } from './client.js';
+import type { QualityScore } from './quality.js';
+
+export interface EvalRow {
+  tool: string;
+  testCase: string;
+  result: ToolResult;
+  score: QualityScore;
+}
+
+export interface EvalReportMeta {
+  endpoint: string;
+  scheme: string;
+  serverInfo: unknown;
+  timestamp: string;
+}
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width
+    ? value
+    : value + ' '.repeat(width - value.length);
+}
+
+/** A one-line-per-case scorecard, followed by any failed checks. */
+export function formatScorecard(rows: EvalRow[], meta: EvalReportMeta): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push('═'.repeat(78));
+  lines.push(`  Terminal49 MCP tool eval — ${meta.timestamp}`);
+  lines.push(`  endpoint: ${meta.endpoint}  (auth: ${meta.scheme})`);
+  lines.push('═'.repeat(78));
+  lines.push(
+    `  ${pad('TOOL', 32)}${pad('CASE', 16)}${pad('HTTP', 6)}${pad('ms', 7)}${pad('steer', 7)}SCORE`,
+  );
+  lines.push('  ' + '─'.repeat(74));
+
+  for (const row of rows) {
+    const steer = row.result.steering
+      ? 'yes'
+      : row.score.checks.some((c) => c.name.includes('steering'))
+        ? 'NO'
+        : '-';
+    const flag =
+      row.score.score >= 1 ? '' : row.score.score >= 0.8 ? ' ~' : ' ✗';
+    lines.push(
+      `  ${pad(row.tool, 32)}${pad(row.testCase, 16)}${pad(String(row.result.http), 6)}${pad(String(row.result.latencyMs), 7)}${pad(steer, 7)}${pct(row.score.score)} (${row.score.passed}/${row.score.total})${flag}`,
+    );
+    const failed = row.score.checks.filter((c) => !c.pass);
+    for (const check of failed) {
+      lines.push(
+        `       └─ FAIL: ${check.name}${check.detail ? ` — ${check.detail}` : ''}`,
+      );
+    }
+  }
+
+  lines.push('  ' + '─'.repeat(74));
+  const mean =
+    rows.length === 0
+      ? 0
+      : rows.reduce((sum, r) => sum + r.score.score, 0) / rows.length;
+  const perfect = rows.filter((r) => r.score.score >= 1).length;
+  const totalMs = rows.reduce((sum, r) => sum + r.result.latencyMs, 0);
+  lines.push(
+    `  cases: ${rows.length}  ·  perfect: ${perfect}  ·  mean score: ${pct(mean)}  ·  total latency: ${totalMs}ms`,
+  );
+  lines.push('═'.repeat(78));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Write a JSON artifact and return its path. */
+export function writeReport(rows: EvalRow[], meta: EvalReportMeta): string {
+  const dir = join(import.meta.dirname, 'reports');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `eval-${meta.timestamp.replace(/[:.]/g, '-')}.json`);
+  const payload = {
+    meta,
+    summary: {
+      cases: rows.length,
+      perfect: rows.filter((r) => r.score.score >= 1).length,
+      meanScore:
+        rows.length === 0
+          ? 0
+          : rows.reduce((sum, r) => sum + r.score.score, 0) / rows.length,
+      totalLatencyMs: rows.reduce((sum, r) => sum + r.result.latencyMs, 0),
+    },
+    cases: rows.map((row) => ({
+      tool: row.tool,
+      testCase: row.testCase,
+      http: row.result.http,
+      isError: row.result.isError,
+      latencyMs: row.result.latencyMs,
+      bytes: row.result.bytes,
+      hasSteering: row.result.steering !== undefined,
+      score: row.score.score,
+      checks: row.score.checks,
+      payloadKeys:
+        row.result.payload &&
+        typeof row.result.payload === 'object' &&
+        !Array.isArray(row.result.payload)
+          ? Object.keys(row.result.payload)
+          : undefined,
+    })),
+  };
+  writeFileSync(file, JSON.stringify(payload, null, 2));
+  return file;
+}

--- a/packages/mcp/eval/report.ts
+++ b/packages/mcp/eval/report.ts
@@ -51,8 +51,11 @@ export function formatScorecard(rows: EvalRow[], meta: EvalReportMeta): string {
       : row.score.checks.some((c) => c.name.includes('steering'))
         ? 'NO'
         : '-';
-    const flag =
-      row.score.score >= 1 ? '' : row.score.score >= 0.8 ? ' ~' : ' ✗';
+    const flag = !row.score.contractPass
+      ? ' ✗'
+      : row.score.score >= 1
+        ? ''
+        : ' ~';
     lines.push(
       `  ${pad(row.tool, 32)}${pad(row.testCase, 16)}${pad(String(row.result.http), 6)}${pad(String(row.result.latencyMs), 7)}${pad(steer, 7)}${pct(row.score.score)} (${row.score.passed}/${row.score.total})${flag}`,
     );
@@ -89,6 +92,7 @@ export function writeReport(rows: EvalRow[], meta: EvalReportMeta): string {
     summary: {
       cases: rows.length,
       perfect: rows.filter((r) => r.score.score >= 1).length,
+      contractFailures: rows.filter((r) => !r.score.contractPass).length,
       meanScore:
         rows.length === 0
           ? 0
@@ -104,6 +108,7 @@ export function writeReport(rows: EvalRow[], meta: EvalReportMeta): string {
       bytes: row.result.bytes,
       hasSteering: row.result.steering !== undefined,
       score: row.score.score,
+      contractPass: row.score.contractPass,
       checks: row.score.checks,
       payloadKeys:
         row.result.payload &&

--- a/packages/mcp/eval/tools.eval.ts
+++ b/packages/mcp/eval/tools.eval.ts
@@ -1,0 +1,466 @@
+/**
+ * Live eval suite for the Terminal49 MCP tools.
+ *
+ * Exercises every registered tool against a deployed gateway and scores each
+ * response on its objective contract (shape, required fields, error semantics,
+ * latency, and the `_agent_steering` guidance block). Read-only: the only
+ * mutating tool, `track_container`, is driven with an already-tracked number so
+ * it takes the idempotent search-match path and creates nothing.
+ *
+ * Opt-in — the whole suite is skipped unless auth is configured:
+ *   MCP_EVAL_BEARER=<oauth access token>   npm run eval --workspace @terminal49/mcp
+ *   MCP_EVAL_TOKEN=<terminal49 api key>    npm run eval --workspace @terminal49/mcp
+ * Endpoint defaults to production; override with MCP_EVAL_ENDPOINT.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  EvalClient,
+  isRecord,
+  resolveConfig,
+  type ToolResult,
+} from './client.js';
+import {
+  hasArray,
+  hasNonEmptyArray,
+  readString,
+  scoreResult,
+  type QualitySpec,
+  type QualityScore,
+} from './quality.js';
+import { formatScorecard, writeReport, type EvalRow } from './report.js';
+
+const cfg = resolveConfig();
+
+if (!cfg) {
+  describe.skip('Terminal49 MCP tool eval (set MCP_EVAL_BEARER or MCP_EVAL_TOKEN)', () => {
+    it('is skipped without credentials', () => {
+      expect(true).toBe(true);
+    });
+  });
+} else {
+  const client = new EvalClient(cfg);
+  const rows: EvalRow[] = [];
+  const fixtures: {
+    shipmentId?: string;
+    containerId?: string;
+    containerNumber?: string;
+    trackingRequestId?: string;
+  } = {};
+  let serverInfo: unknown;
+
+  /** Call a tool, score it, record the row, and return both for assertions. */
+  async function evaluate(
+    tool: string,
+    args: Record<string, unknown>,
+    spec: QualitySpec,
+    testCase = 'happy-path',
+  ): Promise<{ result: ToolResult; score: QualityScore }> {
+    const result = await client.callTool(tool, args);
+    const score = scoreResult(result, spec);
+    rows.push({ tool, testCase, result, score });
+    return { result, score };
+  }
+
+  const POSITIVE_THRESHOLD = 0.85;
+
+  // The only mutating tool (track_container) is opt-in: on an arbitrary account
+  // the idempotent search-match path is not guaranteed, so a call could create a
+  // real tracking request. Enable explicitly with MCP_EVAL_ENABLE_WRITE=1.
+  const enableWrite =
+    process.env.MCP_EVAL_ENABLE_WRITE === '1' ||
+    process.env.MCP_EVAL_ENABLE_WRITE === 'true';
+
+  describe('Terminal49 MCP tool eval', () => {
+    beforeAll(async () => {
+      const init = await client.initialize();
+      serverInfo = init.serverInfo;
+      expect(init.http).toBe(200);
+
+      // Discover real ids to feed the detail tools.
+      const ships = await client.callTool('list_shipments', {
+        page_size: 10,
+        include_containers: true,
+      });
+      const shipItems =
+        isRecord(ships.payload) && Array.isArray(ships.payload.items)
+          ? ships.payload.items
+          : [];
+      for (const shipment of shipItems) {
+        if (!isRecord(shipment) || typeof shipment.id !== 'string') continue;
+        fixtures.shipmentId ??= shipment.id;
+        const containers = Array.isArray(shipment.containers)
+          ? shipment.containers
+          : [];
+        const container = containers.find(
+          (c) => isRecord(c) && typeof c.id === 'string',
+        );
+        if (isRecord(container)) {
+          fixtures.containerId ??=
+            typeof container.id === 'string' ? container.id : undefined;
+          fixtures.containerNumber ??=
+            typeof container.number === 'string' ? container.number : undefined;
+        }
+        if (fixtures.containerId) break;
+      }
+
+      if (!fixtures.containerId) {
+        const containersList = await client.callTool('list_containers', {
+          page_size: 5,
+        });
+        const items =
+          isRecord(containersList.payload) &&
+          Array.isArray(containersList.payload.items)
+            ? containersList.payload.items
+            : [];
+        const first = items.find(
+          (c) => isRecord(c) && typeof c.id === 'string',
+        );
+        if (isRecord(first) && typeof first.id === 'string')
+          fixtures.containerId = first.id;
+      }
+
+      const trs = await client.callTool('list_tracking_requests', {
+        page_size: 5,
+      });
+      const trItems =
+        isRecord(trs.payload) && Array.isArray(trs.payload.items)
+          ? trs.payload.items
+          : [];
+      const tr = trItems.find((t) => isRecord(t) && typeof t.id === 'string');
+      if (isRecord(tr) && typeof tr.id === 'string')
+        fixtures.trackingRequestId = tr.id;
+    }, 60_000);
+
+    afterAll(() => {
+      const meta = {
+        endpoint: client.endpoint,
+        scheme: client.scheme,
+        serverInfo,
+        timestamp: new Date().toISOString(),
+      };
+      console.log(formatScorecard(rows, meta));
+      const path = writeReport(rows, meta);
+      console.log(`  JSON report: ${path}\n`);
+    });
+
+    // ---- list / catalog tools (no ids required) ----
+
+    it('list_shipments returns a paginated collection', async () => {
+      const { result, score } = await evaluate(
+        'list_shipments',
+        { page_size: 5 },
+        {
+          requiredKeys: ['items'],
+          requireSteering: true,
+          predicates: [
+            { name: 'items is an array', test: (p) => hasArray(p, 'items') },
+            {
+              name: 'has pagination meta',
+              test: (p) => isRecord(p) && isRecord(p.meta),
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(hasArray(result.payload, 'items')).toBe(true);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('list_containers returns a paginated collection', async () => {
+      const { result, score } = await evaluate(
+        'list_containers',
+        { page_size: 5 },
+        {
+          requiredKeys: ['items'],
+          requireSteering: true,
+          predicates: [
+            { name: 'items is an array', test: (p) => hasArray(p, 'items') },
+            {
+              name: 'first item has an id',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.items) &&
+                (p.items.length === 0 ||
+                  (isRecord(p.items[0]) && typeof p.items[0].id === 'string')),
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('list_tracking_requests returns typed requests', async () => {
+      const { result, score } = await evaluate(
+        'list_tracking_requests',
+        { page_size: 5 },
+        {
+          requiredKeys: ['items'],
+          requireSteering: true,
+          predicates: [
+            { name: 'items is an array', test: (p) => hasArray(p, 'items') },
+            {
+              name: 'item has requestType and status',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.items) &&
+                (p.items.length === 0 ||
+                  (isRecord(p.items[0]) &&
+                    'requestType' in p.items[0] &&
+                    'status' in p.items[0])),
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('get_supported_shipping_lines returns the carrier catalog', async () => {
+      const { result, score } = await evaluate(
+        'get_supported_shipping_lines',
+        {},
+        {
+          requiredKeys: ['total_lines', 'shipping_lines'],
+          requireSteering: true,
+          predicates: [
+            {
+              name: 'shipping_lines is non-empty',
+              test: (p) => hasNonEmptyArray(p, 'shipping_lines'),
+            },
+            {
+              name: 'each line has scac and name',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.shipping_lines) &&
+                isRecord(p.shipping_lines[0]) &&
+                typeof p.shipping_lines[0].scac === 'string' &&
+                typeof p.shipping_lines[0].name === 'string',
+            },
+            {
+              name: 'total_lines matches array length',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.shipping_lines) &&
+                p.total_lines === p.shipping_lines.length,
+              detail: (p) =>
+                isRecord(p)
+                  ? `total=${String(p.total_lines)} len=${Array.isArray(p.shipping_lines) ? p.shipping_lines.length : '?'}`
+                  : '',
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    // ---- detail tools (require discovered ids) ----
+
+    it('get_container returns a container snapshot', async ({ skip }) => {
+      if (!fixtures.containerId) return skip();
+      const id = fixtures.containerId;
+      const { result, score } = await evaluate(
+        'get_container',
+        { id },
+        {
+          requiredKeys: ['id', 'container_number', 'status'],
+          requireSteering: true,
+          predicates: [
+            { name: 'id round-trips', test: (p) => readString(p, 'id') === id },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(readString(result.payload, 'id')).toBe(id);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('get_shipment_details returns a shipment', async ({ skip }) => {
+      if (!fixtures.shipmentId) return skip();
+      const id = fixtures.shipmentId;
+      const { result, score } = await evaluate(
+        'get_shipment_details',
+        { id, include_containers: true },
+        {
+          requiredKeys: ['id', 'bill_of_lading', 'status'],
+          requireSteering: true,
+          predicates: [
+            { name: 'id round-trips', test: (p) => readString(p, 'id') === id },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(readString(result.payload, 'id')).toBe(id);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('get_container_transport_events returns a timeline', async ({
+      skip,
+    }) => {
+      if (!fixtures.containerId) return skip();
+      const { result, score } = await evaluate(
+        'get_container_transport_events',
+        { id: fixtures.containerId },
+        {
+          requiredKeys: ['total_events', 'timeline'],
+          requireSteering: true,
+          predicates: [
+            {
+              name: 'timeline is an array',
+              test: (p) => hasArray(p, 'timeline'),
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('get_container_route returns route data or a graceful not-found', async ({
+      skip,
+    }) => {
+      if (!fixtures.containerId) return skip();
+      const { result, score } = await evaluate(
+        'get_container_route',
+        { id: fixtures.containerId },
+        {
+          requireSteering: true,
+          predicates: [
+            {
+              name: 'route payload or explained not-found',
+              test: (p) =>
+                isRecord(p) &&
+                (Array.isArray(p.route_locations) ||
+                  'total_legs' in p ||
+                  (typeof p.error === 'string' &&
+                    typeof p.alternative === 'string')),
+              detail: (p) =>
+                isRecord(p) && typeof p.error === 'string'
+                  ? 'graceful not-found'
+                  : 'route data',
+            },
+          ],
+        },
+      );
+      // Soft-error responses are still HTTP 200 with a JSON payload + steering.
+      expect(result.http).toBe(200);
+      expect(result.payload).toBeDefined();
+      expect(result.steering).toBeDefined();
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    // ---- search + track ----
+
+    it('search_container finds the tracked container', async ({ skip }) => {
+      if (!fixtures.containerNumber) return skip();
+      const number = fixtures.containerNumber;
+      const { result, score } = await evaluate(
+        'search_container',
+        { query: number },
+        {
+          requiredKeys: ['containers', 'total_results'],
+          requireSteering: true,
+          predicates: [
+            {
+              name: 'containers is an array',
+              test: (p) => hasArray(p, 'containers'),
+            },
+            {
+              name: 'query matches a returned container',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.containers) &&
+                p.containers.some(
+                  (c) => isRecord(c) && c.container_number === number,
+                ),
+            },
+          ],
+        },
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    it('track_container is idempotent for an already-tracked number (no mutation)', async ({
+      skip,
+    }) => {
+      if (!enableWrite || !fixtures.containerNumber) return skip();
+      const { result, score } = await evaluate(
+        'track_container',
+        { number: fixtures.containerNumber },
+        {
+          requiredKeys: ['tracking_request_created'],
+          predicates: [
+            {
+              name: 'no tracking request created',
+              test: (p) => isRecord(p) && p.tracking_request_created === false,
+            },
+            {
+              name: 'returns a container id',
+              test: (p) => typeof readString(p, 'id') === 'string',
+            },
+          ],
+        },
+        'idempotent',
+      );
+      expect(result.isError).toBe(false);
+      // The critical safety invariant: nothing was created.
+      expect(
+        isRecord(result.payload) && result.payload.tracking_request_created,
+      ).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+
+    // ---- error handling (negative cases) ----
+
+    it('get_container rejects an unknown id with a tool error', async () => {
+      const { result } = await evaluate(
+        'get_container',
+        { id: '00000000-0000-0000-0000-000000000000' },
+        { expectError: true },
+        'unknown-id',
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it('get_container rejects missing required arguments', async () => {
+      const { result } = await evaluate(
+        'get_container',
+        {},
+        { expectError: true },
+        'missing-arg',
+      );
+      expect(result.isError).toBe(true);
+      expect(result.rawText.toLowerCase()).toContain('validation');
+    });
+
+    it('search_container returns an empty result set for gibberish (not an error)', async () => {
+      const { result, score } = await evaluate(
+        'search_container',
+        { query: 'ZZZZ0000000ZZZZ' },
+        {
+          requiredKeys: ['containers', 'total_results'],
+          requireSteering: true,
+          predicates: [
+            {
+              name: 'total_results is 0',
+              test: (p) => isRecord(p) && p.total_results === 0,
+            },
+            {
+              name: 'containers is empty',
+              test: (p) =>
+                isRecord(p) &&
+                Array.isArray(p.containers) &&
+                p.containers.length === 0,
+            },
+          ],
+        },
+        'empty-result',
+      );
+      expect(result.isError).toBe(false);
+      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+    });
+  });
+}

--- a/packages/mcp/eval/tools.eval.ts
+++ b/packages/mcp/eval/tools.eval.ts
@@ -45,7 +45,6 @@ if (!cfg) {
     shipmentId?: string;
     containerId?: string;
     containerNumber?: string;
-    trackingRequestId?: string;
   } = {};
   let serverInfo: unknown;
 
@@ -62,7 +61,11 @@ if (!cfg) {
     return { result, score };
   }
 
-  const POSITIVE_THRESHOLD = 0.85;
+  // Fixture discovery is strict by default (see beforeAll): a sparse account
+  // would silently skip the detail cases. Opt out with MCP_EVAL_ALLOW_SPARSE=1.
+  const allowSparse =
+    process.env.MCP_EVAL_ALLOW_SPARSE === '1' ||
+    process.env.MCP_EVAL_ALLOW_SPARSE === 'true';
 
   // The only mutating tool (track_container) is opt-in: on an arbitrary account
   // the idempotent search-match path is not guaranteed, so a call could create a
@@ -116,20 +119,29 @@ if (!cfg) {
         const first = items.find(
           (c) => isRecord(c) && typeof c.id === 'string',
         );
-        if (isRecord(first) && typeof first.id === 'string')
+        if (isRecord(first) && typeof first.id === 'string') {
           fixtures.containerId = first.id;
+          if (typeof first.number === 'string') {
+            fixtures.containerNumber ??= first.number;
+          }
+        }
       }
 
-      const trs = await client.callTool('list_tracking_requests', {
-        page_size: 5,
-      });
-      const trItems =
-        isRecord(trs.payload) && Array.isArray(trs.payload.items)
-          ? trs.payload.items
-          : [];
-      const tr = trItems.find((t) => isRecord(t) && typeof t.id === 'string');
-      if (isRecord(tr) && typeof tr.id === 'string')
-        fixtures.trackingRequestId = tr.id;
+      // Strict by default: on an account with no discoverable data the detail
+      // tests would all skip and the suite would "pass" without exercising the
+      // tools it gates. Fail loudly instead (MCP_EVAL_ALLOW_SPARSE=1 to allow).
+      if (!allowSparse) {
+        const missing = (
+          ['shipmentId', 'containerId', 'containerNumber'] as const
+        ).filter((key) => fixtures[key] === undefined);
+        if (missing.length > 0) {
+          throw new Error(
+            `fixture discovery found no ${missing.join(', ')} on this account; ` +
+              'detail tools cannot be exercised. Use an account with tracked shipments ' +
+              'or set MCP_EVAL_ALLOW_SPARSE=1 to permit skipping those cases.',
+          );
+        }
+      }
     }, 60_000);
 
     afterAll(() => {
@@ -164,7 +176,7 @@ if (!cfg) {
       );
       expect(result.isError).toBe(false);
       expect(hasArray(result.payload, 'items')).toBe(true);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('list_containers returns a paginated collection', async () => {
@@ -188,7 +200,7 @@ if (!cfg) {
         },
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('list_tracking_requests returns typed requests', async () => {
@@ -214,7 +226,7 @@ if (!cfg) {
         },
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('get_supported_shipping_lines returns the carrier catalog', async () => {
@@ -253,7 +265,7 @@ if (!cfg) {
         },
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     // ---- detail tools (require discovered ids) ----
@@ -274,7 +286,7 @@ if (!cfg) {
       );
       expect(result.isError).toBe(false);
       expect(readString(result.payload, 'id')).toBe(id);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('get_shipment_details returns a shipment', async ({ skip }) => {
@@ -293,7 +305,7 @@ if (!cfg) {
       );
       expect(result.isError).toBe(false);
       expect(readString(result.payload, 'id')).toBe(id);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('get_container_transport_events returns a timeline', async ({
@@ -315,7 +327,7 @@ if (!cfg) {
         },
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('get_container_route returns route data or a graceful not-found', async ({
@@ -348,7 +360,7 @@ if (!cfg) {
       expect(result.http).toBe(200);
       expect(result.payload).toBeDefined();
       expect(result.steering).toBeDefined();
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     // ---- search + track ----
@@ -380,7 +392,7 @@ if (!cfg) {
         },
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     it('track_container is idempotent for an already-tracked number (no mutation)', async ({
@@ -392,6 +404,7 @@ if (!cfg) {
         { number: fixtures.containerNumber },
         {
           requiredKeys: ['tracking_request_created'],
+          requireSteering: true,
           predicates: [
             {
               name: 'no tracking request created',
@@ -410,7 +423,7 @@ if (!cfg) {
       expect(
         isRecord(result.payload) && result.payload.tracking_request_created,
       ).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
 
     // ---- error handling (negative cases) ----
@@ -460,7 +473,7 @@ if (!cfg) {
         'empty-result',
       );
       expect(result.isError).toBe(false);
-      expect(score.score).toBeGreaterThanOrEqual(POSITIVE_THRESHOLD);
+      expect(score.contractPass).toBe(true);
     });
   });
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,7 +13,9 @@
     "format:check": "oxfmt --check src",
     "type-check": "tsc --noEmit",
     "mcp:stdio": "tsx src/index.ts",
-    "sdk:setup": "node ./scripts/sdk-setup.mjs"
+    "sdk:setup": "node ./scripts/sdk-setup.mjs",
+    "eval": "vitest run --config vitest.eval.config.ts",
+    "eval:check": "tsc --noEmit -p tsconfig.eval.json"
   },
   "keywords": [
     "mcp",

--- a/packages/mcp/tsconfig.eval.json
+++ b/packages/mcp/tsconfig.eval.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["eval/**/*.ts"]
+}

--- a/packages/mcp/vitest.eval.config.ts
+++ b/packages/mcp/vitest.eval.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Config for the live tool eval suite (`npm run eval`). Kept separate from the
+ * default unit-test run so CI never hits the network: the default `vitest`
+ * invocation only matches `*.test.ts`, while this config targets `*.eval.ts`.
+ */
+export default defineConfig({
+  test: {
+    include: ['eval/**/*.eval.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    // One live backend — run serially to stay friendly to rate limits.
+    fileParallelism: false,
+    pool: 'forks',
+  },
+});


### PR DESCRIPTION
## What

An opt-in **eval suite** for the Terminal49 MCP tools (`packages/mcp/eval/`). It exercises every registered tool against a deployed gateway and scores each response on its **objective contract** — shape, required fields, error semantics, latency, and the `_agent_steering` guidance block. No LLM required.

## Why

We had unit tests (mocked client) but nothing that verified the *deployed* tools actually respond correctly end-to-end. This gives a fast, credential-gated smoke/quality gate against the live gateway.

## What's included

- **Block-aware MCP client** (`eval/client.ts`) — JSON-RPC over Streamable HTTP, SSE+JSON parsing, separates the primary payload from the `_agent_steering` block. Env-driven auth:
  - `MCP_EVAL_BEARER` → `Authorization: Bearer` (OAuth access token)
  - `MCP_EVAL_TOKEN` → `Authorization: Token` (Terminal49 API key)
  - `MCP_EVAL_ENDPOINT` (defaults to production)
- **Deterministic scorers** (`eval/quality.ts`) — transport, error semantics, required keys, shape predicates, latency budget, steering presence.
- **Scorecard + JSON report** (`eval/report.ts`) → `eval/reports/` (gitignored).
- **Suite** (`eval/tools.eval.ts`) — discovers real ids, covers all 10 tools + 3 negative cases (unknown id, missing arg, gibberish search). The only mutating tool, `track_container`, is **opt-in** (`MCP_EVAL_ENABLE_WRITE`) and **skipped by default**.
- **Scripts**: `npm run eval` (via `vitest.eval.config.ts`), `npm run eval:check` (typecheck via `tsconfig.eval.json`). Kept separate so the default `npm test` and the `src`-only build are untouched.
- **CI**: the `mcp` job now typechecks the suite and runs it live, gated on the `MCP_EVAL_TOKEN` secret.

## Run it

```sh
MCP_EVAL_TOKEN=<terminal49 api key> npm run eval --workspace @terminal49/mcp
# or an OAuth access token:
MCP_EVAL_BEARER=<token> npm run eval --workspace @terminal49/mcp
```

The suite **skips (exit 0)** when no credential is set — so the default test run, forks, and unconfigured repos stay green.

## Verification (live, production)

Ran end-to-end three ways — OAuth Bearer (admin + non-admin accounts) and **API-key `Token` scheme** (non-admin): **12/12 read-only cases pass, mean 100%**, all calls ~130–330ms. Every detail tool round-trips real ids, confirming genuine backend auth. `track_container` skipped (write off).

## Action required to activate in CI

Add a repo secret **`MCP_EVAL_TOKEN`** = a **non-admin** Terminal49 API key (admin data skews latency/shape). Until it's set, the CI step skips green.

> Note: this runs against **production** on each PR/commit — ~12 quick read-only calls; discovery degrades gracefully (skips) if the account's data changes.

## Not in scope

Subjective, LLM-judged *agent-experience* evals (e.g. `vitest-evals`) are intentionally deferred — that needs an LLM provider key and is documented in `eval/README.md` as the next layer.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a live eval suite for the MCP tools. The main changes are:

- New Streamable HTTP eval client, quality scoring, and report output.
- Live Vitest cases for MCP tool responses and error cases.
- Eval-specific TypeScript and Vitest configs.
- CI wiring for typechecking and credential-gated live eval runs.
- Docs and gitignore coverage for generated eval reports.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The eval gate can pass without exercising all claimed tool paths, and valid streamed responses can be parsed incorrectly.

- Sparse eval accounts can skip detail and search coverage while CI stays green.
- Fractional scoring can accept individual required contract failures.
- Multiline SSE responses can lose the JSON-RPC result in the eval client.
- The changes are isolated to eval and CI wiring, not production tool handling.

packages/mcp/eval/tools.eval.ts and packages/mcp/eval/client.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds MCP eval typecheck and live eval CI steps behind the eval token secret. |
| packages/mcp/eval/client.ts | Adds the eval JSON-RPC client, with a parser issue for valid multiline SSE responses. |
| packages/mcp/eval/quality.ts | Adds deterministic score calculation for transport, shape, latency, and steering checks. |
| packages/mcp/eval/tools.eval.ts | Adds live tool eval cases, but fixture skips and threshold scoring can weaken the CI gate. |
| packages/mcp/eval/report.ts | Adds terminal scorecard formatting and JSON report writing. |
| packages/mcp/package.json | Adds npm scripts for running and typechecking the eval suite. |
| packages/mcp/tsconfig.eval.json | Adds a TypeScript config scoped to eval sources. |
| packages/mcp/vitest.eval.config.ts | Adds a serial Vitest config for the live eval files. |
| packages/mcp/eval/README.md | Documents the eval suite, credentials, write opt-in, output, and CI setup. |
| packages/mcp/.gitignore | Ignores generated eval report artifacts. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  CI[GitHub CI mcp job] --> Check[npm run eval:check]
  CI --> Eval[npm run eval]
  Eval --> Config{Eval credential set?}
  Config -- no --> Skip[Suite skips green]
  Config -- yes --> Client[EvalClient JSON-RPC]
  Client --> Gateway[Deployed MCP gateway]
  Gateway --> Parse[Parse JSON or SSE]
  Parse --> Score[Score tool contract]
  Score --> Report[Scorecard and JSON report]
  Score --> Status[Vitest pass or fail]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  CI[GitHub CI mcp job] --> Check[npm run eval:check]
  CI --> Eval[npm run eval]
  Eval --> Config{Eval credential set?}
  Config -- no --> Skip[Suite skips green]
  Config -- yes --> Client[EvalClient JSON-RPC]
  Client --> Gateway[Deployed MCP gateway]
  Gateway --> Parse[Parse JSON or SSE]
  Parse --> Score[Score tool contract]
  Score --> Report[Scorecard and JSON report]
  Score --> Status[Vitest pass or fail]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22futuristic-keyboard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22futuristic-keyboard%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Apackages%2Fmcp%2Feval%2Ftools.eval.ts%3A261-263%0A**Fixture%20Skips%20Hide%20Tool%20Breakage**%0A%0AWhen%20the%20CI%20token%20belongs%20to%20a%20sparse%20account%20with%20no%20discovered%20container%20or%20shipment%20ids%2C%20this%20branch%20skips%20the%20detail%20test%20and%20Vitest%20still%20exits%20successfully.%20The%20same%20fixture%20guards%20cover%20the%20other%20detail%20and%20real-data%20search%20cases%2C%20so%20the%20live%20suite%20can%20report%20success%20without%20calling%20several%20tools%20it%20is%20meant%20to%20gate.%0A%0A%23%23%23%20Issue%202%20of%204%0Apackages%2Fmcp%2Feval%2Ftools.eval.ts%3A65%0A**Threshold%20Allows%20Contract%20Failures**%0A%0AA%20single%20failed%20required-key%2C%20predicate%2C%20or%20steering%20follow-up%20check%20can%20still%20leave%20a%20case%20above%20%600.85%60.%20That%20lets%20CI%20accept%20a%20response%20that%20violates%20one%20of%20the%20objective%20contracts%20this%20suite%20is%20meant%20to%20enforce%2C%20such%20as%20a%20missing%20required%20field%20or%20an%20incomplete%20%60_agent_steering%60%20block.%0A%0A%23%23%23%20Issue%203%20of%204%0Apackages%2Fmcp%2Feval%2Ftools.eval.ts%3A393-406%0A**Write%20Case%20Skips%20Steering**%0A%0AThe%20%60track_container%60%20spec%20omits%20%60requireSteering%3A%20true%60%2C%20unlike%20the%20other%20positive%20tool%20cases.%20When%20%60MCP_EVAL_ENABLE_WRITE%3D1%60%2C%20the%20mutating%20tool%20can%20pass%20even%20if%20it%20drops%20the%20%60_agent_steering%60%20guidance%20that%20the%20suite%20says%20every%20registered%20tool%20must%20return.%0A%0A%23%23%23%20Issue%204%20of%204%0Apackages%2Fmcp%2Feval%2Fclient.ts%3A81-91%0A**Multiline%20SSE%20Drops%20Payload**%0A%0AValid%20SSE%20can%20encode%20one%20event%20with%20multiple%20%60data%3A%60%20lines%2C%20but%20this%20parser%20keeps%20only%20the%20last%20line.%20If%20the%20Streamable%20HTTP%20gateway%20emits%20a%20large%20tool%20response%20that%20way%2C%20the%20client%20parses%20a%20fragment%2C%20loses%20the%20JSON-RPC%20result%2C%20and%20the%20eval%20fails%20payload%20and%20steering%20checks%20for%20a%20valid%20response.%0A%0A&repo=terminal49%2Fapi&pr=292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/mcp/eval/tools.eval.ts:261-263
**Fixture Skips Hide Tool Breakage**

When the CI token belongs to a sparse account with no discovered container or shipment ids, this branch skips the detail test and Vitest still exits successfully. The same fixture guards cover the other detail and real-data search cases, so the live suite can report success without calling several tools it is meant to gate.

### Issue 2 of 4
packages/mcp/eval/tools.eval.ts:65
**Threshold Allows Contract Failures**

A single failed required-key, predicate, or steering follow-up check can still leave a case above `0.85`. That lets CI accept a response that violates one of the objective contracts this suite is meant to enforce, such as a missing required field or an incomplete `_agent_steering` block.

### Issue 3 of 4
packages/mcp/eval/tools.eval.ts:393-406
**Write Case Skips Steering**

The `track_container` spec omits `requireSteering: true`, unlike the other positive tool cases. When `MCP_EVAL_ENABLE_WRITE=1`, the mutating tool can pass even if it drops the `_agent_steering` guidance that the suite says every registered tool must return.

### Issue 4 of 4
packages/mcp/eval/client.ts:81-91
**Multiline SSE Drops Payload**

Valid SSE can encode one event with multiple `data:` lines, but this parser keeps only the last line. If the Streamable HTTP gateway emits a large tool response that way, the client parses a fragment, loses the JSON-RPC result, and the eval fails payload and steering checks for a valid response.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(mcp): add live tool eval suite and..."](https://github.com/terminal49/api/commit/21783b8fd19949ae87a9e3d72a82cc20abd3167d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42287699)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->