### PR TITLE
docs: add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,24 @@ For substantive documentation writing, use the repo-local skill at `skills/termi
 
 - Never commit real API keys or secrets; use placeholders like `Token YOUR_API_KEY`.
 - The MCP gateway is public-facing — treat auth, the resource resolver, and the discovery endpoints as security-sensitive. Keep local credentials in your environment only.
+
+---
+
+## Cursor Cloud specific instructions
+
+Standard commands live in **Build and Development Commands** above; the notes below are the non-obvious gotchas for this environment. The startup update script already runs `npm ci` at the repo root.
+
+### Node version
+- The repo requires **Node 24** (`engines: 24.x`, `.tool-versions` pins `24.4.1`). The VM's baseline `node` on `PATH` (`/exec-daemon/node`) is **v22**; a login-shell hook selects nvm's Node 24, so **run commands from a login shell** (fresh terminals get Node 24). If `node -v` shows v22, run `nvm use 24` first — building/testing on v22 is untested here.
+
+### Products & how to run them (nothing here is a long-running backend — MCP/SDK are clients of the external Terminal49 API at `https://api.terminal49.com/v2`)
+- **SDK** (`@terminal49/sdk`): unit tests are fixture-based and need no network/token (`npm run test --workspace @terminal49/sdk -- --run`). `smoke`/`example` scripts hit the live API and need `T49_API_TOKEN`.
+- **MCP** (`@terminal49/mcp`): build then run the stdio server with `npm run mcp:stdio` (or `node packages/mcp/dist/index.js`). `initialize` + `tools/list` work **without** a token (see the quick-verification snippet in `packages/mcp/LOCAL_DEV.md`); a *successful* `tools/call` result needs a real `T49_API_TOKEN` (without one, tools return a generic Terminal49 error — the wiring still runs). The `api/` HTTP gateway (Path 2/3) additionally needs the Vercel CLI + a local backend and is optional.
+- **Docs** (`docs/`): see the mintlify gotcha below.
+
+### `mintlify dev` gotcha (docs preview)
+- Running `mintlify dev` / local `npx mintlify` **from inside this monorepo fails** — it reports `Unable to parse page metadata` for nearly every page and aborts with `Failed to parse MDX files`. The MDX/frontmatter is valid; the cause is the root `package.json` `overrides` (which pin `zod`/`express`/etc. inside `@mintlify/*` transitive deps) bleeding into the workspace-hoisted `mintlify` and breaking its parser.
+- **Workaround:** run an isolated mintlify install from the docs dir: `cd docs && npx -y mintlify@latest dev`. This serves all pages on `http://localhost:3000`. (Docs deploy via the hosted Mintlify Git integration and CI does not run the preview, so this only affects local preview.)
+
+### No local secrets by default
+- No `T49_API_TOKEN` is provisioned in the Cloud VM, so live SDK/MCP calls against the Terminal49 API can't be exercised without one (matches CI, where the live MCP eval skips without `MCP_EVAL_TOKEN`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this monorepo (docs, MCP server, TypeScript SDK) and records the non-obvious cloud gotchas in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section. No product code was changed.

## Environment setup
- **Node 24** installed via nvm (repo pins `24.x` / `.tool-versions` `24.4.1`; the VM baseline `node` is v22). A login-shell hook selects Node 24 for interactive terminals.
- Root deps installed with `npm ci` (npm workspaces monorepo).

## Verification (all green under Node 24)

| Product | Commands run | Result |
|---|---|---|
| SDK (`@terminal49/sdk`) | `build`, `test -- --run`, `lint` | build OK · 104 tests pass (1 skipped) · lint OK |
| MCP (`@terminal49/mcp`) | `build`, `test -- --run`, `lint` | build OK · 149 tests pass · lint OK |
| `api/` gateway | `npx tsc --noEmit -p tsconfig.json` | typecheck OK |
| Docs (`docs/`) | `npx -y mintlify@latest dev` | preview serves `/home`, `/api-docs/...`, `/sdk/...` (HTTP 200) |

