### PR TITLE
docs: document line hold type

### DIFF
--- a/docs/api-docs/in-depth-guides/holds-and-fees.mdx
+++ b/docs/api-docs/in-depth-guides/holds-and-fees.mdx
@@ -106,6 +106,7 @@ When a hold is cleared, the object is removed from the array entirely. There is 
 | Hold name | Description | Who resolves it |
 |-----------|-------------|-----------------|
 | `freight` | Carrier freight charges unpaid | Shipping line or freight forwarder |
+| `line` | Carrier or steamship-line release pending | Shipping line |
 | `customs` | CBP hold — docs, exam, or inspection | Licensed customs broker |
 | `USDA` | USDA phytosanitary inspection | Customs broker or USDA compliance team |
 | `VACIS` | Non-intrusive X-ray / gamma-ray scan | Customs broker |
@@ -113,7 +114,7 @@ When a hold is cleared, the object is removed from the array entirely. There is 
 | `other` | Unmapped hold — check `description` | Terminal or broker |
 
 <Note>
-Hold names are case-sensitive. `USDA`, `VACIS`, and `TMF` are uppercase. `freight`, `customs`, and `other` are lowercase. Match values exactly in your code.
+Hold names are case-sensitive. `USDA`, `VACIS`, and `TMF` are uppercase. `freight`, `line`, `customs`, and `other` are lowercase. Match values exactly in your code.
 </Note>
 
 <AccordionGroup>
@@ -129,6 +130,20 @@ Hold names are case-sensitive. `USDA`, `VACIS`, and `TMF` are uppercase. `freigh
     ```
 
     **Who resolves it:** Contact the shipping line or your freight forwarder to confirm payment status.
+  </Accordion>
+
+  <Accordion title="line — Carrier release pending">
+    The terminal has not received or confirmed the ocean carrier's release for the container. Terminals may describe this as a line hold, bill of lading hold, carrier hold, or steamship-line release pending. This is distinct from a `freight` hold and does not by itself indicate unpaid freight charges.
+
+    ```json
+    {
+      "name": "line",
+      "status": "hold",
+      "description": "LINE HOLD"
+    }
+    ```
+
+    **Who resolves it:** Contact the shipping line to confirm that it has issued the container or bill of lading release to the terminal.
   </Accordion>
 
   <Accordion title="customs — CBP hold">


### PR DESCRIPTION
## Summary
- add `line` to the canonical terminal hold types
- distinguish carrier-release holds from unpaid freight-charge holds
- document the expected value, terminal descriptions, and resolver

## Validation
- `git diff --check`
- `npx mintlify validate` scanned the edited page without reporting an error; the repository-wide command remains red on pre-existing generated API reference pages with invalid metadata

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788563996&installation_model_id=18852&pr_number=314&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F314&signature=3db520af2f9e7a16946502b944db0f4ed88e4c918d7bb7d540d1357fd54eaa73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->