### PR TITLE
[CHORE] add sample custom fields json payloads

### DIFF
--- a/docs/api-docs/api-reference/containers/create-container-custom-field.mdx
+++ b/docs/api-docs/api-reference/containers/create-container-custom-field.mdx
@@ -18,8 +18,11 @@ Creates or updates a custom field on a container. If a custom field with the spe
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `api_slug` | Yes | The slug of the custom field definition |
-| `value` | Yes | The value to set (type depends on the definition's data type) |
+| `data.type` | Yes | Must be `custom_field` |
+| `data.attributes.api_slug` | Yes | The slug of the custom field definition |
+| `data.attributes.value` | Yes | The value to set (type depends on the definition's data type) |
+
+The container is implied by the path, so do not send `data.relationships.entity` on this endpoint.
 
 ## Authorization
 
@@ -34,3 +37,47 @@ Returns `201 Created` with the custom field resource on success.
 - Uses `find_or_initialize_by` internally, so it creates if missing or updates if it exists
 - Values are validated against the definition's data type
 - For enum fields, values are validated against the definition's options
+
+## Example request
+
+```json
+{
+  "data": {
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124"
+    }
+  }
+}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "id": "YOUR_CUSTOM_FIELD_ID",
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124",
+      "display_value": "ABC124"
+    },
+    "relationships": {
+      "entity": {
+        "data": {
+          "id": "YOUR_CONTAINER_ID",
+          "type": "container"
+        }
+      },
+      "definition": {
+        "data": {
+          "id": "YOUR_DEFINITION_ID",
+          "type": "custom_field_definition"
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/api-docs/api-reference/custom-fields/create-a-custom-field.mdx
+++ b/docs/api-docs/api-reference/custom-fields/create-a-custom-field.mdx
@@ -6,15 +6,17 @@ og:description: Create a custom field value on a shipment or container using the
 openapi: post /custom_fields
 ---
 
-Use this endpoint to create a custom field value on a shipment or container. The field must reference an existing custom field definition.
+Use this endpoint to create a custom field value on a shipment or container when you need to send the full JSON:API relationship payload yourself. The field must reference an existing custom field definition.
 
 ## Request body
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `entity` | Yes | Polymorphic relationship to a Shipment or Container |
-| `api_slug` | Yes | The slug of the custom field definition |
-| `value` | Yes | The field value (must match the definition's data type) |
+| `data.type` | Yes | Must be `custom_field` |
+| `data.attributes.api_slug` | Yes | The slug of the custom field definition |
+| `data.attributes.value` | Yes | The field value (must match the definition's data type) |
+| `data.relationships.entity.data.type` | Yes | `shipment` or `container` |
+| `data.relationships.entity.data.id` | Yes | The shipment or container ID |
 
 ## Value formats by data type
 
@@ -35,3 +37,55 @@ Use this endpoint to create a custom field value on a shipment or container. The
 - Enum values must match one of the definition's configured options
 - Reference values must match the definition's configured `reference_type`
 - The `api_slug` must reference a definition belonging to your account or a Terminal49 template
+
+## Example request
+
+```json
+{
+  "data": {
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124"
+    },
+    "relationships": {
+      "entity": {
+        "data": {
+          "type": "shipment",
+          "id": "YOUR_SHIPMENT_ID"
+        }
+      }
+    }
+  }
+}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "id": "YOUR_CUSTOM_FIELD_ID",
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124",
+      "display_value": "ABC124"
+    },
+    "relationships": {
+      "entity": {
+        "data": {
+          "id": "YOUR_SHIPMENT_ID",
+          "type": "shipment"
+        }
+      },
+      "definition": {
+        "data": {
+          "id": "YOUR_DEFINITION_ID",
+          "type": "custom_field_definition"
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/api-docs/api-reference/shipments/create-shipment-custom-field.mdx
+++ b/docs/api-docs/api-reference/shipments/create-shipment-custom-field.mdx
@@ -18,8 +18,11 @@ Creates or updates a custom field on a shipment. If a custom field with the spec
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `api_slug` | Yes | The slug of the custom field definition |
-| `value` | Yes | The value to set (type depends on the definition's data type) |
+| `data.type` | Yes | Must be `custom_field` |
+| `data.attributes.api_slug` | Yes | The slug of the custom field definition |
+| `data.attributes.value` | Yes | The value to set (type depends on the definition's data type) |
+
+The shipment is implied by the path, so do not send `data.relationships.entity` on this endpoint.
 
 ## Authorization
 
@@ -34,3 +37,47 @@ Returns `201 Created` with the custom field resource on success.
 - Uses `find_or_initialize_by` internally, so it creates if missing or updates if it exists
 - Values are validated against the definition's data type
 - For enum fields, values are validated against the definition's options
+
+## Example request
+
+```json
+{
+  "data": {
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124"
+    }
+  }
+}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "id": "YOUR_CUSTOM_FIELD_ID",
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124",
+      "display_value": "ABC124"
+    },
+    "relationships": {
+      "entity": {
+        "data": {
+          "id": "YOUR_SHIPMENT_ID",
+          "type": "shipment"
+        }
+      },
+      "definition": {
+        "data": {
+          "id": "YOUR_DEFINITION_ID",
+          "type": "custom_field_definition"
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/api-docs/api-reference/tracking-requests/create-tracking-request-custom-field.mdx
+++ b/docs/api-docs/api-reference/tracking-requests/create-tracking-request-custom-field.mdx
@@ -18,8 +18,11 @@ Creates or updates a custom field on a tracking request. If a custom field with 
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `api_slug` | Yes | The slug of the custom field definition |
-| `value` | Yes | The value to set (type depends on the definition's data type) |
+| `data.type` | Yes | Must be `custom_field` |
+| `data.attributes.api_slug` | Yes | The slug of the custom field definition |
+| `data.attributes.value` | Yes | The value to set (type depends on the definition's data type) |
+
+The tracking request is implied by the path, so do not send `data.relationships.entity` on this endpoint.
 
 ## Authorization
 
@@ -34,3 +37,47 @@ Returns `201 Created` with the custom field resource on success.
 - Uses `find_or_initialize_by` internally, so it creates if missing or updates if it exists
 - Values are validated against the definition's data type
 - For enum fields, values are validated against the definition's options
+
+## Example request
+
+```json
+{
+  "data": {
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124"
+    }
+  }
+}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "id": "YOUR_CUSTOM_FIELD_ID",
+    "type": "custom_field",
+    "attributes": {
+      "api_slug": "customer_reference_number",
+      "value": "ABC124",
+      "display_value": "ABC124"
+    },
+    "relationships": {
+      "entity": {
+        "data": {
+          "id": "YOUR_TRACKING_REQUEST_ID",
+          "type": "tracking_request"
+        }
+      },
+      "definition": {
+        "data": {
+          "id": "YOUR_DEFINITION_ID",
+          "type": "custom_field_definition"
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds concrete JSON:API-shaped example request and response payloads to four custom-field documentation pages, and updates the request-body parameter tables to reflect the correct nested structure (`data.type`, `data.attributes.*`, `data.relationships.*`). It also adds a clarifying note on each path-based endpoint (shipments, containers, tracking requests) explaining that `data.relationships.entity` should be omitted because the entity is already implied by the URL.

- **Four docs pages updated**: `create-a-custom-field`, `create-shipment-custom-field`, `create-container-custom-field`, and `create-tracking-request-custom-field` — all now include matching example request/response blocks in valid JSON:API format.
- **Generic vs. path-based distinction clarified**: The generic `/custom_fields` page now explicitly notes it is for callers that need to send the full relationship payload, while the path-based pages note that the entity relationship must _not_ be sent.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure documentation update — no code, migrations, or API behavior changed; safe to merge.

All four files are .mdx documentation pages. The example payloads are structurally correct JSON:API, the parameter tables accurately reflect the nested structure, and the entity-implied notes are consistent across the three path-based endpoints. No logic, schema, or runtime behavior is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/api-docs/api-reference/custom-fields/create-a-custom-field.mdx | Updated request body params to JSON:API format and added example request/response payloads; also clarified this endpoint is for when a full relationship payload is needed. |
| docs/api-docs/api-reference/shipments/create-shipment-custom-field.mdx | Updated request body table to show JSON:API structure, added note that data.relationships.entity is not needed on this path-based endpoint, and added example payloads. |
| docs/api-docs/api-reference/containers/create-container-custom-field.mdx | Same pattern as shipment custom field: added JSON:API request body parameters, entity-implied note, and example payloads. |
| docs/api-docs/api-reference/tracking-requests/create-tracking-request-custom-field.mdx | Same pattern as the other entity-specific endpoints: added JSON:API request body table, path-implied entity note, and example payloads with correct tracking_request type in the response. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as Terminal49 API

    Note over Client,API: Option A — Path-based (entity implied)
    Client->>API: "POST /shipments/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Client->>API: "POST /containers/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Client->>API: "POST /tracking_requests/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Note over Client,API: Option B — Generic endpoint (full relationship required)
    Client->>API: POST /custom_fields with relationships.entity
    API-->>Client: 201 Created — custom_field resource
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as Terminal49 API

    Note over Client,API: Option A — Path-based (entity implied)
    Client->>API: "POST /shipments/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Client->>API: "POST /containers/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Client->>API: "POST /tracking_requests/{id}/custom_fields"
    API-->>Client: 201 Created — custom_field resource

    Note over Client,API: Option B — Generic endpoint (full relationship required)
    Client->>API: POST /custom_fields with relationships.entity
    API-->>Client: 201 Created — custom_field resource
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add sample custom fields json payloads"](https://github.com/terminal49/api/commit/fac3d5b1bf707dbb466742f0400147b984214272) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42804028)</sub>

<!-- /greptile_comment -->