## Hello-world actions
- **MCP stdio server** boots, completes the `initialize` handshake, and returns its real 10-tool catalog; invoking `get_supported_shipping_lines` runs end-to-end (returns the server's generic error since no live `T49_API_TOKEN` is provisioned).
- **Docs site** rendered and navigated in-browser (home → Getting Started → API reference).

[Docs home page](https://cursor.com/agents/bc-af6d67c3-ebd1-4edd-af06-2c92dac8ff55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_home_page.webp)
[Getting started page](https://cursor.com/agents/bc-af6d67c3-ebd1-4edd-af06-2c92dac8ff55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_getting_started.webp)
[API reference - List containers](https://cursor.com/agents/bc-af6d67c3-ebd1-4edd-af06-2c92dac8ff55/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_api_reference_list_containers.webp)

## Key gotcha documented
Running `mintlify dev` from inside the monorepo fails to parse page metadata for nearly every page (`Failed to parse MDX files`). The MDX is valid — the root `package.json` `overrides` (pinning `zod`/`express` inside `@mintlify/*` deps) break the hoisted mintlify's parser. Workaround: `cd docs && npx -y mintlify@latest dev` (isolated install). Docs deploy via hosted Mintlify and CI does not run the preview, so this only affects local preview.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af6d67c3-ebd1-4edd-af06-2c92dac8ff55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af6d67c3-ebd1-4edd-af06-2c92dac8ff55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788138126&installation_model_id=18852&pr_number=311&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F311&signature=c0284ef40e3a9bcade185b04b8e4372f741343ec08b90e5d2a683187d7fadc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Cursor Cloud setup and verification guidance to `AGENTS.md`, documenting the required Node version, workspace commands, local service prerequisites, and a Mintlify preview workaround.
- Documents Node 24 selection and root dependency installation.
- Adds SDK, MCP, and documentation-site verification commands.
- Records token availability and local-preview limitations.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation-only PR is safe to merge, though its token-free MCP verification instructions should be corrected.

The stdio server exits before initialization when `T49_API_TOKEN` is unset, while the new instructions say initialization and tool listing work without a token.

**Files Needing Attention:** AGENTS.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds Cursor Cloud development instructions, but incorrectly says the MCP stdio server can initialize without setting `T49_API_TOKEN`. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fsetup-dev-environment-ff55%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fsetup-dev-environment-ff55%22.%0A%0AGreploop%20terminal49%2Fapi%20PR%20%23311%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=terminal49%2Fapi&pr=311&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fsetup-dev-environment-ff55%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fsetup-dev-environment-ff55%22.%0A%0A%23%23%23%20Issue%201%0AAGENTS.md%3A107%0A**Token-free%20MCP%20startup%20is%20misstated**%0A%0AStarting%20the%20documented%20stdio%20server%20without%20%60T49_API_TOKEN%60%20exits%20before%20%60initialize%60%2C%20%60tools%2Flist%60%2C%20or%20%60tools%2Fcall%60%20can%20run%3B%20token-free%20verification%20requires%20setting%20a%20placeholder%20such%20as%20%60T49_API_TOKEN%3Dsmoke%60%2C%20while%20successful%20API%20calls%20require%20a%20real%20token.%0A%0A%60%60%60suggestion%0A-%20**MCP**%20%28%60%40terminal49%2Fmcp%60%29%3A%20build%20then%20run%20the%20stdio%20server%20with%20%60npm%20run%20mcp%3Astdio%60%20%28or%20%60node%20packages%2Fmcp%2Fdist%2Findex.js%60%29.%20The%20server%20requires%20%60T49_API_TOKEN%60%20to%20be%20set%20before%20it%20starts%3B%20a%20placeholder%20such%20as%20%60T49_API_TOKEN%3Dsmoke%60%20is%20sufficient%20for%20%60initialize%60%20%2B%20%60tools%2Flist%60%20%28see%20the%20quick-verification%20snippet%20in%20%60packages%2Fmcp%2FLOCAL_DEV.md%60%29%2C%20while%20a%20*successful*%20%60tools%2Fcall%60%20result%20needs%20a%20real%20token.%20The%20%60api%2F%60%20HTTP%20gateway%20%28Path%202%2F3%29%20additionally%20needs%20the%20Vercel%20CLI%20%2B%20a%20local%20backend%20and%20is%20optional.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AAGENTS.md%3A107%0A**Token-free%20MCP%20startup%20is%20misstated**%0A%0AStarting%20the%20documented%20stdio%20server%20without%20%60T49_API_TOKEN%60%20exits%20before%20%60initialize%60%2C%20%60tools%2Flist%60%2C%20or%20%60tools%2Fcall%60%20can%20run%3B%20token-free%20verification%20requires%20setting%20a%20placeholder%20such%20as%20%60T49_API_TOKEN%3Dsmoke%60%2C%20while%20successful%20API%20calls%20require%20a%20real%20token.%0A%0A%60%60%60suggestion%0A-%20**MCP**%20%28%60%40terminal49%2Fmcp%60%29%3A%20build%20then%20run%20the%20stdio%20server%20with%20%60npm%20run%20mcp%3Astdio%60%20%28or%20%60node%20packages%2Fmcp%2Fdist%2Findex.js%60%29.%20The%20server%20requires%20%60T49_API_TOKEN%60%20to%20be%20set%20before%20it%20starts%3B%20a%20placeholder%20such%20as%20%60T49_API_TOKEN%3Dsmoke%60%20is%20sufficient%20for%20%60initialize%60%20%2B%20%60tools%2Flist%60%20%28see%20the%20quick-verification%20snippet%20in%20%60packages%2Fmcp%2FLOCAL_DEV.md%60%29%2C%20while%20a%20*successful*%20%60tools%2Fcall%60%20result%20needs%20a%20real%20token.%20The%20%60api%2F%60%20HTTP%20gateway%20%28Path%202%2F3%29%20additionally%20needs%20the%20Vercel%20CLI%20%2B%20a%20local%20backend%20and%20is%20optional.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
AGENTS.md:107
**Token-free MCP startup is misstated**

Starting the documented stdio server without `T49_API_TOKEN` exits before `initialize`, `tools/list`, or `tools/call` can run; token-free verification requires setting a placeholder such as `T49_API_TOKEN=smoke`, while successful API calls require a real token.

```suggestion
- **MCP** (`@terminal49/mcp`): build then run the stdio server with `npm run mcp:stdio` (or `node packages/mcp/dist/index.js`). The server requires `T49_API_TOKEN` to be set before it starts; a placeholder such as `T49_API_TOKEN=smoke` is sufficient for `initialize` + `tools/list` (see the quick-verification snippet in `packages/mcp/LOCAL_DEV.md`), while a *successful* `tools/call` result needs a real token. The `api/` HTTP gateway (Path 2/3) additionally needs the Vercel CLI + a local backend and is optional.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Cursor Cloud specific setup in..."](https://github.com/terminal49/api/commit/07172b85201dc29405936780770a4231415dd262) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53220163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->