### PR TITLE
Add Gnosis Freight migration guide and update existing migration docs

### DIFF
--- a/docs/api-docs/useful-info/entitlements.mdx
+++ b/docs/api-docs/useful-info/entitlements.mdx
@@ -22,6 +22,7 @@ Some Terminal49 features require account enablement beyond standard API access.
 | MCP `get_container_route` tool | Routing Data | Contact sales@terminal49.com | The tool returns a feature-not-enabled response; use `get_container_transport_events` for historical milestones |
 | Terminal49 Map Embed | Publishable map API key | Contact support@terminal49.com | The browser embed cannot authenticate without a valid publishable key |
 | Tracking Widget Embed | Publishable widget API key | Contact support@terminal49.com | The browser widget cannot authenticate without a valid publishable key |
+| Container refresh (`PATCH /v2/containers/{id}/refresh`) | On-demand refresh | Contact sales@terminal49.com | `403 Forbidden`; the endpoint is also rate-limited to 10 requests per minute for entitled accounts |
 | Rail LFD data (`import_deadlines.pickup_lfd_rail` and the `container.pickup_lfd_rail.changed` webhook event) | Rail Plan | Contact sales@terminal49.com | `container.pickup_lfd_rail.changed` notifications are not delivered, and rail-carrier LFD updates are not surfaced on the container |
 
 ## Pricing

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -352,6 +352,7 @@
               "migrate/searates",
               "migrate/project44",
               "migrate/fourkites",
+              "migrate/gnosisfreight",
               "migrate/vizion",
               "migrate/opentrack",
               "migrate/shipsgo",

--- a/docs/migrate/beacon.mdx
+++ b/docs/migrate/beacon.mdx
@@ -2,7 +2,6 @@
 title: "Migrating from Beacon"
 sidebarTitle: "Beacon"
 description: "Map Beacon tracking API fields, parameters, and errors to their Terminal49 equivalents. Includes webhook setup, carrier coverage, and a migration checklist."
-icon: "face-smile-relaxed"
 ---
 
 Beacon combines visibility with forwarding services. If you use only the tracking API, moving to Terminal49 gives you direct terminal integrations (holds, fees, LFD) and 30\+ webhook events. This guide covers the tracking API only, not their forwarding service.
@@ -44,8 +43,12 @@ You do not need to talk to anyone to try this.
 </Warning>
 
 <Tip>
-  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -71,13 +74,13 @@ You can keep polling if you prefer. Point your existing scheduler at `GET /v2/sh
 | --- | --- | --- |
 | Tracking model | Poll on demand | Register once, then push or poll |
 | Authentication | API key or bearer token | `Authorization: Token` header |
-| Base URL | `https://beacon.io` | `https://api.terminal49.com/v2` |
+| Base URL | Your Beacon API endpoint | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Supported | 30\+ events, HMAC-signed |
-| Carrier identification | Carrier name or code | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | Carrier name or code | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Getting an API key | Self-serve | Self-serve |
 
@@ -88,7 +91,8 @@ Move the key into the `Authorization: Token` header and set the content type to 
 <CodeGroup>
 
 ```bash Beacon
-curl -X GET "https://beacon.io/api/v1/shipments?number=MRKU9465770" \
+# However your Beacon integration authenticates today, for example:
+curl -X GET "https://<your-beacon-api-endpoint>/shipments?number=MRKU9465770" \
   -H "Authorization: Bearer YOUR_BEACON_KEY" \
   -H "Content-Type: application/json"
 ```
@@ -113,18 +117,18 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 
 | Beacon parameter | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| `[Beacon's shipment identifier]` | `request_number` | Container, BOL, or booking number |
-| `[Beacon's container identifier]` | `request_type: "container"` |  |
-| `[Beacon's BOL identifier]` | `request_type: "bill_of_lading"` | Master or house BOL |
-| `[Beacon's booking identifier]` | `request_type: "booking_number"` |  |
-| `[Beacon's carrier field]` | `scac` | Same SCAC values for most carriers |
-| Omit carrier | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
-| `[Beacon's refresh parameter]` | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| `[Beacon's route data]` | Always included | See [Routing](/api-docs/in-depth-guides/routing) |
+| Shipment identifier | `request_number` | Container, BOL, or booking number |
+| Container identifier | `request_type: "container"` |  |
+| BOL identifier | `request_type: "bill_of_lading"` | Master or house BOL |
+| Booking identifier | `request_type: "booking_number"` |  |
+| Carrier field | `scac` | Same SCAC values for most carriers |
+| Omit carrier | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| Refresh parameter | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| Route data | `GET /v2/containers/{id}/map_geojson` — requires the Routing Data entitlement | See [Routing](/api-docs/in-depth-guides/routing) |
 | API key header | `Authorization` header | `Token` prefix, not `Bearer` |
 
 <Note>
-  Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources.
+  Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -137,44 +141,44 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 
 | Beacon | Terminal49 |
 | --- | --- |
-| `[Beacon's shipment number field]` | `shipment.attributes.bill_of_lading_number` |
-| `[Beacon's carrier code field]` | `shipment.attributes.shipping_line_scac` |
-| `[Beacon's carrier name field]` | `shipment.attributes.shipping_line_name` |
-| `[Beacon's shipment status field]` | Derived from container status and milestones |
-| `[Beacon's origin location field]` | `shipment.relationships.port_of_lading` |
-| `[Beacon's destination location field]` | `shipment.relationships.port_of_discharge` |
-| `[Beacon's inland destination field]` | `shipment.relationships.destination` |
-| `[Beacon's ETA field]` | `shipment.attributes.pod_eta_at` |
-| `[Beacon's cache or refresh fields]` | No equivalent. Refresh is managed for you. |
+| Shipment number field | `shipment.attributes.bill_of_lading_number` |
+| Carrier code field | `shipment.attributes.shipping_line_scac` |
+| Carrier name field | `shipment.attributes.shipping_line_name` |
+| Shipment status field | Derived from container status and milestones |
+| Origin location field | `shipment.relationships.port_of_lading` |
+| Destination location field | `shipment.relationships.port_of_discharge` |
+| Inland destination field | `shipment.relationships.destination` |
+| ETA field | `shipment.attributes.pod_eta_at` |
+| Cache or refresh fields | No equivalent. Refresh is managed for you. |
 
 ### Container level
 
 | Beacon | Terminal49 |
 | --- | --- |
-| `[Beacon's container number field]` | `container.attributes.number` |
-| `[Beacon's equipment code field]` | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| `[Beacon's container status field]` | `container.attributes.current_status` |
-| `[Beacon's event array field]` | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| Container number field | `container.attributes.number` |
+| Equipment code field | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+| Container status field | `container.attributes.current_status` |
+| Event array field | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  Beacon may return a single equipment code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing equipment codes yourself, you can delete that code.
+  Beacon may return a single equipment code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing equipment codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
 
 | Beacon | Terminal49 |
 | --- | --- |
-| `[Beacon's port name field]` | `port.attributes.name` |
-| `[Beacon's port code field]` | `port.attributes.code` |
-| `[Beacon's port coordinates]` | `port.attributes.latitude` / `.longitude` |
-| `[Beacon's port timezone]` | `port.attributes.time_zone` |
-| `[Beacon's port country field]` | `port.attributes.country_code` |
-| `[Beacon's terminal name field]` | `terminal.attributes.name` |
-| `[Beacon's terminal code field]` | `terminal.attributes.smdg_code` or `bic_code` |
-| `[Beacon's vessel name field]` | `shipment.attributes.pod_vessel_name` |
-| `[Beacon's vessel IMO field]` | `shipment.attributes.pod_vessel_imo` |
-| `[Beacon's vessel MMSI field]` | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
-| `[Beacon's vessel extra fields]` | Not returned |
+| Port name field | `port.attributes.name` |
+| Port code field | `port.attributes.code` |
+| Port coordinates | `port.attributes.latitude` / `.longitude` |
+| Port timezone | `port.attributes.time_zone` |
+| Port country field | `port.attributes.country_code` |
+| Terminal name field | `terminal.attributes.name` |
+| Terminal code field | `terminal.attributes.smdg_code` or `bic_facility_code` |
+| Vessel name field | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO field | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI field | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
+| Vessel extra fields | Not returned |
 
 ## Milestone and event mapping
 
@@ -182,14 +186,14 @@ Beacon returns a flat events array with status codes or names. Terminal49 expose
 
 | Beacon milestone | Terminal49 event |
 | --- | --- |
-| `[Beacon's loaded event]` | `container.transport.vessel_loaded` |
-| `[Beacon's departed event]` | `container.transport.vessel_departed` |
-| `[Beacon's arrived event]` | `container.transport.vessel_arrived` |
-| `[Beacon's discharged event]` | `container.transport.vessel_discharged` |
-| `[Beacon's gated out event]` | `container.transport.full_out` |
-| `[Beacon's gated in event]` | `container.transport.full_in` |
-| `[Beacon's empty out event]` | `container.transport.empty_out` |
-| `[Beacon's empty in event]` | `container.transport.empty_in` |
+| Loaded event | `container.transport.vessel_loaded` |
+| Departed event | `container.transport.vessel_departed` |
+| Arrived event | `container.transport.vessel_arrived` |
+| Discharged event | `container.transport.vessel_discharged` |
+| Gated out event | `container.transport.full_out` |
+| Gated in event | `container.transport.full_in` |
+| Empty out event | `container.transport.empty_out` |
+| Empty in event | `container.transport.empty_in` |
 
 Terminal49 also emits milestones Beacon has no equivalent for:
 
@@ -292,7 +296,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Gotchas that will bite you
@@ -341,13 +345,13 @@ Rough equivalence for the Beacon errors you are handling today:
 
 | Beacon error | Terminal49 |
 | --- | --- |
-| `[Beacon's invalid key error]` | HTTP 401 |
-| `[Beacon's insufficient permissions error]` | HTTP 403 |
-| `[Beacon's rate limit error]` | HTTP 429 |
-| `[Beacon's invalid parameter error]` | HTTP 400 or 422 |
-| `[Beacon's unsupported carrier error]` | HTTP 422 |
-| `[Beacon's no data found error]` | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
-| `[Beacon's carrier unavailable error]` | Not surfaced. We retry internally. |
+| Invalid key error | HTTP 401 |
+| Insufficient permissions error | HTTP 403 |
+| Rate limit error | HTTP 429 |
+| Invalid parameter error | HTTP 400 or 422 |
+| Unsupported carrier error | HTTP 422 |
+| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Carrier unavailable error | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
@@ -483,7 +487,7 @@ Copy this into your agent. Replace the bracketed placeholders in the **Repo cont
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
 You are migrating this codebase from the Beacon tracking API to the Terminal49 API,
 side by side. Terminal49's authoritative migration guide is at
-https://terminal49.com/docs/api-docs/getting-started/migrate-from-beacon. Use it as
+https://terminal49.com/docs/migrate/beacon. Use it as
 the source of truth for field mappings, event names, error codes, and behavior differences.
 
 # Repo context (fill this in before running)
@@ -533,7 +537,7 @@ the source of truth for field mappings, event names, error codes, and behavior d
     tracking request ID.
   - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
   - `getContainer(id)`.
-  - `refreshContainer(id)` mapping to `POST /v2/containers/{id}/refresh`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
 - Normalize responses to the same shape Beacon callers expect today, using the field
   mapping from the guide. Split equipment codes into `equipment_type`, `equipment_length`,
   `equipment_height`. Convert timestamps to UTC + `time_zone`.
@@ -638,6 +642,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/beacon.mdx
+++ b/docs/migrate/beacon.mdx
@@ -4,17 +4,17 @@ sidebarTitle: "Beacon"
 description: "Map Beacon tracking API fields, parameters, and errors to their Terminal49 equivalents. Includes webhook setup, carrier coverage, and a migration checklist."
 ---
 
-Beacon combines visibility with forwarding services. If you use only the tracking API, moving to Terminal49 gives you direct terminal integrations (holds, fees, LFD) and 30\+ webhook events. This guide covers the tracking API only, not their forwarding service.
+Beacon is a supply chain visibility platform that also tracks air waybills and offers order management. If you use only the ocean tracking API, moving to Terminal49 gives you direct terminal integrations (holds, fees, LFD) and 30\+ webhook events. This guide covers ocean container and BOL tracking only, not Beacon's air tracking or order management.
 
 There is no compatibility shim. You will change your request code and your response parsing. For most integrations that is an afternoon.
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Sign up at [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -42,6 +42,10 @@ You do not need to talk to anyone to try this.
   The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
 
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
+
 <Tip>
   If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
@@ -52,13 +56,13 @@ You do not need to talk to anyone to try this.
 
 ## The architectural shift
 
-Beacon gives you a shipment-centric API. You call it with a number, get current state back, and own the schedule, the cache, and the deduplication.
+Beacon gives you a container-centric API. You register a container number, poll for current state, and own the schedule, the cache, and the deduplication.
 
 Terminal49 splits this in two. You register a tracking request once. We keep it updated and push changes to your webhook.
 
 <CardGroup cols={2}>
   <Card title="Before: Beacon" icon="rotate">
-    Cron every few hours, call Beacon's shipment endpoint, diff against your cache, dedupe events, then write to your database. Every call spends quota. Freshness is capped by your polling interval.
+    Cron every 2+ hours, call Beacon's container endpoint, diff against your cache, dedupe events, then write to your database. Every successful call spends contracted usage. Freshness is capped by your polling interval.
   </Card>
 
   <Card title="After: Terminal49" icon="webhook">
@@ -72,29 +76,40 @@ You can keep polling if you prefer. Point your existing scheduler at `GET /v2/sh
 
 |  | Beacon | Terminal49 |
 | --- | --- | --- |
-| Tracking model | Poll on demand | Register once, then push or poll |
-| Authentication | API key or bearer token | `Authorization: Token` header |
-| Base URL | Your Beacon API endpoint | `https://api.terminal49.com/v2` |
+| Tracking model | Register containers, then poll (max every 2h recommended) | Register once, then push or poll |
+| Authentication | Username/password login → short-lived Bearer token | `Authorization: Token` header |
+| Base URL | `https://api.beacon.com/v1` | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
-| Response format | Custom JSON | JSON:API |
-| Webhooks | Supported | 30\+ events, HMAC-signed |
-| Carrier identification | Carrier name or code | `scac`, or `auto_detect_vocc_scac` |
+| Response format | JSON API schema | JSON:API |
+| Webhooks | Available via support | 30\+ events, HMAC-signed |
+| Carrier identification | 4-character SCAC (`carrier_code`) | `scac`, or `auto_detect_vocc_scac` |
 | Terminal holds and fees | No direct equivalent | Included on the container object |
 | Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
-| Getting an API key | Self-serve | Self-serve |
+| Getting an API key | Granted per user by your customer success manager | Self-serve |
 
 ## Authentication
 
-Move the key into the `Authorization: Token` header and set the content type to `application/vnd.api+json`.
+Beacon issues a short-lived Bearer token from a login call and expects you to refresh it before it expires. Terminal49 uses a single static API key, so this entire flow goes away.
 
 <CodeGroup>
 
 ```bash Beacon
-# However your Beacon integration authenticates today, for example:
-curl -X GET "https://<your-beacon-api-endpoint>/shipments?number=MRKU9465770" \
-  -H "Authorization: Bearer YOUR_BEACON_KEY" \
+# Step 1: log in to get an access token (max 20 requests/minute)
+curl -X POST https://api.beacon.com/v1/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "YOUR_BEACON_USERNAME", "password": "YOUR_BEACON_PASSWORD"}'
+# Returns: { "access_token", "refresh_token", "token_type": "Bearer", "expires_in": 300 }
+
+# Step 2: call the API with the access token (expires after 300 seconds)
+curl -X GET "https://api.beacon.com/v1/containers/MRKU9465770" \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json"
+
+# Step 3: refresh before it expires
+curl -X POST https://api.beacon.com/v1/login/token \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token": "YOUR_REFRESH_TOKEN"}'
 ```
 
 ```bash Terminal49
@@ -113,16 +128,23 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
   Note the `Token` prefix. It is not `Bearer`.
 </Note>
 
+<Tip>
+  Terminal49's API key does not expire. Once you switch, delete the login call, the token cache, the 300-second expiry timer, and the refresh logic entirely — there is nothing to replace them with.
+</Tip>
+
+Beacon also requires your customer success manager to grant API access per user before you can call the API at all. Terminal49 keys are self-serve from the dashboard.
+
 ## Request parameter mapping
 
-| Beacon parameter | Terminal49 equivalent | Notes |
+Beacon's `POST /v1/containers` takes an array of container objects in one call. Terminal49's `POST /tracking_requests` takes one identifier per request, but that identifier can be a container number, a BOL, or a booking number.
+
+| Beacon field | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| Shipment identifier | `request_number` | Container, BOL, or booking number |
-| Container identifier | `request_type: "container"` |  |
-| BOL identifier | `request_type: "bill_of_lading"` | Master or house BOL |
-| Booking identifier | `request_type: "booking_number"` |  |
-| Carrier field | `scac` | Same SCAC values for most carriers |
-| Omit carrier | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| `container_number` (required) | `request_number` + `request_type: "container"` | Terminal49 also accepts BOL (`request_type: "bill_of_lading"`) and booking numbers (`request_type: "booking_number"`) as the identifier, which Beacon's container endpoint does not |
+| `carrier_code` (optional, 4-char SCAC) | `scac` | Same SCAC format |
+| Omit `carrier_code` | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| `destination_warehouse_name` (optional) | No equivalent field | Terminal49 does not model an inland warehouse name on the tracking request; the container's `relationships.destination` covers inland rail/port destinations |
+| `custom_fields` (optional, up to 10 `{name, value}` pairs) | `ref_numbers` (array of strings) on the tracking request, per the [OpenAPI spec](/api-docs/api-reference/introduction) | Terminal49 stores these as a flat list of reference strings, not named key/value pairs — if you rely on the field name to route data downstream, you'll need to encode that in the string or handle it in your own mapping layer |
 | Refresh parameter | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
 | Route data | `GET /v2/containers/{id}/map_geojson` — requires the Routing Data entitlement | See [Routing](/api-docs/in-depth-guides/routing) |
 | API key header | `Authorization` header | `Token` prefix, not `Bearer` |
@@ -131,69 +153,73 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
   Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
+<Warning>
+  Beacon consumes your contracted usage whenever a request succeeds and returns tracking data — even for containers you've stopped actively watching. Terminal49's free plan tracks up to 10 active containers at no cost; beyond that, usage is based on active tracking requests, not per-call lookups.
+</Warning>
+
 ## Response field mapping
 
 Terminal49 is JSON:API compliant, so relationships between shipments, containers, ports, and terminals are explicit rather than something you reassemble from ID references.
 
 Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to sideload related resources in one call instead of chasing IDs.
 
+Beacon's `GET /v1/containers/{containerNumber}` response is container-centric — it does not return a separate shipment object. Below, the Beacon column reflects the real field names from that response.
+
 ### Shipment level
 
-| Beacon | Terminal49 |
+| Beacon field | Terminal49 |
 | --- | --- |
-| Shipment number field | `shipment.attributes.bill_of_lading_number` |
-| Carrier code field | `shipment.attributes.shipping_line_scac` |
-| Carrier name field | `shipment.attributes.shipping_line_name` |
-| Shipment status field | Derived from container status and milestones |
-| Origin location field | `shipment.relationships.port_of_lading` |
-| Destination location field | `shipment.relationships.port_of_discharge` |
-| Inland destination field | `shipment.relationships.destination` |
-| ETA field | `shipment.attributes.pod_eta_at` |
-| Cache or refresh fields | No equivalent. Refresh is managed for you. |
+| `carrier.code` | `shipment.attributes.shipping_line_scac` |
+| `carrier.name` | `shipment.attributes.shipping_line_name` |
+| `status` (enum) | Derived from container status and milestones |
+| `port_of_loading` | `shipment.relationships.port_of_lading` |
+| `port_of_discharge` | `shipment.relationships.port_of_discharge` |
+| `vessel_arrival_dates.estimated_date` | `shipment.attributes.pod_eta_at` |
+| No polling/refresh cache field | No equivalent. Refresh is managed for you. |
 
 ### Container level
 
-| Beacon | Terminal49 |
+| Beacon field | Terminal49 |
 | --- | --- |
-| Container number field | `container.attributes.number` |
-| Equipment code field | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| Container status field | `container.attributes.current_status` |
-| Event array field | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| `container_number` | `container.attributes.number` |
+| `status` (enum: `GATED_OUT_EMPTY`, `GATED_IN_FULL`, `LOADED_AT_POL`, `IN_TRANSIT`, `ARRIVED_AT_POD`, `DISCHARGED_AT_POD`, `GATED_OUT_FULL`, `PROCESSING`) | `container.attributes.current_status` |
+| `gated_out_empty_dates` … `gated_out_full_dates` (each with `estimated_date` and/or `actual_date`) | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events — see the milestone mapping below |
+| `custom_fields` | Set at tracking-request time as `ref_numbers`; not returned on the container object |
+| `purchase_orders` | No equivalent. Terminal49's tracking API does not do order management |
 
 <Note>
-  Beacon may return a single equipment code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing equipment codes yourself, you can delete that code.
+  Beacon's documented container response does not include an equipment type or size field. If your integration reads container equipment (dry, reefer, size) from Beacon today, confirm with Beacon support where that comes from before you map it — Terminal49 returns it as `container.attributes.equipment_type`, `equipment_length` (10, 20, 40, 45), and `equipment_height` (standard, high cube).
 </Note>
 
 ### Locations, facilities, and vessels
 
-| Beacon | Terminal49 |
+| Beacon field | Terminal49 |
 | --- | --- |
-| Port name field | `port.attributes.name` |
-| Port code field | `port.attributes.code` |
-| Port coordinates | `port.attributes.latitude` / `.longitude` |
-| Port timezone | `port.attributes.time_zone` |
-| Port country field | `port.attributes.country_code` |
-| Terminal name field | `terminal.attributes.name` |
-| Terminal code field | `terminal.attributes.smdg_code` or `bic_facility_code` |
-| Vessel name field | `shipment.attributes.pod_vessel_name` |
-| Vessel IMO field | `shipment.attributes.pod_vessel_imo` |
-| Vessel MMSI field | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
-| Vessel extra fields | Not returned |
+| `port_of_loading.name` | `port.attributes.name` |
+| `port_of_loading.un_location_code` | `port.attributes.code` |
+| `port_of_discharge.name` / `.un_location_code` | Same fields, on the discharge port resource |
+| Port coordinates | Not returned by Beacon. Terminal49: `port.attributes.latitude` / `.longitude` |
+| Port timezone | Not returned by Beacon. Terminal49: `port.attributes.time_zone` |
+| Port country | Not returned by Beacon. Terminal49: `port.attributes.country_code` |
+| Terminal name/code | Not returned by Beacon. Terminal49: `terminal.attributes.name`, `terminal.attributes.smdg_code` or `bic_facility_code` |
+| `vessel.name` | `shipment.attributes.pod_vessel_name` |
+| `vessel.imo_number` | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI, position, extra fields | Not returned by Beacon. Available on Terminal49 via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
 
 ## Milestone and event mapping
 
-Beacon returns a flat events array with status codes or names. Terminal49 exposes the same milestones as normalized transport events and pushes each one to your webhook.
+Beacon returns each milestone as its own date object with `estimated_date` and/or `actual_date`, rather than a single flat events array. Terminal49 exposes the same milestones as normalized transport events and pushes each one to your webhook.
 
-| Beacon milestone | Terminal49 event |
+| Beacon date object | Terminal49 event |
 | --- | --- |
-| Loaded event | `container.transport.vessel_loaded` |
-| Departed event | `container.transport.vessel_departed` |
-| Arrived event | `container.transport.vessel_arrived` |
-| Discharged event | `container.transport.vessel_discharged` |
-| Gated out event | `container.transport.full_out` |
-| Gated in event | `container.transport.full_in` |
-| Empty out event | `container.transport.empty_out` |
-| Empty in event | `container.transport.empty_in` |
+| `gated_out_empty_dates` | `container.transport.empty_out` |
+| `gated_in_full_dates` | `container.transport.full_in` |
+| `loaded_dates` | `container.transport.vessel_loaded` |
+| `vessel_departure_dates` | `container.transport.vessel_departed` |
+| `vessel_arrival_dates` | `container.transport.vessel_arrived` |
+| `discharged_dates` | `container.transport.vessel_discharged` |
+| `gated_out_full_dates` | `container.transport.full_out` |
+| No equivalent | `container.transport.empty_in` |
 
 Terminal49 also emits milestones Beacon has no equivalent for:
 
@@ -302,8 +328,16 @@ Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/ho
 ## Gotchas that will bite you
 
 <AccordionGroup>
-  <Accordion title="Scope is tracking only, not forwarding" icon="arrows-left-right">
-    Beacon also offers freight forwarding and booking management. Terminal49 does not. If your integration uses Beacon forwarding APIs, plan to keep Beacon for those or replace them separately.
+  <Accordion title="Scope is ocean only, not air or orders" icon="arrows-left-right">
+    Beacon also tracks air waybills (AWBs) and offers order management (creating and updating orders, linking an order to a shipment). Terminal49 does not do either. If your integration uses Beacon for air freight or order management, plan to keep Beacon for those or replace them separately — this guide covers ocean container and BOL tracking only.
+  </Accordion>
+
+  <Accordion title="No more token refresh loop" icon="key">
+    Beacon's access token expires every 300 seconds, so a real integration ends up with a refresh timer, a token cache, and retry logic around `401`s from an expired token. Terminal49's API key is static — delete all of that. There is no login call, no refresh endpoint, and no expiry to track.
+  </Accordion>
+
+  <Accordion title="Usage accounting works differently" icon="receipt">
+    Beacon consumes your contracted usage every time a request succeeds and returns tracking data, even for containers you're no longer actively watching — so idle containers you forgot to stop polling still cost you. Terminal49's free plan tracks up to 10 active containers; usage is based on active tracking requests, not per-call lookups, so stopping a tracking request stops it counting.
   </Accordion>
 
   <Accordion title="Tracking requests are asynchronous" icon="hourglass-half">
@@ -315,7 +349,11 @@ Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/ho
   </Accordion>
 
   <Accordion title="Timestamps are UTC with a separate timezone field" icon="clock">
-    Beacon may return local time or timezone-naive timestamps. Terminal49 stores event timestamps in UTC and returns the matching IANA timezone alongside. Convert for display rather than assuming local time. See [Event Timestamps](/api-docs/in-depth-guides/event-timestamps).
+    Beacon's date fields carry a local UTC offset for the event's location, but fall back to a plain `...Z` UTC timestamp if no zone information is available, or a date with no time at all if no time information is available — so parsing has to branch on which shape you got. Terminal49 always stores event timestamps in UTC and returns the matching IANA timezone alongside as a separate field. Convert for display rather than assuming local time. See [Event Timestamps](/api-docs/in-depth-guides/event-timestamps).
+  </Accordion>
+
+  <Accordion title="Polling cadence vs. webhooks" icon="arrows-rotate">
+    Beacon recommends polling `GET /v1/containers/{containerNumber}` no more than once every 2 hours. If your Beacon integration is polling on a cron, you can either keep the same cadence against `GET /v2/containers`, or drop polling entirely and let Terminal49 push webhook events as they happen — freshness is no longer capped by how often you ask.
   </Accordion>
 
   <Accordion title="Empty arrays are the normal state" icon="brackets-square">
@@ -329,7 +367,7 @@ Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/ho
 
 ## Error handling
 
-Beacon returns HTTP status codes with error details in the response body. Terminal49 also uses standard HTTP status codes. Replace any Beacon-specific error parsing with status-code checks.
+Beacon returns HTTP status codes with an error body containing `timestamp`, `error`, and `sub_error` fields. Terminal49 also uses standard HTTP status codes. Replace any Beacon-specific error parsing with status-code checks.
 
 | Status | Meaning |
 | --- | --- |
@@ -341,17 +379,16 @@ Beacon returns HTTP status codes with error details in the response body. Termin
 | 429 | Rate limited. See [Rate Limiting](/api-docs/in-depth-guides/rate-limiting) |
 | 5xx | Terminal49 or an upstream carrier or terminal is unavailable |
 
-Rough equivalence for the Beacon errors you are handling today:
+Rough equivalence for the Beacon status codes you are handling today:
 
-| Beacon error | Terminal49 |
+| Beacon status | Terminal49 |
 | --- | --- |
-| Invalid key error | HTTP 401 |
-| Insufficient permissions error | HTTP 403 |
-| Rate limit error | HTTP 429 |
-| Invalid parameter error | HTTP 400 or 422 |
-| Unsupported carrier error | HTTP 422 |
-| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
-| Carrier unavailable error | Not surfaced. We retry internally. |
+| 400 Bad request | HTTP 400 or 422 |
+| 401 Unauthorised (missing or expired token) | HTTP 401 — but there is no token to expire, since the key is static |
+| 403 Forbidden | HTTP 403 |
+| 429 Rate limit exceeded (120/min non-login, 20/min login) | HTTP 429. See [Rate Limiting](/api-docs/in-depth-guides/rate-limiting) for Terminal49's limits |
+| No tracking data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Carrier unavailable | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
@@ -359,13 +396,13 @@ The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`Authenticat
 
 Worth knowing before you commit.
 
-**Carrier count.** Terminal49 integrates directly with 36 ocean carriers, plus 2 more enabled on request, as of 14 August 2026. Beacon may list more. Ours are direct integrations covering the lines that move volume into North America, and each is normalized into one schema. Check your carrier mix against the [ocean carrier list](/coverage/ocean-carriers) before cutover, and read the known issues section there. We publish the per-carrier field gaps.
+**Carrier count.** Terminal49 integrates directly with 36 ocean carriers, plus 2 more enabled on request, as of 14 August 2026. Beacon advertises coverage across 160\+ ocean and air carriers combined. Ours are direct integrations covering the lines that move volume into North America, and each is normalized into one schema. Check your carrier mix against the [ocean carrier list](/coverage/ocean-carriers) before cutover, and read the known issues section there. We publish the per-carrier field gaps.
 
 **Terminal data is North America.** Holds, fees, LFD, and availability come from direct terminal integrations concentrated in the US and Canada, with European ports expanding. Ocean milestones work globally; terminal-level operational data does not yet.
 
-**No air, parcel, or road tracking.** If your integration covers those modes, this migration handles only the ocean portion.
+**No air tracking.** Beacon also tracks air waybills (AWBs). Terminal49 tracks ocean only. If your integration covers air freight, keep it on Beacon or move it elsewhere — this migration handles only the ocean portion.
 
-**No freight forwarding or booking management.** We do not offer forwarding services, rate calculators, or booking APIs. If your Beacon integration uses those, keep Beacon for them or replace them separately.
+**No order management.** Beacon lets you create and update orders and link an order to a shipment. Terminal49 does not model orders — it tracks shipments and containers. If your Beacon integration uses order management, keep Beacon for that or replace it separately.
 
 **Some fields are source-dependent.** Seal number, container weight, and departure or arrival events vary by carrier. The [field availability reference](/coverage/fields) says which fields are always present and which depend on the carrier, terminal, or journey.
 
@@ -476,7 +513,8 @@ If you use Cursor, Claude Code, Windsurf, Copilot, or another AI coding assistan
     - A parity report per shipment: matched fields, diverged fields, and Terminal49-only fields (holds, fees, LFD).
     - A feature-flagged cutover: route reads to Terminal49, keep Beacon as fallback until you flip the flag off.
     - A webhook receiver with HMAC verification, or a polling scheduler, depending on which path you pick.
-    - A cleanup PR that removes Beacon code, env vars, dependencies, and dedupe logic.
+    - A cleanup PR that removes Beacon code, its login/token-refresh flow, env vars,
+      dependencies, and dedupe logic.
   </Accordion>
 </AccordionGroup>
 
@@ -494,9 +532,13 @@ the source of truth for field mappings, event names, error codes, and behavior d
 
 - Beacon client lives at: [path/to/beacon/client.ts]
 - Beacon is called from: [list the call sites or "find them"]
+- Beacon auth env vars in use today: [e.g. BEACON_USERNAME, BEACON_PASSWORD — Beacon
+  logs in via POST /v1/login and refreshes a 300-second access token via
+  POST /v1/login/token; note anywhere that refresh timer or token cache lives]
 - Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
 - Storage for tracking state: [e.g. Postgres table `shipments`]
-- Current polling schedule: [e.g. cron every 2h via BullMQ]
+- Current polling schedule: [e.g. cron every 2h via BullMQ, matching Beacon's recommended
+  minimum interval]
 - Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
 - Deployment target: [e.g. AWS ECS, Vercel, Fly.io]
 - Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
@@ -590,8 +632,14 @@ the source of truth for field mappings, event names, error codes, and behavior d
 
 ## PR 7 — Cleanup
 
-- Delete `BeaconClient`, its tests, its env vars, its dedupe cache, and any
-  equipment-code parsing helpers Terminal49 makes redundant.
+- Delete `BeaconClient`, its tests, its dedupe cache, and any equipment-code parsing
+  helpers Terminal49 makes redundant.
+- Delete the Beacon login flow entirely: the `POST /v1/login` call, the
+  `POST /v1/login/token` refresh call, the token cache, and any refresh timer or
+  scheduled job tied to the 300-second expiry. Terminal49's key does not expire, so
+  none of this has a replacement — it just goes away.
+- Remove `BEACON_USERNAME`, `BEACON_PASSWORD`, and any Beacon token env vars from the
+  secret store and deployment config.
 - Remove the shadow provider and the feature flag.
 - Update README and any runbooks. Note the new webhook endpoint if applicable.
 

--- a/docs/migrate/beacon.mdx
+++ b/docs/migrate/beacon.mdx
@@ -387,7 +387,7 @@ Rough equivalence for the Beacon status codes you are handling today:
 | 401 Unauthorised (missing or expired token) | HTTP 401 — but there is no token to expire, since the key is static |
 | 403 Forbidden | HTTP 403 |
 | 429 Rate limit exceeded (120/min non-login, 20/min login) | HTTP 429. See [Rate Limiting](/api-docs/in-depth-guides/rate-limiting) for Terminal49's limits |
-| No tracking data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| No tracking data found | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | Carrier unavailable | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
@@ -471,8 +471,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers`.
@@ -552,8 +552,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/fourkites.mdx
+++ b/docs/migrate/fourkites.mdx
@@ -16,11 +16,11 @@ There is no compatibility shim. You will change your request code and your respo
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    [Create an account](https://app.terminal49.com) — the free Developer Key tracks up to 10 active containers.
+    [Create an account](https://app.terminal49.com) — the free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Generate a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -47,6 +47,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 
@@ -307,7 +311,7 @@ Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/ho
 
 <AccordionGroup>
   <Accordion title="Enterprise contract vs self-serve pricing">
-    FourKites is an enterprise platform. Terminal49 is self-serve with a Developer Key that tracks up to 10 containers free. If you need volume pricing, it exists, but you do not need a contract to start.
+    FourKites is an enterprise platform. Terminal49 is self-serve with a free plan that tracks up to 10 active containers. API reads require a free 7-day API trial we enable on request. If you need volume pricing, it exists, but you do not need a contract to start.
   </Accordion>
 
   <Accordion title="Multi-modal shipment model: extract ocean segments">

--- a/docs/migrate/fourkites.mdx
+++ b/docs/migrate/fourkites.mdx
@@ -433,7 +433,7 @@ Everyone does the base path. Then pick a branch.
     See [webhook best practices](/api-docs/webhooks/best-practices) for retries and idempotency.
   </Tab>
   <Tab title="Polling path">
-    1. Store the tracking request ID and shipment ID from the creation response.
+    1. Store the tracking request ID from the creation response. The shipment ID arrives later — the creation response is pending with no shipment attached; fetch the tracking request again (or handle `tracking_request.succeeded`) to get it once the carrier responds.
     2. Repoint your existing scheduler at `GET /v2/shipments` or `GET /v2/containers`.
     3. Keep your existing cadence.
 
@@ -500,8 +500,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/fourkites.mdx
+++ b/docs/migrate/fourkites.mdx
@@ -48,7 +48,11 @@ You do not need to talk to anyone to try this.
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
 
-If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -73,26 +77,27 @@ You can keep polling if you prefer — point your existing scheduler at `GET /v2
 |  | FourKites | Terminal49 |
 | --- | --- | --- |
 | Tracking model | Poll via enterprise platform | Register once, then push or poll |
-| Authentication | OAuth2 bearer token or API key header | `Authorization: Token` header |
-| Base URL | `https://fourkites.com` | `https://api.terminal49.com/v2` |
+| Authentication | Platform credentials (varies by product) | `Authorization: Token` header |
+| Base URL | Your FourKites API endpoint | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Available | 30\+ events, HMAC-signed |
-| Carrier identification | SCAC or internal mapping | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | SCAC or internal mapping | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Available | North American Class I and short-line |
 | Multi-modal scope | Ocean, road, rail, freight | Ocean and North American terminals only |
 | Getting an API key | Enterprise contract | Self-serve |
 
 ## Authentication
 
-Move from OAuth2 bearer tokens or API key headers to a single `Authorization: Token` header.
+Move from your FourKites credentials — whichever scheme your FourKites product uses today — to a single `Authorization: Token` header.
 
 <CodeGroup>
 
 ```bash FourKites
-curl "https://fourkites.com/[your provider's shipment resource]" \
+# However your integration authenticates today, for example:
+curl "https://<your-fourkites-api-endpoint>/shipments" \
   -H "Authorization: Bearer YOUR_FOURKITES_TOKEN"
 ```
 
@@ -114,17 +119,17 @@ Note the `Token` prefix. It is not `Bearer`.
 
 | FourKites parameter | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| `[provider's shipment identifier]` | `request_number` |  |
-| `[provider's container identifier]` | `request_type: "container"` \+ `request_number` |  |
-| `[provider's bill of lading field]` | `request_type: "bill_of_lading"` | Master or house BOL |
-| `[provider's booking number field]` | `request_type: "booking_number"` |  |
+| Shipment / load identifier | `request_number` |  |
+| Container number | `request_type: "container"` \+ `request_number` |  |
+| Bill of lading number | `request_type: "bill_of_lading"` | Master or house BOL |
+| Booking number | `request_type: "booking_number"` |  |
 | SCAC / carrier code | `scac` | Same SCAC values for most carriers |
-| `[provider's auto-detect option]` | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
-| `[provider's refresh option]` | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| `[provider's route field]` | Always included | See [Routing](/api-docs/in-depth-guides/routing) |
+| Carrier auto-detection | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| Force refresh | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| Route / journey legs | `GET /v2/containers/{id}/map_geojson` | Requires the Routing Data entitlement. See [Routing](/api-docs/in-depth-guides/routing) |
 
 <Note>
-  FourKites organizes around shipments and loads that may contain multiple segments across modes. Terminal49 takes one ocean identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources.
+  FourKites organizes around shipments and loads that may contain multiple segments across modes. Terminal49 takes one ocean identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -137,45 +142,45 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 
 | FourKites | Terminal49 |
 | --- | --- |
-| `[provider's bill of lading field]` | `shipment.attributes.bill_of_lading_number` |
-| `[provider's carrier scac field]` | `shipment.attributes.shipping_line_scac` |
-| `[provider's carrier name field]` | `shipment.attributes.shipping_line_name` |
-| `[provider's shipment status field]` | Derived from container status and milestones |
-| `[provider's origin location]` | `shipment.attributes.port_of_lading_*` (place of receipt) |
-| `[provider's port of loading]` | `shipment.relationships.port_of_lading` |
-| `[provider's port of discharge]` | `shipment.relationships.port_of_discharge` |
-| `[provider's destination]` | `shipment.relationships.destination` (inland) |
-| `[provider's ETA field]` | `shipment.attributes.pod_eta_at` |
+| Bill of lading number | `shipment.attributes.bill_of_lading_number` |
+| Carrier SCAC | `shipment.attributes.shipping_line_scac` |
+| Carrier name | `shipment.attributes.shipping_line_name` |
+| Shipment status | Derived from container status and milestones |
+| Inland origin / place of receipt | No direct equivalent — Terminal49 shipments start at the port of lading |
+| Port of loading | `shipment.relationships.port_of_lading` (name and LOCODE also on `shipment.attributes.port_of_lading_*`) |
+| Port of discharge | `shipment.relationships.port_of_discharge` |
+| Final destination (inland) | `shipment.relationships.destination` |
+| ETA at discharge port | `shipment.attributes.pod_eta_at` |
 
 ### Container level
 
 | FourKites | Terminal49 |
 | --- | --- |
-| `[provider's container number field]` | `container.attributes.number` |
-| `[provider's equipment code field]` | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| `[provider's container status field]` | `container.attributes.current_status` |
-| `[provider's event list]` | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| Container number | `container.attributes.number` |
+| Equipment / ISO code | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+| Container status | `container.attributes.current_status` |
+| Event list | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  FourKites may return an ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  FourKites may return an ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
 
 | FourKites | Terminal49 |
 | --- | --- |
-| `[provider's port name field]` | `port.attributes.name` |
-| `[provider's port code field]` | `port.attributes.code` |
-| `[provider's port coordinates]` | `port.attributes.latitude` / `.longitude` |
-| `[provider's port timezone]` | `port.attributes.time_zone` |
-| `[provider's port country]` | `port.attributes.country_code` |
-| `[provider's terminal name field]` | `terminal.attributes.name` |
-| `[provider's terminal smdg code]` | `terminal.attributes.smdg_code` |
-| `[provider's terminal bic code]` | `terminal.attributes.bic_code` |
-| `[provider's vessel name field]` | `shipment.attributes.pod_vessel_name` |
-| `[provider's vessel IMO field]` | `shipment.attributes.pod_vessel_imo` |
-| `[provider's vessel MMSI field]` | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
-| `[provider's vessel call sign / flag]` | Not returned |
+| Port name | `port.attributes.name` |
+| Port code / UN/LOCODE | `port.attributes.code` |
+| Port coordinates | `port.attributes.latitude` / `.longitude` |
+| Port timezone | `port.attributes.time_zone` |
+| Port country | `port.attributes.country_code` |
+| Terminal / facility name | `terminal.attributes.name` |
+| Terminal SMDG code | `terminal.attributes.smdg_code` |
+| Terminal BIC facility code | `terminal.attributes.bic_facility_code` |
+| Vessel name | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
+| Vessel call sign / flag | Not returned |
 
 ## Milestone and event mapping
 
@@ -185,12 +190,12 @@ Where mappings exist:
 
 | FourKites milestone | Terminal49 event |
 | --- | --- |
-| `[provider's vessel loaded event]` | `container.transport.vessel_loaded` |
-| `[provider's vessel departed event]` | `container.transport.vessel_departed` |
-| `[provider's vessel arrived event]` | `container.transport.vessel_arrived` |
-| `[provider's vessel discharged event]` | `container.transport.vessel_discharged` |
-| `[provider's full out / gated out event]` | `container.transport.full_out` |
-| `[provider's full in / gated in event]` | `container.transport.full_in` |
+| Loaded on vessel | `container.transport.vessel_loaded` |
+| Vessel departed | `container.transport.vessel_departed` |
+| Vessel arrived | `container.transport.vessel_arrived` |
+| Discharged from vessel | `container.transport.vessel_discharged` |
+| Full out / gated out | `container.transport.full_out` |
+| Full in / gated in | `container.transport.full_in` |
 | — | `container.transport.empty_out` |
 | — | `container.transport.empty_in` |
 
@@ -295,7 +300,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement — rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement — Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Gotchas that will bite you
@@ -348,12 +353,12 @@ Rough equivalence for the FourKites errors you are handling today:
 
 | FourKites error | Terminal49 |
 | --- | --- |
-| `[provider's auth error]` | HTTP 401 |
-| `[provider's permission error]` | HTTP 403 |
-| `[provider's rate limit error]` | HTTP 429 |
-| `[provider's validation error]` | HTTP 400 or 422 |
-| `[provider's not found error]` | HTTP 404 |
-| `[provider's upstream unavailable error]` | Not surfaced — we retry internally |
+| Authentication failure | HTTP 401 |
+| Permission / access denied | HTTP 403 |
+| Rate limit exceeded | HTTP 429 |
+| Validation failure | HTTP 400 or 422 |
+| Resource not found | HTTP 404 |
+| Upstream carrier unavailable | Not surfaced — we retry internally |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
@@ -436,36 +441,168 @@ Everyone does the base path. Then pick a branch.
 
 ## Migrate with an AI coding agent
 
+If you use Claude Code, Cursor, Codex, Windsurf, Copilot, or another AI coding assistant, hand it the prompt below. It is written to run a **side-by-side migration**: the agent stands up a Terminal49 client next to your existing FourKites code, shadows every FourKites call with a Terminal49 call, diffs the responses, and only cuts over once parity is proven.
+
+<Tip>
+  Point your agent at this page as context (paste the URL or add it as a doc source). The prompt references the mappings above, so the more of this page the agent can see, the better it does.
+</Tip>
+
+<AccordionGroup>
+  <Accordion title="How to use this prompt" icon="wand-magic-sparkles">
+    1. Open your repo in your AI coding tool.
+    2. Add this page as a documentation source, or paste its URL into the chat.
+    3. Copy the prompt below into a new chat and send it.
+    4. Answer the agent's discovery questions (FourKites client location, env var names, carrier mix).
+    5. Review each PR the agent opens. It should ship in small, reviewable steps: client, shadow, parity harness, cutover, cleanup.
+  </Accordion>
+
+  <Accordion title="What the agent will produce" icon="list-check">
+    - A `Terminal49Client` alongside your existing FourKites client, sharing the same interface where possible.
+    - A shadow-mode wrapper that calls both providers and logs response diffs without changing behavior.
+    - A parity report per shipment: matched fields, diverged fields, and Terminal49-only fields (holds, fees, LFD).
+    - A feature-flagged cutover: route reads to Terminal49, keep FourKites as fallback until you flip the flag off.
+    - A webhook receiver with HMAC verification, or a polling scheduler, depending on which path you pick.
+    - A cleanup PR that removes FourKites code, env vars, dependencies, and dedupe logic.
+  </Accordion>
+</AccordionGroup>
+
+### The prompt
+
+Copy this into your agent. Replace the bracketed placeholders in the **Repo context** block before sending.
+
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
-You are migrating this codebase from the FourKites ocean tracking API to Terminal49.
+You are migrating this codebase from the FourKites API to the Terminal49 API,
+side by side. Terminal49's authoritative migration guide is at
+https://terminal49.com/docs/migrate/fourkites. Use it as
+the source of truth for field mappings, event names, error codes, and behavior differences.
 
-Context you already have:
-- The existing integration uses FourKites for ocean container tracking.
-- Environment variables FOURKITES_BASE_URL and FOURKITES_API_KEY are in use.
-- The app polls for shipment state and stores events in the database.
+# Repo context (fill this in before running)
 
-Your task:
-1. Replace all FourKites ocean API calls with Terminal49 equivalents.
-2. Remove polling for ocean shipments; register webhooks for
-   container.transport.vessel_discharged, container.transport.available,
-   container.pickup_lfd.changed, tracking_request.succeeded, and tracking_request.failed.
-3. Parse JSON:API responses and map fields:
-   - shipment.attributes.bill_of_lading_number
-   - shipment.attributes.shipping_line_scac
-   - shipment.attributes.shipping_line_name
-   - container.attributes.number
-   - container.attributes.equipment_type / equipment_length / equipment_height
-   - container.attributes.holds_at_pod_terminal
-   - container.attributes.fees_at_pod_terminal
-   - container.attributes.pickup_lfd
-   - container.attributes.available_for_pickup
-4. Handle async tracking request lifecycle: succeeded, failed, awaiting_manifest.
-5. Update error handling to use HTTP status codes and typed SDK errors.
-6. Keep road, rail, and LTL tracking in FourKites or leave stubs pointing elsewhere.
-7. Add holds_at_pod_terminal and fees_at_pod_terminal to the data model.
-8. Write tests for webhook signature verification and container.updated changeset parsing.
-9. Do not change anything outside the ocean tracking module.
-10. Use the Terminal49 TypeScript SDK where possible.
+- FourKites client lives at: [path/to/client]
+- FourKites is called from: [list the call sites or "find them"]
+- Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
+- Storage for tracking state: [e.g. Postgres table `shipments`]
+- Current polling schedule: [e.g. cron every 2h]
+- Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
+- Deployment target: [e.g. AWS ECS, Vercel, Fly.io]
+- Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
+
+# Rules
+
+1. Do not delete FourKites code until the cleanup step. Migration is side by side.
+2. Ship in small PRs. Each PR must build, pass tests, and be independently revertable.
+3. Never invent Terminal49 fields, endpoints, or event names. If the guide does not
+   confirm a mapping, ask me. Do not guess.
+4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
+   `application/vnd.api+json`. Get this right on the first request.
+5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
+   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
+   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
+7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
+   not missing data. A fee `amount` of 0 is valid.
+8. On `container.updated`, prefer the `changeset` over diffing state yourself.
+9. Terminal49 covers the ocean leg only. Keep FourKites road, rail, and LTL tracking
+   in place (or leave stubs pointing elsewhere). Extract the ocean segment from each
+   multi-modal FourKites shipment before mapping it.
+
+# Plan (execute in order, one PR per step)
+
+## PR 1 — Discovery and interface
+
+- Grep the repo for every FourKites call site. List them in the PR description.
+- Extract the FourKites client's public surface into an interface
+  (`TrackingProvider` with methods like `track(number, type, carrier)`,
+  `getShipment(id)`, `refresh(id)`).
+- Make the existing FourKites client implement it. No behavior change.
+
+## PR 2 — Terminal49 client
+
+- Add a `Terminal49Client` implementing the same `TrackingProvider` interface.
+- Auth via `T49_API_KEY` env var, header `Authorization: Token ${key}`.
+- Base URL `https://api.terminal49.com/v2`, content type `application/vnd.api+json`.
+- Implement:
+  - `createTrackingRequest({ request_number, request_type, scac })` returning the
+    tracking request ID.
+  - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge' })`.
+  - `getContainer(id)`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh` (a paid
+    feature — skip it unless our account has it enabled).
+- Normalize responses to the same shape FourKites callers expect today, using the field
+  mapping from the guide. Split equipment codes into `equipment_type`, `equipment_length`,
+  `equipment_height`. Convert timestamps to UTC + `time_zone`.
+- Map errors to typed classes: `AuthenticationError` (401), `AuthorizationError` (403),
+  `ValidationError` (400/422), `RateLimitError` (429), `UpstreamError` (5xx),
+  `FeatureNotEnabledError` (403 + feature flag response).
+- Add unit tests using recorded fixtures. Do not hit the live API in tests.
+
+## PR 3 — Shadow mode
+
+- Add a `ShadowProvider` that wraps both clients. On every read:
+  - Call FourKites as the primary. Return its response.
+  - Fire-and-forget a Terminal49 call for the same identifier.
+  - Log a structured diff: matched fields, diverged fields, T49-only fields.
+- Gate with env var `TRACKING_SHADOW_MODE=true`. Off by default.
+- Add a parity report script that aggregates shadow logs by SCAC and field.
+- Do NOT change what callers see. This step is observation only.
+
+## PR 4 — Backfill script
+
+- Write a one-shot script that reads all active shipments from our database and calls
+  `POST /tracking_requests` for each (one per BOL, booking, or container).
+- Store the returned `tracking_request.id` and eventual `shipment.id` on our records.
+- Rate-limit to respect Terminal49's limits (handle 429 with exponential backoff).
+- Idempotent: safe to re-run. Skip rows already backfilled.
+
+## PR 5 — Webhook receiver (only if we picked the webhook path)
+
+- Add `POST /webhooks/terminal49` endpoint.
+- Verify HMAC signature using the shared secret from `T49_WEBHOOK_SECRET`. Reject on
+  mismatch with 401.
+- Handle these events at minimum:
+  - `tracking_request.succeeded`, `tracking_request.failed`, `tracking_request.awaiting_manifest`
+  - `container.transport.vessel_discharged`, `container.transport.available`,
+    `container.transport.full_out`
+  - `container.updated` (use the `changeset`, do not diff)
+  - `container.pickup_lfd.changed`
+- Persist events idempotently keyed by event ID.
+- Register the webhook via `POST /v2/webhooks` from a bootstrap script, subscribing
+  only to events we handle.
+- If our firewall restricts inbound traffic, whitelist Terminal49 IPs from
+  `GET /v2/webhooks/ips`.
+
+## PR 6 — Cutover behind a flag
+
+- Add feature flag `TRACKING_PROVIDER` with values `fourkites` (default) and `terminal49`.
+- Route all reads through the flag. FourKites stays available as a fallback for one
+  release cycle.
+- Flip staging to `terminal49`, verify parity report is clean, then flip production.
+
+## PR 7 — Cleanup
+
+- Delete the FourKites client, its tests, its env vars, its dedupe cache, and any
+  equipment-code parsing helpers Terminal49 makes redundant.
+- Remove the shadow provider and the feature flag.
+- Update README and any runbooks. Note the new webhook endpoint if applicable.
+
+# Definition of done
+
+- All FourKites call sites now go through Terminal49.
+- Webhook (or polling) is live in production.
+- Parity report shows no unexplained divergences for our top 10 SCACs.
+- Holds, fees, and LFD are exposed to whichever downstream system needs them
+  (dashboard, alerts, customer emails). Do not migrate without wiring these up. They
+  are the reason to do this properly.
+- FourKites dependency, env vars, and dead code are gone from the repo.
+
+# Ask me before you
+
+- Choose between the webhook path and the polling path. Default to webhooks unless our
+  infra makes an inbound HTTPS endpoint hard.
+- Change the shape of any function FourKites callers use today. Prefer a normalization
+  layer inside the Terminal49 client.
+- Add a new dependency. Prefer stdlib and what is already in the repo.
+- Touch anything outside the tracking integration.
 ```
 
 ## Getting help
@@ -488,6 +625,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/gnosisfreight.mdx
+++ b/docs/migrate/gnosisfreight.mdx
@@ -1,0 +1,692 @@
+---
+title: "Migrating from Gnosis Freight"
+sidebarTitle: "Gnosis Freight"
+description: "Map Gnosis Freight's Container Lifecycle Management (CLM) Platform fields, OAuth2 auth, and container polling to their Terminal49 equivalents. Includes authentication, request mapping, and migration checklist."
+---
+
+If you have Gnosis Freight's CLM platform in production, this page maps it onto Terminal49 field by field, so you can cut over without reverse-engineering our schema.
+
+There is no compatibility shim. You will change your request code and your response parsing. Gnosis and Terminal49 both track ocean containers through terminals and rail, so most of the work is a rename and reshape, not a redesign.
+
+## Start in sixty seconds
+
+Signing up and getting a key is self-serve.
+
+<Steps>
+  <Step title="Create an account">
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
+  </Step>
+  <Step title="Generate an API key">
+    Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
+  </Step>
+  <Step title="Make your first request">
+    ```bash
+    curl -X POST https://api.terminal49.com/v2/tracking_requests \
+      -H "Content-Type: application/vnd.api+json" \
+      -H "Authorization: Token YOUR_API_KEY" \
+      -d '{
+        "data": {
+          "type": "tracking_request",
+          "attributes": {
+            "request_number": "YOUR_BOL_NUMBER",
+            "request_type": "bill_of_lading",
+            "scac": "MAEU"
+          }
+        }
+      }'
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+  The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
+</Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
+
+<Tip>
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
+</Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
+
+## The architectural shift
+
+Gnosis's CLM platform (tracking engine "Marlo") and Terminal49 both integrate with ocean carriers, terminals, and rail. The difference is in how you fetch the result and how much of the operational picture arrives already computed for you.
+
+<CardGroup cols={2}>
+  <Card title="Before: Gnosis Freight" icon="rotate">
+    Get an OAuth2 token via POST /api/auth/token. Create a tracking request via POST /api/v1/tracking\_requests/ with an array of MBL numbers. Poll GET /api/v1/containers/ for state, or read a separate webhook schema for push updates.
+  </Card>
+
+  <Card title="After: Terminal49" icon="webhook">
+    POST /tracking\_requests once, per bill of lading. Terminal49 polls carriers, terminals, and rail, then POSTs to your endpoint as things change. Container objects carry holds, fees, and last free day directly.
+  </Card>
+</CardGroup>
+
+The biggest mechanical change is the tracking request shape: Gnosis accepts an array of MBL numbers in one call, while Terminal49 takes one bill of lading, booking, or container number per tracking request. If you batch MBLs today, you will loop over that array and issue one request per number.
+
+## Quick comparison
+
+|  | Gnosis Freight | Terminal49 |
+| --- | --- | --- |
+| Tracking model | Create tracking request, then poll or receive push updates | Register once, then push or poll |
+| Authentication | OAuth2 password grant, `Bearer` token | `Authorization: Token` header |
+| Base URL | `https://api.freight.fyi` | `https://api.terminal49.com/v2` |
+| Content type | `application/json` | `application/vnd.api+json` |
+| Response format | Custom JSON, paginated container list | JSON:API |
+| Webhooks | Schema published, dictionary of field names and types | 30\+ named events, HMAC-signed |
+| Carrier identification | Inferred from MBL number | `scac`, or `auto_detect_vocc_scac` |
+| Modes covered | Ocean, rail, air, customs, drayage execution | Ocean and rail |
+| Fee prediction | Predictive amounts (`gnosis_estimated_*` fields) | Terminal-reported amounts only, no prediction |
+| Getting an API key | Issued by an account rep or via the CLM portal | Self-serve |
+
+## Authentication
+
+Gnosis uses an OAuth2 password grant: exchange a username and password for a bearer token, then send that token on every request. Terminal49 uses a static API key sent as a token, with no separate token-exchange step.
+
+<CodeGroup>
+
+```bash Gnosis Freight
+# Step 1: get a token
+curl -X POST https://api.freight.fyi/api/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=YOUR_USERNAME&password=YOUR_PASSWORD"
+
+# Step 2: use it
+curl -X POST https://api.freight.fyi/api/v1/tracking_requests/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{"mbl_numbers": ["MRKU9465770"]}'
+```
+
+```bash Terminal49
+curl -X POST https://api.terminal49.com/v2/tracking_requests \
+  -H "Content-Type: application/vnd.api+json" \
+  -H "Authorization: Token YOUR_T49_KEY" \
+  -d '{"data":{"type":"tracking_request","attributes":{
+       "request_number":"MRKU9465770",
+       "request_type":"bill_of_lading"}}}'
+```
+
+</CodeGroup>
+
+<Note>
+  Note the prefix. Gnosis uses `Bearer`. Terminal49 uses `Token`.
+</Note>
+
+Gnosis tokens are issued from a username and password, and (depending on how your account is configured) may expire and need refreshing. Terminal49 API keys are static: generate one in the dashboard and use it until you rotate it yourself. There is no token-refresh flow to build.
+
+## Request parameter mapping
+
+| Gnosis Freight parameter | Terminal49 equivalent | Notes |
+| --- | --- | --- |
+| `mbl_numbers` (array) | `request_number` + `request_type: "bill_of_lading"` | Terminal49 takes one identifier per tracking request, not an array. Loop over your MBL array and issue one `POST /tracking_requests` per number. |
+| Carrier detected automatically from MBL | `scac`, or `auto_detect_vocc_scac: true` | Terminal49 can also infer the SCAC when you set `auto_detect_vocc_scac: true`, or by calling [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first. Auto-detection is asynchronous; a failed inference fails the tracking request with `scac_auto_detect_failed`. |
+| `organization_uuid` query param | Not applicable | Terminal49 scopes tracking requests to your account by API key; there is no separate organization identifier to pass. |
+| Booking, per-container, and air variants of create tracking request | `request_type: "booking"` or `request_type: "container"` for ocean; no air equivalent | Container-number tracking requests are currently in beta. Air cargo has no Terminal49 equivalent. |
+| Polling `GET /api/v1/containers/` | `POST /v2/webhooks`, or `GET /v2/containers` | Register a webhook to be notified of changes instead of polling, or keep polling if that fits your architecture better. |
+| Re-poll a specific container | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute. |
+
+<Note>
+  Gnosis's `POST /api/v1/tracking_requests/` accepts multiple MBL numbers in a single call and returns one tracking request per number internally. Terminal49's `POST /v2/tracking_requests` is one call per bill of lading, booking, or container. Track by BOL and we return every container on that bill of lading as related container resources.
+</Note>
+
+## Response field mapping
+
+Terminal49 is JSON:API compliant, so relationships between shipments, containers, ports, and terminals are explicit rather than something you reassemble from ID references. Gnosis returns a flat, paginated container list from `GET /api/v1/containers/` (`{metadata, containers: [...]}`); Terminal49 splits the same information across shipment, container, port, and terminal resources.
+
+Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to sideload related resources in one call instead of chasing IDs.
+
+### Shipment level
+
+| Gnosis Freight | Terminal49 |
+| --- | --- |
+| `mbl` / `mbls` | `shipment.attributes.bill_of_lading_number` |
+| Carrier inferred from MBL | `shipment.attributes.shipping_line_scac`, `shipment.attributes.shipping_line_name` |
+| `por_locode`, `por_city` | `shipment.relationships.port_of_lading` (place of receipt, where applicable) |
+| `pol_locode`, `pol_city` | `shipment.relationships.port_of_lading` |
+| `pod_locode`, `pod_city` | `shipment.relationships.port_of_discharge` |
+| `vessel_eta_dt` | `shipment.attributes.pod_eta_at` |
+| `gnosis_vessel_eta_dt` (predictive ETA) | No equivalent. Terminal49 does not publish a separate predictive ETA field. |
+| `vessel_ata_dt` | `shipment.attributes.pod_ata_at` |
+| `mother_vessel` / `mother_vessel_imo` | `shipment.attributes.pod_vessel_name` / `pod_vessel_imo` |
+| `mother_voyage` | Not returned as a discrete voyage-number field |
+| `current_vessel`, `first_vessel` | Not applicable — Terminal49 exposes the vessel active for the current leg via [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events) rather than named "current"/"first" vessel fields |
+| `transshipments` | [Transshipment transport events](/api-docs/webhooks/event-catalog) (arrived, discharged, loaded, departed) |
+| `barge_journeys` | [Feeder vessel transport events](/api-docs/webhooks/event-catalog) (arrived, discharged, loaded, departed) |
+
+### Container level
+
+| Gnosis Freight | Terminal49 |
+| --- | --- |
+| `container_number` | `container.attributes.number` |
+| `uuid` | `container.id` |
+| `container_journey_start_key` | No direct equivalent |
+| `container_status` (e.g. "At Origin", "On the Water", "Awaiting Discharge") | `container.attributes.current_status` (Terminal49's own status values — see [Container Statuses](/api-docs/in-depth-guides/container-statuses)) |
+| `tracking` (bool) | Whether the parent tracking request or shipment is active; see `shipment.attributes.tracked` and [stop/resume tracking](/api-docs/api-reference/shipments/stop-tracking-shipment) |
+| `available_for_pickup` (bool) | `container.attributes.available_for_pickup` — same name, same boolean |
+| Equipment size/type (not itemized in the verified field list) | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+
+<Note>
+  Terminal49 normalizes equipment into three fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you parse a combined size/type code from Gnosis today, you can delete that parsing step.
+</Note>
+
+### Locations, facilities, and vessels
+
+| Gnosis Freight | Terminal49 |
+| --- | --- |
+| `pol_locode` / `pod_locode` / `por_locode` | `port.attributes.code` on the relevant port relationship |
+| `pol_city` / `pod_city` / `por_city` | `port.attributes.name` |
+| `pol_terminal_name` | `terminal.attributes.name` on `port_of_lading_terminal` |
+| `pod_terminal_name` (with FIRMS code) | `terminal.attributes.name` \+ `terminal.attributes.firms_code` on `pod_terminal` |
+| Terminal SMDG code (not in Gnosis's verified field list) | `terminal.attributes.smdg_code` |
+| Terminal BIC facility code (not in Gnosis's verified field list) | `terminal.attributes.bic_facility_code` |
+| `mother_vessel` / `mother_vessel_imo` | `shipment.attributes.pod_vessel_name` / `pod_vessel_imo` |
+| Vessel MMSI, call sign, position | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) for MMSI and position; call sign is not returned |
+
+## Milestone and event mapping
+
+Gnosis exposes milestones as dated fields on the container object (`loaded_on_vessel_dt`, `discharged_dt`, and so on) plus a separate webhook schema endpoint. Terminal49 exposes the same milestones as normalized transport events and pushes each one to your webhook.
+
+| Gnosis Freight field | Milestone | Terminal49 event |
+| --- | --- | --- |
+| `loaded_on_vessel_dt` | Loaded on vessel at origin | `container.transport.vessel_loaded` |
+| Vessel departure | Vessel departed origin | `container.transport.vessel_departed` |
+| `vessel_ata_dt` | Vessel arrived at destination | `container.transport.vessel_arrived` |
+| `discharged_dt` | Discharged from vessel | `container.transport.vessel_discharged` |
+| `available_for_pickup` flipping true | Available for pickup | `container.transport.available` |
+| `available_for_pickup` flipping false | No longer available for pickup | `container.transport.not_available` |
+| `is_railing` / `loaded_on_rail_dt` | Loaded onto rail car | `container.transport.rail_loaded` |
+| Rail departure | Rail car departed | `container.transport.rail_departed` |
+| `rail_ata_dt` | Rail car arrived | `container.transport.rail_arrived` |
+| `rail_discharged_dt` | Container unloaded from rail car | `container.transport.rail_unloaded` |
+| `rail_notify_dt` | Arrived at final inland destination | `container.transport.arrived_at_inland_destination` |
+| `customs_clearance_dt` | No direct transport-event equivalent. See the `customs` entry on `holds_at_pod_terminal` for a hold-based signal instead. | — |
+
+Terminal49 also emits milestones Gnosis's verified field list has no equivalent for:
+
+- **Empty picked up / returned:** `container.transport.empty_out` and `.empty_in`
+- **Full gated in / out:** `container.transport.full_in` and `.full_out`
+- **Vessel berthed:** `container.transport.vessel_berthed`
+- **Transshipment:** arrived, discharged, loaded, departed
+- **Feeder vessel and barge:** arrived, discharged, loaded, departed
+- **ETA changes:** `container.transport.estimated.vessel_arrived`, `shipment.estimated.arrival`
+
+See the full [event catalog](/api-docs/webhooks/event-catalog).
+
+### Registering a webhook
+
+Gnosis publishes its webhook shape as a schema dictionary at `GET /api/v1/webhooks/containers/webhook_schema`, which you inspect and subscribe to out of band. Terminal49 webhooks are self-service: register a URL and a list of named events directly.
+
+```bash
+curl -X POST https://api.terminal49.com/v2/webhooks \
+  -H "Content-Type: application/vnd.api+json" \
+  -H "Authorization: Token YOUR_API_KEY" \
+  -d '{
+    "data": {
+      "type": "webhook",
+      "attributes": {
+        "url": "https://your-endpoint.example.com/t49",
+        "active": true,
+        "events": [
+          "container.transport.vessel_discharged",
+          "container.transport.available",
+          "container.pickup_lfd.changed"
+        ]
+      }
+    }
+  }'
+```
+
+Payloads are HMAC-signed. See [webhook setup](/api-docs/in-depth-guides/webhooks) for signature verification, and [List webhook IPs](/api-docs/api-reference/webhooks/list-webhook-ips) if your firewall restricts inbound traffic.
+
+## What you gain
+
+This is the part worth reading even if the rest is mechanical. Terminal49 integrates with terminals directly, and normalizes holds, fees, and last free day into a fixed shape you don't have to reconcile yourself.
+
+### Holds
+
+`holds_at_pod_terminal` is an array of active holds blocking pickup:
+
+```json
+{
+  "holds_at_pod_terminal": [
+    { "name": "customs", "status": "hold", "description": "CBP HOLD" },
+    { "name": "freight", "status": "hold", "description": null }
+  ]
+}
+```
+
+Hold names are `freight`, `customs`, `USDA`, `VACIS`, `TMF`, and `other`. Status is `hold` or `pending`. When a hold clears, the object is removed from the array. There is no released state.
+
+<Warning>
+  Hold names are case-sensitive. `USDA`, `VACIS`, and `TMF` are uppercase; `freight`, `customs`, and `other` are lowercase. Match exactly.
+</Warning>
+
+Gnosis's `holds` object is a dictionary of hold types where a `true` value means the container is held by that party. Terminal49's shape is an array of objects, one per active hold, each carrying a name, a status, and a description. Rewrite any code that checks `holds.customs === true` to instead check whether an entry with `name: "customs"` exists in the array.
+
+### Fees
+
+`fees_at_pod_terminal` carries type, amount, and currency:
+
+```json
+{
+  "fees_at_pod_terminal": [
+    { "type": "demurrage", "amount": 850.00, "currency_code": "USD" },
+    { "type": "exam", "amount": 450.00, "currency_code": "USD" }
+  ]
+}
+```
+
+Fee types are `demurrage`, `extended_dwell_time`, `exam`, `total`, and `other`.
+
+<Warning>
+  Some terminals report a `total` line item alongside individual fees. Filter it out before summing or you will double-count.
+</Warning>
+
+Gnosis's `demurrage_amount` maps to a `demurrage` entry in `fees_at_pod_terminal`. Gnosis also publishes predictive fields — `gnosis_estimated_demurrage_amount`, `gnosis_estimated_detention_amount`, and `gnosis_estimated_next_day_demurrage_amount` — that project charges before the terminal reports them. Terminal49 has no equivalent: `fees_at_pod_terminal` only reports amounts the terminal has actually posted. If your workflow depends on predictive fee amounts, budget time to either drop that logic or replace it with your own estimate.
+
+### Last free day
+
+`pickup_lfd` is a coalesced value that follows a fixed source priority: shipping line, then terminal, then rail. It does not pick the earliest date. The individual sources are available separately on `import_deadlines`:
+
+- `pickup_lfd_line`: the shipping line's LFD (per diem deadline) — the Terminal49 equivalent of Gnosis's `last_free_detention_day_dt`
+- `pickup_lfd_terminal`: the terminal's LFD (demurrage deadline) — the equivalent of Gnosis's `last_free_demurrage_day_dt`
+- `pickup_lfd_rail`: the rail carrier's LFD at the inland destination
+
+Each has its own webhook event, so you can alert on whichever source your operation cares about. Gnosis's `gnosis_estimated_last_free_demurrage_day_dt` is a predictive estimate; Terminal49 has no equivalent, since `import_deadlines` only carries dates the terminal or line has actually published.
+
+### Release readiness
+
+Two fields answer "can I pick this up?" `available_for_pickup` and the holds array:
+
+```javascript
+function isReadyForPickup(container) {
+  const { available_for_pickup, holds_at_pod_terminal } = container.attributes;
+  const hasActiveHolds = holds_at_pod_terminal.some(h => h.status === 'hold');
+  return available_for_pickup === true && !hasActiveHolds;
+}
+```
+
+Gnosis's `available_for_pickup` field is a straight match — same name, same boolean. The difference is what you check alongside it: swap a dictionary lookup on `holds` for an array scan on `holds_at_pod_terminal`.
+
+Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
+
+<Info>
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
+</Info>
+
+## Gotchas that will bite you
+
+<AccordionGroup>
+  <Accordion title="MBL arrays become one tracking request per number" icon="layer-group">
+    Gnosis's `POST /api/v1/tracking_requests/` accepts an array of `mbl_numbers` in a single call. Terminal49's `POST /v2/tracking_requests` takes one `request_number` per call. If you currently batch MBLs, loop over the array and fire one request per bill of lading; store the returned `tracking_request.id` per number, not per batch.
+  </Accordion>
+
+  <Accordion title="OAuth2 token exchange goes away" icon="key">
+    Gnosis requires exchanging a username and password for a bearer token before every session (and refreshing it as needed). Terminal49 API keys are static — generate one, send it as `Authorization: Token YOUR_API_KEY`, and delete the token-refresh logic entirely.
+  </Accordion>
+
+  <Accordion title="JSON:API response shape" icon="code">
+    Gnosis returns a flat `{metadata, containers: [...]}` list. Terminal49 relationships are ID references into an `included` array. Use a JSON:API client library, or use `include` to sideload exactly what you need. Parsing raw JSON works but you will write more code than you expect.
+  </Accordion>
+
+  <Accordion title="Holds go from a boolean map to an array" icon="fingerprint">
+    Gnosis's `holds` object marks each hold type `true` or `false`. Terminal49's `holds_at_pod_terminal` is an array containing only the holds currently active, each with a name, status, and description. Rewrite `holds.customs === true` checks as array-membership checks.
+  </Accordion>
+
+  <Accordion title="Timestamps are UTC with a separate timezone field" icon="clock">
+    Terminal49 stores event timestamps in UTC and returns the matching IANA timezone alongside. Convert for display rather than assuming local time. See [Event Timestamps](/api-docs/in-depth-guides/event-timestamps).
+  </Accordion>
+
+  <Accordion title="Empty arrays are the normal state" icon="brackets-square">
+    `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` mean no active holds or fees. This is the common case. Do not treat it as missing data.
+  </Accordion>
+
+  <Accordion title="container.updated carries a changeset" icon="code-compare">
+    Terminal changes (fees, holds, LFD, appointment, availability) arrive on `container.updated` with a `changeset` showing old value first, new value second. Use it instead of diffing state yourself, the way you might diff two `GET /api/v1/containers/` polls today.
+  </Accordion>
+
+  <Accordion title="Async lifecycle" icon="hourglass-half">
+    `POST /tracking_requests` returns immediately with a pending status. The shipment appears once the carrier responds. Subscribe to `tracking_request.succeeded`, `tracking_request.failed`, and `tracking_request.awaiting_manifest` rather than expecting shipment data in the creation response. See [Tracking Request Lifecycle](/api-docs/in-depth-guides/tracking-request-lifecycle).
+  </Accordion>
+</AccordionGroup>
+
+## Error handling
+
+Gnosis returns a `422 HTTPValidationError` with an array of validation details (location, message, type) for malformed requests. Terminal49 uses standard HTTP status codes consistently across every endpoint.
+
+| Status | Meaning |
+| --- | --- |
+| 400 | Malformed request or failed validation |
+| 401 | Missing or invalid API key |
+| 403 | Key lacks permission, or the feature is not enabled on your plan |
+| 404 | Resource does not exist |
+| 422 | Valid syntax, rejected content. For example, a malformed container number |
+| 429 | Rate limited. See [Rate Limiting](/api-docs/in-depth-guides/rate-limiting) |
+| 5xx | Terminal49 or an upstream carrier or terminal is unavailable |
+
+Rough equivalence for the Gnosis errors you are handling today:
+
+| Gnosis Freight | Terminal49 |
+| --- | --- |
+| Invalid or expired OAuth2 token | HTTP 401 |
+| `422 HTTPValidationError` (bad MBL format, missing field) | HTTP 400 or 422 |
+| Carrier not supported | HTTP 422 |
+| No data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Temporary unavailability | Not surfaced. We retry internally. |
+
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
+
+## Where we are narrower than Gnosis Freight
+
+Worth knowing before you commit.
+
+**No air cargo tracking.** Gnosis's CLM platform covers air cargo alongside ocean and rail. Terminal49 tracks ocean containers and their rail legs only. If your integration depends on air shipment visibility, this migration handles only the ocean and rail portion.
+
+**No drayage execution features.** Gnosis is built as an execution platform with import drayage workflows (`import_drayage`). Terminal49 is a tracking and visibility API — it tells you what happened and what's next, but it does not book, dispatch, or execute drayage moves.
+
+**No customs milestone tracking.** Gnosis exposes customs milestones and a `customs_clearance_dt` field directly. Terminal49 has no direct equivalent beyond the `customs` entry on `holds_at_pod_terminal`, which tells you whether a customs hold is currently blocking pickup, not a full customs event timeline.
+
+**No predictive fee or ETA estimates.** Gnosis publishes `gnosis_estimated_*` fields for demurrage, detention, next-day demurrage, and LFD, plus a `gnosis_vessel_eta_dt` predictive ETA. Terminal49 reports what carriers and terminals have actually posted — `pod_eta_at`, `fees_at_pod_terminal`, and `import_deadlines` — and does not predict future values.
+
+**Carrier count.** Terminal49 integrates directly with 36 ocean carriers, plus 2 more enabled on request, as of 14 August 2026. Check your carrier mix against the [ocean carrier list](/coverage/ocean-carriers) before cutover, and read the known issues section there. We publish the per-carrier field gaps.
+
+**Terminal data is North America.** Holds, fees, LFD, and availability come from direct terminal integrations concentrated in the US and Canada, with European ports expanding. Ocean milestones work globally; terminal-level operational data does not yet.
+
+**Some fields are source-dependent.** Seal number, container weight, and departure or arrival events vary by carrier. The [field availability reference](/coverage/fields) says which fields are always present and which depend on the carrier, terminal, or journey.
+
+## Migration checklist
+
+Everyone does the base path. Then pick a branch.
+
+### Base path
+
+<Steps>
+  <Step title="Get a key">
+    Self-serve at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys). Copy it immediately, it is shown once.
+  </Step>
+  <Step title="Switch authentication">
+    Drop the OAuth2 password-grant token exchange. Move to `Authorization: Token`, a single static key.
+  </Step>
+  <Step title="Check your carrier mix">
+    Compare your Gnosis-tracked carriers against the [carrier list](/coverage/ocean-carriers). Flag anything missing before you cut over.
+  </Step>
+  <Step title="Unbatch your MBL arrays">
+    Replace one call with an array of `mbl_numbers` with one `POST /tracking_requests` per bill of lading, booking, or container.
+  </Step>
+  <Step title="Handle the async lifecycle">
+    Tracking requests start pending. Handle `succeeded`, `failed`, and `awaiting_manifest` rather than expecting data on creation.
+  </Step>
+  <Step title="Update response parsing">
+    JSON:API structure, split equipment fields, UTC timestamps with a separate timezone, holds as an array instead of a boolean map.
+  </Step>
+  <Step title="Update error handling">
+    Replace `422 HTTPValidationError` envelope parsing with HTTP status-code checks.
+  </Step>
+  <Step title="Backfill active shipments">
+    Submit tracking requests for everything currently in transit. Send us the list if it is large and we will load it.
+  </Step>
+  <Step title="Decide what to do about predictive fields">
+    Gnosis's `gnosis_estimated_*` amounts and ETA have no Terminal49 equivalent. Decide whether to drop that logic or replace it with your own estimate before cutover.
+  </Step>
+</Steps>
+
+### Then pick one
+
+<Tabs>
+  <Tab title="Webhook path">
+    <Steps>
+      <Step title="Expose an HTTPS endpoint">
+        Accept our POST payloads at a public URL.
+      </Step>
+      <Step title="Register a webhook">
+        Subscribe only to events you act on.
+      </Step>
+      <Step title="Verify HMAC signatures">
+        Reject any payload whose signature does not match.
+      </Step>
+      <Step title="Whitelist our IPs">
+        Only needed if your firewall restricts inbound traffic.
+      </Step>
+      <Step title="Trigger a test delivery">
+        Confirm end-to-end before going live.
+      </Step>
+      <Step title="Retire your polling job">
+        Remove the loop that called `GET /api/v1/containers/` on a schedule.
+      </Step>
+    </Steps>
+
+    See [webhook best practices](/api-docs/webhooks/best-practices) for retries and idempotency.
+  </Tab>
+  <Tab title="Polling path">
+    <Steps>
+      <Step title="Store the IDs">
+        Keep the tracking request ID and shipment ID from the creation response.
+      </Step>
+      <Step title="Repoint your scheduler">
+        Point it at `GET /v2/shipments` or `GET /v2/containers` instead of `GET /api/v1/containers/`.
+      </Step>
+      <Step title="Keep your existing cadence">
+        No change to how often you poll.
+      </Step>
+    </Steps>
+
+    Skipped: endpoint setup, signature verification, IP whitelisting, delivery testing.
+
+    <Tip>
+      Terminal data changes on a cadence polling tends to miss. If you only adopt webhooks for one thing, make it `container.updated` and `container.pickup_lfd.changed`.
+    </Tip>
+  </Tab>
+</Tabs>
+
+## Migrate with an AI coding agent
+
+If you use Cursor, Claude Code, Windsurf, Copilot, or another AI coding assistant, hand it the prompt below. It is written to run a **side-by-side migration**: the agent stands up a Terminal49 client next to your existing Gnosis Freight code, shadows every Gnosis call with a Terminal49 call, diffs the responses, and only cuts over once parity is proven.
+
+<Tip>
+  Point your agent at this page as context (paste the URL or add it as a doc source). The prompt references the mappings above, so the more of this page the agent can see, the better it does.
+</Tip>
+
+<AccordionGroup>
+  <Accordion title="How to use this prompt" icon="wand-magic-sparkles">
+    1. Open your repo in your AI coding tool.
+    2. Add this page as a documentation source, or paste its URL into the chat.
+    3. Copy the prompt below into a new chat and send it.
+    4. Answer the agent's discovery questions (Gnosis client location, env var names, carrier mix).
+    5. Review each PR the agent opens. It should ship in small, reviewable steps: client, shadow, parity harness, cutover, cleanup.
+  </Accordion>
+
+  <Accordion title="What the agent will produce" icon="list-check">
+    - A `Terminal49Client` alongside your existing `GnosisClient`, sharing the same interface where possible.
+    - A shadow-mode wrapper that calls both providers and logs response diffs without changing behavior.
+    - A parity report per shipment: matched fields, diverged fields, and Terminal49-only fields (holds, fees, LFD).
+    - A feature-flagged cutover: route reads to Terminal49, keep Gnosis as fallback until you flip the flag off.
+    - A webhook receiver with HMAC verification, or a polling scheduler, depending on which path you pick.
+    - A cleanup PR that removes Gnosis code, env vars, the OAuth2 token-refresh logic, dependencies, and dedupe logic.
+  </Accordion>
+</AccordionGroup>
+
+### The prompt
+
+Copy this into your agent. Replace the bracketed placeholders in the **Repo context** block before sending.
+
+```markdown Terminal49 migration agent prompt expandable icon=robot wrap
+You are migrating this codebase from the Gnosis Freight CLM API to the Terminal49 API,
+side by side. Terminal49's authoritative migration guide is at
+https://terminal49.com/docs/migrate/gnosisfreight. Use it as
+the source of truth for field mappings, event names, error codes, and behavior differences.
+
+# Repo context (fill this in before running)
+
+- Gnosis client lives at: [path/to/gnosis/client.ts]
+- Gnosis is called from: [list the call sites or "find them"]
+- Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
+- Storage for tracking state: [e.g. Postgres table `shipments`]
+- Current polling schedule: [e.g. cron every 2h via BullMQ]
+- Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
+- Deployment target: [e.g. AWS ECS, Vercel, Fly.io]
+- Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
+
+# Rules
+
+1. Do not delete Gnosis code until the cleanup step. Migration is side by side.
+2. Ship in small PRs. Each PR must build, pass tests, and be independently revertable.
+3. Never invent Terminal49 fields, endpoints, or event names. If the guide does not
+   confirm a mapping, ask me. Do not guess.
+4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`, and no OAuth2 token
+   exchange) and content type `application/vnd.api+json`. Get this right on the first
+   request.
+5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
+   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
+   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+6. Terminal49 accepts one bill of lading, booking, or container number per tracking
+   request, not an array like Gnosis's `mbl_numbers`. Loop over any batch and issue one
+   request per number.
+7. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
+8. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
+   not missing data. A fee `amount` of 0 is valid. Holds are an array of active holds,
+   not a boolean dictionary like Gnosis's `holds` object.
+9. On `container.updated`, prefer the `changeset` over diffing state yourself.
+10. Terminal49 has no equivalent for Gnosis's `gnosis_estimated_*` predictive fee and
+    ETA fields, air cargo tracking, drayage execution, or customs milestone timelines.
+    Do not attempt to fake these — flag them to me if the app depends on them.
+
+# Plan (execute in order, one PR per step)
+
+## PR 1 — Discovery and interface
+
+- Grep the repo for every Gnosis call site. List them in the PR description.
+- Extract the Gnosis client's public surface into an interface
+  (`TrackingProvider` with methods like `track(number, type, scac)`,
+  `getShipment(id)`, `refresh(id)`).
+- Make the existing Gnosis client implement it. No behavior change.
+
+## PR 2 — Terminal49 client
+
+- Add a `Terminal49Client` implementing the same `TrackingProvider` interface.
+- Auth via `T49_API_KEY` env var, header `Authorization: Token ${key}`. No token
+  exchange, no refresh logic.
+- Base URL `https://api.terminal49.com/v2`, content type `application/vnd.api+json`.
+- Implement:
+  - `createTrackingRequest({ request_number, request_type, scac })` returning the
+    tracking request ID. Call this once per MBL number, not once per batch.
+  - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
+  - `getContainer(id)`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
+- Normalize responses to the same shape Gnosis callers expect today, using the field
+  mapping from the guide. Convert Gnosis's `holds` boolean map into array-membership
+  checks against `holds_at_pod_terminal`. Convert timestamps to UTC + `time_zone`.
+- Map errors to typed classes: `AuthenticationError` (401), `AuthorizationError` (403),
+  `ValidationError` (400/422), `RateLimitError` (429), `UpstreamError` (5xx),
+  `FeatureNotEnabledError` (403 + feature flag response).
+- Add unit tests using recorded fixtures. Do not hit the live API in tests.
+
+## PR 3 — Shadow mode
+
+- Add a `ShadowProvider` that wraps both clients. On every read:
+  - Call Gnosis as the primary. Return its response.
+  - Fire-and-forget a Terminal49 call for the same identifier.
+  - Log a structured diff: matched fields, diverged fields, T49-only fields.
+- Gate with env var `TRACKING_SHADOW_MODE=true`. Off by default.
+- Add a parity report script that aggregates shadow logs by SCAC and field.
+- Do NOT change what callers see. This step is observation only.
+
+## PR 4 — Backfill script
+
+- Write a one-shot script that reads all active shipments from our database and calls
+  `POST /tracking_requests` for each (one per BOL, booking, or container — unbatch any
+  MBL arrays).
+- Store the returned `tracking_request.id` and eventual `shipment.id` on our records.
+- Rate-limit to respect Terminal49's limits (handle 429 with exponential backoff).
+- Idempotent: safe to re-run. Skip rows already backfilled.
+
+## PR 5 — Webhook receiver (only if we picked the webhook path)
+
+- Add `POST /webhooks/terminal49` endpoint.
+- Verify HMAC signature using the shared secret from `T49_WEBHOOK_SECRET`. Reject on
+  mismatch with 401.
+- Handle these events at minimum:
+  - `tracking_request.succeeded`, `tracking_request.failed`, `tracking_request.awaiting_manifest`
+  - `container.transport.vessel_discharged`, `container.transport.available`,
+    `container.transport.full_out`
+  - `container.updated` (use the `changeset`, do not diff)
+  - `container.pickup_lfd.changed`
+- Persist events idempotently keyed by event ID.
+- Register the webhook via `POST /v2/webhooks` from a bootstrap script, subscribing
+  only to events we handle.
+- If our firewall restricts inbound traffic, whitelist Terminal49 IPs from
+  `GET /v2/webhooks/ips`.
+
+## PR 6 — Cutover behind a flag
+
+- Add feature flag `TRACKING_PROVIDER` with values `gnosis` (default) and `terminal49`.
+- Route all reads through the flag. Gnosis stays available as a fallback for one
+  release cycle.
+- Flip staging to `terminal49`, verify parity report is clean, then flip production.
+
+## PR 7 — Cleanup
+
+- Delete `GnosisClient`, its tests, its env vars, its OAuth2 token-refresh logic, its
+  dedupe cache, and any equipment-code parsing helpers Terminal49 makes redundant.
+- Remove the shadow provider and the feature flag.
+- Update README and any runbooks. Note the new webhook endpoint if applicable.
+
+# Definition of done
+
+- All Gnosis call sites now go through Terminal49.
+- Webhook (or polling) is live in production.
+- Parity report shows no unexplained divergences for our top 10 SCACs.
+- Holds, fees, and LFD are exposed to whichever downstream system needs them
+  (dashboard, alerts, customer emails). Do not migrate without wiring these up. They
+  are the reason to do this properly.
+- Any code depending on Gnosis's predictive fields, air cargo tracking, drayage
+  execution, or customs milestones has been explicitly reviewed with me — none of
+  these carry over automatically.
+- Gnosis dependency, env vars, and dead code are gone from the repo.
+
+# Ask me before you
+
+- Choose between the webhook path and the polling path. Default to webhooks unless our
+  infra makes an inbound HTTPS endpoint hard.
+- Change the shape of any function Gnosis callers use today. Prefer a normalization
+  layer inside the Terminal49 client.
+- Add a new dependency. Prefer stdlib and what is already in the repo.
+- Touch anything outside the tracking integration.
+
+Start with PR 1. Post the list of Gnosis call sites and the proposed
+`TrackingProvider` interface, and wait for my review before writing PR 2.
+```
+
+<Note>
+  The prompt is deliberately opinionated on side-by-side migration and small PRs. If your team prefers a big-bang cutover or a different branching model, edit the **Plan** section before sending it to your agent.
+</Note>
+
+## Getting help
+
+Send us your list of active container and bill of lading numbers and we will load them rather than making you script the backfill.
+
+If something in this mapping is wrong or incomplete, tell us. We would rather fix the page than have you work around it.
+
+<CardGroup cols={2}>
+  <Card title="API reference" icon="code" href="/api-docs/api-reference/introduction">
+    Every endpoint, with request and response schemas
+  </Card>
+
+  <Card title="TypeScript SDK" icon="rectangle-terminal" href="/sdk/introduction">
+    Typed client with retries and pagination built in
+  </Card>
+
+  <Card title="Coverage" icon="ship" href="/coverage/home">
+    Carriers, terminals, rail, and field availability
+  </Card>
+
+  <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
+    Simulate success and failure outcomes
+  </Card>
+</CardGroup>

--- a/docs/migrate/gnosisfreight.mdx
+++ b/docs/migrate/gnosisfreight.mdx
@@ -128,7 +128,7 @@ Gnosis tokens are issued from a username and password, and (depending on how you
 | `mbl_numbers` (array) | `request_number` + `request_type: "bill_of_lading"` | Terminal49 takes one identifier per tracking request, not an array. Loop over your MBL array and issue one `POST /tracking_requests` per number. |
 | Carrier detected automatically from MBL | `scac`, or `auto_detect_vocc_scac: true` | Terminal49 can also infer the SCAC when you set `auto_detect_vocc_scac: true`, or by calling [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first. Auto-detection is asynchronous; a failed inference fails the tracking request with `scac_auto_detect_failed`. |
 | `organization_uuid` query param | Not applicable | Terminal49 scopes tracking requests to your account by API key; there is no separate organization identifier to pass. |
-| Booking, per-container, and air variants of create tracking request | `request_type: "booking"` or `request_type: "container"` for ocean; no air equivalent | Container-number tracking requests are currently in beta. Air cargo has no Terminal49 equivalent. |
+| Booking, per-container, and air variants of create tracking request | `request_type: "booking_number"` or `request_type: "container"` for ocean; no air equivalent | Container-number tracking requests are currently in beta. Air cargo has no Terminal49 equivalent. |
 | Polling `GET /api/v1/containers/` | `POST /v2/webhooks`, or `GET /v2/containers` | Register a webhook to be notified of changes instead of polling, or keep polling if that fits your architecture better. |
 | Re-poll a specific container | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute. |
 
@@ -378,7 +378,7 @@ Rough equivalence for the Gnosis errors you are handling today:
 | Invalid or expired OAuth2 token | HTTP 401 |
 | `422 HTTPValidationError` (bad MBL format, missing field) | HTTP 400 or 422 |
 | Carrier not supported | HTTP 422 |
-| No data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| No data found | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | Temporary unavailability | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
@@ -466,8 +466,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers` instead of `GET /api/v1/containers/`.
@@ -543,8 +543,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
    exchange) and content type `application/vnd.api+json`. Get this right on the first
    request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Terminal49 accepts one bill of lading, booking, or container number per tracking
    request, not an array like Gnosis's `mbl_numbers`. Loop over any batch and issue one
    request per number.

--- a/docs/migrate/gocomet.mdx
+++ b/docs/migrate/gocomet.mdx
@@ -45,8 +45,12 @@ You do not need to talk to anyone to try this.
 </Warning>
 
 <Tip>
-  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -72,13 +76,13 @@ You can keep polling if you prefer. Point your existing scheduler at `GET /v2/sh
 | --- | --- | --- |
 | Tracking model | Poll on demand | Register once, then push or poll |
 | Authentication | API key via header | `Authorization: Token` header |
-| Base URL | `https://gocomet.com` | `https://api.terminal49.com/v2` |
+| Base URL | Your GoComet API endpoint | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Limited or none | 30\+ events, HMAC-signed |
-| Carrier identification | SCAC or carrier name | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | SCAC or carrier name | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Getting an API key | Self-serve | Self-serve |
 
@@ -89,7 +93,8 @@ Move from your provider's API key header format to ours.
 <CodeGroup>
 
 ```bash GoComet
-curl "https://gocomet.com/api/shipment-tracking" \
+# However your GoComet integration authenticates today, for example:
+curl "https://<your-gocomet-api-endpoint>/shipment-tracking" \
   -H "X-API-Key: YOUR_GOCOMET_KEY" \
   -H "Content-Type: application/json"
 ```
@@ -114,18 +119,18 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 
 | GoComet parameter | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| \[GoComet reference number field\] | `request_number` | Container number, BOL, or booking |
-| \[GoComet BOL type parameter\] | `request_type: "bill_of_lading"` | Master or house BOL |
-| \[GoComet container type parameter\] | `request_type: "container"` |  |
-| \[GoComet booking type parameter\] | `request_type: "booking_number"` |  |
-| \[GoComet carrier identifier field\] | `scac` | Same SCAC values for most carriers |
-| \[GoComet auto-detect parameter\] | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
-| \[GoComet force refresh parameter\] | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| \[GoComet route parameter\] | Always included | See [Routing](/api-docs/in-depth-guides/routing) |
-| \[GoComet API key header\] | `Authorization` header |  |
+| Reference number field | `request_number` | Container number, BOL, or booking |
+| BOL type parameter | `request_type: "bill_of_lading"` | Master or house BOL |
+| Container type parameter | `request_type: "container"` |  |
+| Booking type parameter | `request_type: "booking_number"` |  |
+| Carrier identifier field | `scac` | Same SCAC values for most carriers |
+| Auto-detect parameter | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| Force refresh parameter | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| Route parameter | `GET /v2/containers/{id}/map_geojson` — requires the Routing Data entitlement | See [Routing](/api-docs/in-depth-guides/routing) |
+| API key header | `Authorization` header |  |
 
 <Note>
-  Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources.
+  Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -138,45 +143,45 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 
 | GoComet | Terminal49 |
 | --- | --- |
-| \[GoComet BOL field\] | `shipment.attributes.bill_of_lading_number` |
-| \[GoComet carrier SCAC field\] | `shipment.attributes.shipping_line_scac` |
-| \[GoComet carrier name field\] | `shipment.attributes.shipping_line_name` |
-| \[GoComet shipment status field\] | Derived from container status and milestones |
-| \[GoComet origin place field\] | `shipment.attributes.port_of_lading_*` (place of receipt) |
-| \[GoComet POL field\] | `shipment.relationships.port_of_lading` |
-| \[GoComet POD field\] | `shipment.relationships.port_of_discharge` |
-| \[GoComet destination field\] | `shipment.relationships.destination` (inland) |
-| \[GoComet ETA field\] | `shipment.attributes.pod_eta_at` |
+| BOL field | `shipment.attributes.bill_of_lading_number` |
+| Carrier SCAC field | `shipment.attributes.shipping_line_scac` |
+| Carrier name field | `shipment.attributes.shipping_line_name` |
+| Shipment status field | Derived from container status and milestones |
+| Origin place field | `shipment.attributes.port_of_lading_*` (place of receipt) |
+| POL field | `shipment.relationships.port_of_lading` |
+| POD field | `shipment.relationships.port_of_discharge` |
+| Destination field | `shipment.relationships.destination` (inland) |
+| ETA field | `shipment.attributes.pod_eta_at` |
 
 ### Container level
 
 | GoComet | Terminal49 |
 | --- | --- |
-| \[GoComet container number field\] | `container.attributes.number` |
-| \[GoComet ISO code field\] | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| \[GoComet container size field\] | Same three fields above |
-| \[GoComet container status field\] | `container.attributes.current_status` |
-| \[GoComet container events field\] | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| Container number field | `container.attributes.number` |
+| ISO code field | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+| Container size field | Same three fields above |
+| Container status field | `container.attributes.current_status` |
+| Container events field | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  GoComet likely returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  GoComet likely returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
 
 | GoComet | Terminal49 |
 | --- | --- |
-| \[GoComet port name field\] | `port.attributes.name` |
-| \[GoComet port code field\] | `port.attributes.code` |
-| \[GoComet port lat/lng fields\] | `port.attributes.latitude` / `.longitude` |
-| \[GoComet port timezone field\] | `port.attributes.time_zone` |
-| \[GoComet port country field\] | `port.attributes.country_code` |
-| \[GoComet terminal name field\] | `terminal.attributes.name` |
-| \[GoComet terminal SMDG field\] | `terminal.attributes.smdg_code` |
-| \[GoComet terminal BIC field\] | `terminal.attributes.bic_code` |
-| \[GoComet vessel name field\] | `shipment.attributes.pod_vessel_name` |
-| \[GoComet vessel IMO field\] | `shipment.attributes.pod_vessel_imo` |
-| \[GoComet vessel MMSI field\] | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
+| Port name field | `port.attributes.name` |
+| Port code field | `port.attributes.code` |
+| Port lat/lng fields | `port.attributes.latitude` / `.longitude` |
+| Port timezone field | `port.attributes.time_zone` |
+| Port country field | `port.attributes.country_code` |
+| Terminal name field | `terminal.attributes.name` |
+| Terminal SMDG field | `terminal.attributes.smdg_code` |
+| Terminal BIC field | `terminal.attributes.bic_facility_code` |
+| Vessel name field | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO field | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI field | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
 
 ## Milestone and event mapping
 
@@ -184,12 +189,12 @@ GoComet returns a flat events array with event names or codes attached to each s
 
 | GoComet event | Milestone | Terminal49 event |
 | --- | --- | --- |
-| \[GoComet loaded event\] | Loaded on vessel at origin | `container.transport.vessel_loaded` |
-| \[GoComet departed event\] | Vessel departed origin | `container.transport.vessel_departed` |
-| \[GoComet arrived event\] | Vessel arrived at destination | `container.transport.vessel_arrived` |
-| \[GoComet discharged event\] | Discharged from vessel | `container.transport.vessel_discharged` |
-| \[GoComet gated out event\] | Gated out at destination | `container.transport.full_out` |
-| \[GoComet gated in event\] | Gated in at origin | `container.transport.full_in` |
+| Loaded event | Loaded on vessel at origin | `container.transport.vessel_loaded` |
+| Departed event | Vessel departed origin | `container.transport.vessel_departed` |
+| Arrived event | Vessel arrived at destination | `container.transport.vessel_arrived` |
+| Discharged event | Discharged from vessel | `container.transport.vessel_discharged` |
+| Gated out event | Gated out at destination | `container.transport.full_out` |
+| Gated in event | Gated in at origin | `container.transport.full_in` |
 | — | Empty picked up at origin | `container.transport.empty_out` |
 | — | Empty returned at destination | `container.transport.empty_in` |
 
@@ -294,7 +299,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Gotchas that will bite you
@@ -347,15 +352,15 @@ Rough equivalence for the GoComet errors you are handling today:
 
 | GoComet error | Terminal49 |
 | --- | --- |
-| \[GoComet invalid API key error\] | HTTP 401 |
-| \[GoComet insufficient permissions error\] | HTTP 403 |
-| \[GoComet rate limit error\] | HTTP 429 |
-| \[GoComet invalid parameter error\] | HTTP 400 or 422 |
-| \[GoComet unsupported carrier error\] | HTTP 422 |
-| \[GoComet no data found error\] | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
-| \[GoComet service unavailable error\] | Not surfaced. We retry internally. |
+| Invalid API key error | HTTP 401 |
+| Insufficient permissions error | HTTP 403 |
+| Rate limit error | HTTP 429 |
+| Invalid parameter error | HTTP 400 or 422 |
+| Unsupported carrier error | HTTP 422 |
+| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Service unavailable error | Not surfaced. We retry internally. |
 
-The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`) and retries rate-limit and server errors automatically with exponential backoff.
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
 ## Where we are narrower than GoComet
 
@@ -489,7 +494,7 @@ Copy this into your agent. Replace the bracketed placeholders in the **Repo cont
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
 You are migrating this codebase from the GoComet tracking API to the Terminal49 API,
 side by side. Terminal49's authoritative migration guide is at
-https://terminal49.com/docs/api-docs/getting-started/migrate-from-gocomet. Use it as
+https://terminal49.com/docs/migrate/gocomet. Use it as
 the source of truth for field mappings, event names, error codes, and behavior differences.
 
 # Repo context (fill this in before running)
@@ -539,7 +544,7 @@ the source of truth for field mappings, event names, error codes, and behavior d
     tracking request ID.
   - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
   - `getContainer(id)`.
-  - `refreshContainer(id)` mapping to `POST /v2/containers/{id}/refresh`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
 - Normalize responses to the same shape GoComet callers expect today, using the field
   mapping from the guide. Split `iso_code` into `equipment_type`, `equipment_length`,
   `equipment_height`. Convert timestamps to UTC + `time_zone`.
@@ -644,6 +649,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/gocomet.mdx
+++ b/docs/migrate/gocomet.mdx
@@ -12,11 +12,11 @@ There is no compatibility shim. You will change your request code and your respo
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Sign up at [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -43,6 +43,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 <Tip>
   If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.

--- a/docs/migrate/gocomet.mdx
+++ b/docs/migrate/gocomet.mdx
@@ -361,7 +361,7 @@ Rough equivalence for the GoComet errors you are handling today:
 | Rate limit error | HTTP 429 |
 | Invalid parameter error | HTTP 400 or 422 |
 | Unsupported carrier error | HTTP 422 |
-| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| No data found error | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | Service unavailable error | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
@@ -445,8 +445,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers`.
@@ -521,8 +521,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/home.mdx
+++ b/docs/migrate/home.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Migrate to Terminal49"
 sidebarTitle: "Overview"
-description: "Move your container tracking integration to Terminal49 from SeaRates, project44, FourKites, Vizion, OpenTrack, ShipsGo, GoComet, or Beacon in a weekend."
+description: "Move your container tracking integration to Terminal49 from SeaRates, project44, FourKites, Vizion, OpenTrack, ShipsGo, GoComet, Beacon, or Gnosis Freight in a weekend."
 ---
 
 Terminal49 integrates directly with 36\+ ocean carriers and North American terminals. If you are running another provider today, these guides map your current integration onto ours, field by field, so you can cut over without reverse-engineering our schema.
@@ -54,13 +54,17 @@ If you have ever had to explain a demurrage invoice to a customer, you already u
   <Card title="Beacon" icon="signal-stream" href="/migrate/beacon">
     Supply chain visibility. Replace shipment-level polling with per-container webhooks.
   </Card>
+
+  <Card title="Gnosis Freight" icon="container-storage" href="/migrate/gnosisfreight">
+    Container Lifecycle Management platform. Move MBL-based tracking and polling onto tracking requests and webhooks.
+  </Card>
 </CardGroup>
 
 ## What every migration has in common
 
 <Steps>
   <Step title="Self-serve an API key">
-    Create an account at [app.terminal49.com](https://app.terminal49.com) and generate a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys). The free Developer Key tracks up to 10 active containers, enough for a parity test. No call required.
+    Create an account at [app.terminal49.com](https://app.terminal49.com) and generate a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys). The free plan tracks up to 10 active containers, enough for a parity test. Creating tracking requests through the API is immediate; to read tracking data back through the API, ask us to enable the free 7-day API trial (same 10-container limit) via in-app chat or support@terminal49.com.
   </Step>
   <Step title="Register tracking requests once">
     `POST /v2/tracking_requests` per BOL, booking, or container. We poll the carrier, terminal, and rail sources on your behalf.

--- a/docs/migrate/home.mdx
+++ b/docs/migrate/home.mdx
@@ -182,8 +182,8 @@ or event names; if the docs do not confirm a mapping, ask me.
   `relationships`, and an `included` array.
 - Base URL is `https://api.terminal49.com/v2`.
 - Tracking is asynchronous: `POST /tracking_requests` returns pending; data arrives via
-  `tracking_request.succeeded` / `tracking_request.failed` / `awaiting_manifest`
-  webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+  `tracking_request.succeeded` / `tracking_request.failed` /
+  `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 - Timestamps are UTC with a separate IANA `time_zone` field.
 - `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state, not
   missing data.

--- a/docs/migrate/home.mdx
+++ b/docs/migrate/home.mdx
@@ -6,7 +6,7 @@ description: "Move your container tracking integration to Terminal49 from SeaRat
 
 Terminal49 integrates directly with 36\+ ocean carriers and North American terminals. If you are running another provider today, these guides map your current integration onto ours, field by field, so you can cut over without reverse-engineering our schema.
 
-Every guide covers the same ground: authentication, request and response mapping, event and webhook equivalents, error handling, the gotchas that will bite you, and a migration checklist. Each one also carries a prompt you can hand to Cursor, Claude Code, or Copilot to run the migration side by side.
+Every guide covers the same ground: authentication, request and response mapping, event and webhook equivalents, error handling, the gotchas that will bite you, and a migration checklist. Each one also carries a prompt you can hand to Claude Code, Codex, Cursor, or Copilot to run the migration side by side.
 
 ## Why we care so much about terminal data
 
@@ -72,6 +72,10 @@ If you have ever had to explain a demurrage invoice to a customer, you already u
     Holds, fees, last free day, release readiness. These are the reason to migrate rather than port like for like.
   </Step>
 </Steps>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The fields that change how your week goes
 
@@ -145,7 +149,79 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 
 ## Migrate with an AI coding agent
 
-Every provider page carries a copyable prompt that walks an AI coding assistant through a **side-by-side migration**: stand up a Terminal49 client next to your current provider, shadow every call, diff the responses, and cut over only once parity is proven. The prompts are opinionated about small PRs and reference the mappings on each page, so give your agent the page URL as context.
+Every provider page carries a copyable prompt that walks an AI coding assistant — Claude Code, Codex, Cursor, Copilot, or any agent that can read your repo — through a **side-by-side migration**: stand up a Terminal49 client next to your current provider, shadow every call, diff the responses, and cut over only once parity is proven. The prompts are opinionated about small PRs and reference the mappings on each page, so give your agent the page URL as context.
+
+Coming from a provider we have not written up? Use the generic version below and fill in the provider name.
+
+```markdown Terminal49 side-by-side migration prompt (generic) expandable icon=robot wrap
+You are migrating this codebase from our current container tracking provider,
+[PROVIDER], to the Terminal49 API, side by side. Terminal49's documentation is at
+https://terminal49.com/docs — use the API reference and the migration guides under
+https://terminal49.com/docs/migrate/home as the source of truth for field mappings,
+event names, error codes, and behavior. Never invent Terminal49 fields, endpoints,
+or event names; if the docs do not confirm a mapping, ask me.
+
+# Repo context (fill this in before running)
+
+- [PROVIDER] client lives at: [path/to/client]
+- [PROVIDER] is called from: [list the call sites or "find them"]
+- Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
+- Storage for tracking state: [e.g. Postgres table `shipments`]
+- Current polling schedule: [e.g. cron every 2h]
+- Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
+- Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
+
+# Terminal49 facts (do not deviate)
+
+- Auth header is `Authorization: Token <key>` — not `Bearer`.
+- Content type is `application/vnd.api+json`; responses are JSON:API with `data`,
+  `relationships`, and an `included` array.
+- Base URL is `https://api.terminal49.com/v2`.
+- Tracking is asynchronous: `POST /tracking_requests` returns pending; data arrives via
+  `tracking_request.succeeded` / `tracking_request.failed` / `awaiting_manifest`
+  webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+- Timestamps are UTC with a separate IANA `time_zone` field.
+- `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state, not
+  missing data.
+- On `container.updated`, use the `changeset` instead of diffing state yourself.
+
+# Plan (one small, revertable PR per step)
+
+1. Discovery: find every [PROVIDER] call site; extract the client's public surface into
+   a `TrackingProvider` interface; make the existing client implement it.
+2. Terminal49 client: implement the same interface against Terminal49
+   (`createTrackingRequest`, `getShipment` with `include=containers`, `getContainer`).
+   Normalize responses to the shape existing callers expect. Map errors to typed
+   classes by HTTP status (401, 403, 400/422, 404, 429, 5xx). Unit tests on recorded
+   fixtures only.
+3. Shadow mode: wrap both clients; [PROVIDER] stays primary; fire-and-forget the same
+   lookup against Terminal49 and log structured diffs. Add a parity report aggregated
+   by SCAC and field. No caller-visible changes.
+4. Backfill: one-shot idempotent script that creates a tracking request per active BOL,
+   booking, or container and stores the returned IDs.
+5. Webhooks (preferred) or polling: HMAC-verified receiver, idempotent event storage
+   keyed by event ID, registered via `POST /v2/webhooks` for only the events we handle.
+6. Cutover behind a `TRACKING_PROVIDER` feature flag; [PROVIDER] stays as fallback for
+   one release cycle; flip staging first, verify the parity report, then production.
+7. Cleanup: delete the [PROVIDER] client, env vars, dependencies, and dedupe logic;
+   remove the shadow layer and the flag.
+
+# Definition of done
+
+- All call sites go through Terminal49; webhooks or polling live in production.
+- Parity report is clean for our top SCACs.
+- Holds (`holds_at_pod_terminal`), fees (`fees_at_pod_terminal`), last free day
+  (`pickup_lfd`), and `available_for_pickup` are wired into whichever downstream
+  system acts on them. They are the reason to migrate properly.
+- [PROVIDER] is gone from the repo.
+
+# Ask me before you
+
+- Choose webhooks vs polling.
+- Change any function signature existing callers use.
+- Add a dependency.
+- Touch anything outside the tracking integration.
+```
 
 ## Start somewhere
 
@@ -159,7 +235,7 @@ Every provider page carries a copyable prompt that walks an AI coding assistant 
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases before you cut over
+    Simulate success and failure before you cut over
   </Card>
 
   <Card title="Send us your list" icon="comment" href="https://www.terminal49.com/demo">

--- a/docs/migrate/opentrack.mdx
+++ b/docs/migrate/opentrack.mdx
@@ -10,11 +10,11 @@ OpenTrack and Terminal49 both do ocean container tracking. The differences are T
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Sign up at [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -41,6 +41,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 <Tip>
   If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.

--- a/docs/migrate/opentrack.mdx
+++ b/docs/migrate/opentrack.mdx
@@ -43,8 +43,12 @@ You do not need to talk to anyone to try this.
 </Warning>
 
 <Tip>
-  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -70,15 +74,15 @@ You can keep polling if you prefer. Point your existing scheduler at `GET /v2/sh
 | --- | --- | --- |
 | Tracking model | Poll on demand | Register once, then push or poll |
 | Authentication | API key in header or query | `Authorization: Token` header |
-| Base URL | \[OpenTrack API domain\] | `https://api.terminal49.com/v2` |
+| Base URL | API domain | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | May be available | 30\+ events, HMAC-signed |
-| Carrier identification | SCAC or similar | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | SCAC or similar | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
-| Getting an API key | \[OpenTrack signup URL\] | Self-serve |
+| Getting an API key | Signup URL | Self-serve |
 
 ## Authentication
 
@@ -87,8 +91,9 @@ Move your key into the `Authorization: Token` header.
 <CodeGroup>
 
 ```bash OpenTrack
-curl -H "Authorization: [YOUR_OPENTRACK_KEY]" \
-  "[OpenTrack API domain]/[your OpenTrack shipment endpoint]"
+# However your OpenTrack integration authenticates today, for example:
+curl -H "Authorization: YOUR_OPENTRACK_KEY" \
+  "https://<your-opentrack-api-endpoint>/shipments"
 ```
 
 ```bash Terminal49
@@ -111,15 +116,15 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 
 | OpenTrack parameter | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| \[OpenTrack container number field\] | `request_number` | Pass in the tracking request attributes |
-| \[OpenTrack BOL field\] | `request_type: "bill_of_lading"` | Master or house BOL |
-| \[OpenTrack booking field\] | `request_type: "booking_number"` |  |
-| \[OpenTrack SCAC field\] | `scac` | Same SCAC values for most carriers |
-| Auto-detect carrier | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
-| Force refresh | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
+| Container number field | `request_number` | Pass in the tracking request attributes |
+| BOL field | `request_type: "bill_of_lading"` | Master or house BOL |
+| Booking field | `request_type: "booking_number"` |  |
+| SCAC field | `scac` | Same SCAC values for most carriers |
+| Auto-detect carrier | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| Force refresh | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
 
 <Note>
-  OpenTrack may accept a combined identifier value in a single field. Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources.
+  OpenTrack may accept a combined identifier value in a single field. Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -132,57 +137,57 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 
 | OpenTrack | Terminal49 |
 | --- | --- |
-| \[OpenTrack BOL field\] | `shipment.attributes.bill_of_lading_number` |
-| \[OpenTrack SCAC field\] | `shipment.attributes.shipping_line_scac` |
-| \[OpenTrack carrier name field\] | `shipment.attributes.shipping_line_name` |
-| \[OpenTrack status field\] | Derived from container status and milestones |
-| \[OpenTrack origin port field\] | `shipment.relationships.port_of_lading` |
-| \[OpenTrack destination port field\] | `shipment.relationships.port_of_discharge` |
-| \[OpenTrack inland destination field\] | `shipment.relationships.destination` |
-| \[OpenTrack ETA field\] | `shipment.attributes.pod_eta_at` |
+| BOL field | `shipment.attributes.bill_of_lading_number` |
+| SCAC field | `shipment.attributes.shipping_line_scac` |
+| Carrier name field | `shipment.attributes.shipping_line_name` |
+| Status field | Derived from container status and milestones |
+| Origin port field | `shipment.relationships.port_of_lading` |
+| Destination port field | `shipment.relationships.port_of_discharge` |
+| Inland destination field | `shipment.relationships.destination` |
+| ETA field | `shipment.attributes.pod_eta_at` |
 
 ### Container level
 
 | OpenTrack | Terminal49 |
 | --- | --- |
-| \[OpenTrack container number field\] | `container.attributes.number` |
-| \[OpenTrack ISO code field\] | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| \[OpenTrack size/type field\] | Same three fields above |
-| \[OpenTrack container status field\] | `container.attributes.current_status` |
-| \[OpenTrack events array\] | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| Container number field | `container.attributes.number` |
+| ISO code field | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+| Size/type field | Same three fields above |
+| Container status field | `container.attributes.current_status` |
+| Events array | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  OpenTrack may return a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  OpenTrack may return a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
 
 | OpenTrack | Terminal49 |
 | --- | --- |
-| \[OpenTrack port name field\] | `port.attributes.name` |
-| \[OpenTrack port code field\] | `port.attributes.code` |
-| \[OpenTrack port lat/lng fields\] | `port.attributes.latitude` / `.longitude` |
-| \[OpenTrack port timezone field\] | `port.attributes.time_zone` |
-| \[OpenTrack port country field\] | `port.attributes.country_code` |
-| \[OpenTrack terminal name field\] | `terminal.attributes.name` |
-| \[OpenTrack terminal SMDG field\] | `terminal.attributes.smdg_code` |
-| \[OpenTrack terminal BIC field\] | `terminal.attributes.bic_code` |
-| \[OpenTrack vessel name field\] | `shipment.attributes.pod_vessel_name` |
-| \[OpenTrack vessel IMO field\] | `shipment.attributes.pod_vessel_imo` |
-| \[OpenTrack vessel MMSI field\] | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
+| Port name field | `port.attributes.name` |
+| Port code field | `port.attributes.code` |
+| Port lat/lng fields | `port.attributes.latitude` / `.longitude` |
+| Port timezone field | `port.attributes.time_zone` |
+| Port country field | `port.attributes.country_code` |
+| Terminal name field | `terminal.attributes.name` |
+| Terminal SMDG field | `terminal.attributes.smdg_code` |
+| Terminal BIC field | `terminal.attributes.bic_facility_code` |
+| Vessel name field | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO field | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI field | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
 
 ## Milestone and event mapping
 
-OpenTrack returns a flat event array with \[OpenTrack's event vocabulary\]. Terminal49 exposes the same milestones as normalized transport events and pushes each one to your webhook.
+OpenTrack returns a flat event array with Event vocabulary. Terminal49 exposes the same milestones as normalized transport events and pushes each one to your webhook.
 
 | OpenTrack event | Milestone | Terminal49 event |
 | --- | --- | --- |
-| \[OpenTrack loaded event\] | Loaded on vessel at origin | `container.transport.vessel_loaded` |
-| \[OpenTrack departed event\] | Vessel departed origin | `container.transport.vessel_departed` |
-| \[OpenTrack arrived event\] | Vessel arrived at destination | `container.transport.vessel_arrived` |
-| \[OpenTrack discharged event\] | Discharged from vessel | `container.transport.vessel_discharged` |
-| \[OpenTrack gated out event\] | Gated out at destination | `container.transport.full_out` |
-| \[OpenTrack gated in event\] | Gated in at origin | `container.transport.full_in` |
+| Loaded event | Loaded on vessel at origin | `container.transport.vessel_loaded` |
+| Departed event | Vessel departed origin | `container.transport.vessel_departed` |
+| Arrived event | Vessel arrived at destination | `container.transport.vessel_arrived` |
+| Discharged event | Discharged from vessel | `container.transport.vessel_discharged` |
+| Gated out event | Gated out at destination | `container.transport.full_out` |
+| Gated in event | Gated in at origin | `container.transport.full_in` |
 | — | Empty picked up at origin | `container.transport.empty_out` |
 | — | Empty returned at destination | `container.transport.empty_in` |
 
@@ -287,7 +292,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Gotchas that will bite you
@@ -336,15 +341,15 @@ Rough equivalence for the OpenTrack errors you are handling today:
 
 | OpenTrack error | Terminal49 |
 | --- | --- |
-| \[OpenTrack authentication error\] | HTTP 401 |
-| \[OpenTrack authorization error\] | HTTP 403 |
-| \[OpenTrack rate limit error\] | HTTP 429 |
-| \[OpenTrack validation error\] | HTTP 400 or 422 |
-| \[OpenTrack unsupported carrier error\] | HTTP 422 |
-| \[OpenTrack no data found error\] | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
-| \[OpenTrack server error\] | Not surfaced. We retry internally or return HTTP 5xx. |
+| Authentication error | HTTP 401 |
+| Authorization error | HTTP 403 |
+| Rate limit error | HTTP 429 |
+| Validation error | HTTP 400 or 422 |
+| Unsupported carrier error | HTTP 422 |
+| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Server error | Not surfaced. We retry internally or return HTTP 5xx. |
 
-The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`) and retries rate-limit and server errors automatically with exponential backoff.
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
 ## Where we are narrower than OpenTrack
 
@@ -526,7 +531,7 @@ mappings, event names, error codes, and behavior differences.
     tracking request ID.
   - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
   - `getContainer(id)`.
-  - `refreshContainer(id)` mapping to `POST /v2/containers/{id}/refresh`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
 - Normalize responses to the same shape OpenTrack callers expect today, using the field
   mapping from the guide. Split `iso_code` into `equipment_type`, `equipment_length`,
   `equipment_height`. Convert timestamps to UTC + `time_zone`.
@@ -631,6 +636,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/opentrack.mdx
+++ b/docs/migrate/opentrack.mdx
@@ -350,7 +350,7 @@ Rough equivalence for the OpenTrack errors you are handling today:
 | Rate limit error | HTTP 429 |
 | Validation error | HTTP 400 or 422 |
 | Unsupported carrier error | HTTP 422 |
-| No data found error | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| No data found error | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | Server error | Not surfaced. We retry internally or return HTTP 5xx. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
@@ -432,8 +432,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers`.
@@ -508,8 +508,8 @@ mappings, event names, error codes, and behavior differences.
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/project44.mdx
+++ b/docs/migrate/project44.mdx
@@ -373,7 +373,7 @@ Rough equivalence for the Project44 errors you are handling today:
 | Rate limit exceeded | HTTP 429 |
 | Invalid request parameters, malformed identifier | HTTP 400 or 422 |
 | Shipment not found, unsupported SCAC | HTTP 422 |
-| Carrier temporary unavailability, no response | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested. Not surfaced directly — we retry internally. |
+| Carrier temporary unavailability, no response | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested. Not surfaced directly — we retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
@@ -444,7 +444,7 @@ Everyone does the base path. Then pick a branch.
     See [webhook best practices](/api-docs/webhooks/best-practices) for retries and idempotency.
   </Tab>
   <Tab title="Polling path">
-    1. Store the tracking request ID and shipment ID from the creation response.
+    1. Store the tracking request ID from the creation response. The shipment ID arrives later — the creation response is pending with no shipment attached; fetch the tracking request again (or handle `tracking_request.succeeded`) to get it once the carrier responds.
     2. Repoint your existing scheduler at `GET /v2/shipments` or `GET /v2/containers`.
     3. Keep your existing cadence.
 
@@ -511,8 +511,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/project44.mdx
+++ b/docs/migrate/project44.mdx
@@ -11,16 +11,16 @@ Terminal49 is ocean and terminal focused. We do not cover road, rail, LTL, or ai
 There is no compatibility shim. You will change your authentication, request shape, and response parsing. For most integrations that is an afternoon.
 
 <Note>
-  Terminal49 self-serves. Create an account, generate a free Developer Key, and start tracking up to 10 active containers at no cost. Terminal data: holds, fees, and last free day are included on the container object out of the box.
+  Terminal49 self-serves. Create an account, generate a free API key, and start tracking up to 10 active containers at no cost. Terminal data: holds, fees, and last free day are included on the container object out of the box.
 </Note>
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Go to [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Go to [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate a key">
     Visit [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys). Copy the key immediately. It is shown once and then masked forever.
@@ -47,6 +47,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 

--- a/docs/migrate/project44.mdx
+++ b/docs/migrate/project44.mdx
@@ -48,7 +48,11 @@ You do not need to talk to anyone to try this.
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
 
-If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -76,9 +80,9 @@ You can keep polling if you prefer — point your existing scheduler at `GET /v2
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Webhook subscriptions available | 30\+ events, HMAC-signed |
-| Carrier identification | SCAC or carrier code | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | SCAC or carrier code | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Multi-modal | Ocean, road, rail, air, LTL | Ocean and terminal only |
 | Getting an API key | Account setup with Project44 | Self-serve |
@@ -91,14 +95,14 @@ Project44 uses OAuth2 client credentials. You request a bearer token from their 
 
 ```bash Project44
 # 1. Request bearer token
-curl -X POST https://[your OAuth token endpoint] \
+curl -X POST https://<your-project44-token-endpoint> \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=client_credentials" \
   -d "client_id=YOUR_CLIENT_ID" \
   -d "client_secret=YOUR_CLIENT_SECRET"
 
 # 2. Use bearer token on every call
-curl https://api.project44.com/[shipment resource] \
+curl https://api.project44.com/<shipment-resource> \
   -H "Authorization: Bearer YOUR_BEARER_TOKEN"
 ```
 
@@ -125,13 +129,13 @@ Note the `Token` prefix. It is not `Bearer`.
 | Bill of lading tracking | `request_type: "bill_of_lading"` | Master or house BOL |
 | Booking number tracking | `request_type: "booking_number"` |  |
 | SCAC / carrier code | `scac` | Same SCAC values for most carriers |
-| Omit carrier / auto-detect | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns predicted SCAC and number type |
-| Force refresh / requery | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| Shipment legs / routes | Always included | See [Routing](/api-docs/in-depth-guides/routing) |
+| Omit carrier / auto-detect | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| Force refresh / requery | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| Shipment legs / routes | `GET /v2/containers/{id}/map_geojson` — requires the Routing Data entitlement | See [Routing](/api-docs/in-depth-guides/routing) |
 | OAuth `client_id` / `client_secret` | `Authorization: Token` header | Single static key, no token rotation |
 
 <Note>
-  Project44 bundles multi-modal legs in one shipment. Terminal49 expects one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. If you were tracking a single leg in Project44, send the corresponding container or BOL number to Terminal49.
+  Project44 bundles multi-modal legs in one shipment. Terminal49 expects one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta. If you were tracking a single leg in Project44, send the corresponding container or BOL number to Terminal49.
 </Note>
 
 ## Response field mapping
@@ -167,7 +171,7 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 | Transport events / legs | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  Project44 returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  Project44 returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
@@ -181,7 +185,7 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 | Country code | `port.attributes.country_code` |
 | Terminal / facility name | `terminal.attributes.name` |
 | Terminal SMDG code | `terminal.attributes.smdg_code` |
-| Terminal BIC code | `terminal.attributes.bic_code` |
+| Terminal BIC code | `terminal.attributes.bic_facility_code` |
 | Vessel name | `shipment.attributes.pod_vessel_name` |
 | Vessel IMO | `shipment.attributes.pod_vessel_imo` |
 | Vessel MMSI | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
@@ -193,12 +197,12 @@ Project44 uses event codes or status fields on shipment legs. Terminal49 exposes
 
 | Project44 ocean event | Milestone | Terminal49 event |
 | --- | --- | --- |
-| `[Project44 vessel loaded event]` | Loaded on vessel at origin | `container.transport.vessel_loaded` |
-| `[Project44 vessel departed event]` | Vessel departed origin | `container.transport.vessel_departed` |
-| `[Project44 vessel arrived event]` | Vessel arrived at destination | `container.transport.vessel_arrived` |
-| `[Project44 vessel discharged event]` | Discharged from vessel | `container.transport.vessel_discharged` |
-| `[Project44 container gated out event]` | Gated out at destination | `container.transport.full_out` |
-| `[Project44 container gated in event]` | Gated in at origin | `container.transport.full_in` |
+| Vessel loaded event | Loaded on vessel at origin | `container.transport.vessel_loaded` |
+| Vessel departed event | Vessel departed origin | `container.transport.vessel_departed` |
+| Vessel arrived event | Vessel arrived at destination | `container.transport.vessel_arrived` |
+| Vessel discharged event | Discharged from vessel | `container.transport.vessel_discharged` |
+| Container gated out event | Gated out at destination | `container.transport.full_out` |
+| Container gated in event | Gated in at origin | `container.transport.full_in` |
 | — | Empty picked up at origin | `container.transport.empty_out` |
 | — | Empty returned at destination | `container.transport.empty_in` |
 
@@ -448,43 +452,171 @@ Everyone does the base path. Then pick a branch.
 
 ## Migrate with an AI coding agent
 
-Paste the prompt below into your AI coding assistant. It includes the full context of this migration, the field mapping, and the environment variables to swap.
+If you use Claude Code, Cursor, Codex, Windsurf, Copilot, or another AI coding assistant, hand it the prompt below. It is written to run a **side-by-side migration**: the agent stands up a Terminal49 client next to your existing project44 code, shadows every project44 call with a Terminal49 call, diffs the responses, and only cuts over once parity is proven.
+
+<Tip>
+  Point your agent at this page as context (paste the URL or add it as a doc source). The prompt references the mappings above, so the more of this page the agent can see, the better it does.
+</Tip>
+
+<AccordionGroup>
+  <Accordion title="How to use this prompt" icon="wand-magic-sparkles">
+    1. Open your repo in your AI coding tool.
+    2. Add this page as a documentation source, or paste its URL into the chat.
+    3. Copy the prompt below into a new chat and send it.
+    4. Answer the agent's discovery questions (project44 client location, env var names, carrier mix).
+    5. Review each PR the agent opens. It should ship in small, reviewable steps: client, shadow, parity harness, cutover, cleanup.
+  </Accordion>
+
+  <Accordion title="What the agent will produce" icon="list-check">
+    - A `Terminal49Client` alongside your existing project44 client, sharing the same interface where possible.
+    - A shadow-mode wrapper that calls both providers and logs response diffs without changing behavior.
+    - A parity report per shipment: matched fields, diverged fields, and Terminal49-only fields (holds, fees, LFD).
+    - A feature-flagged cutover: route reads to Terminal49, keep project44 as fallback until you flip the flag off.
+    - A webhook receiver with HMAC verification, or a polling scheduler, depending on which path you pick.
+    - A cleanup PR that removes project44 code, env vars, dependencies, and dedupe logic.
+  </Accordion>
+</AccordionGroup>
+
+### The prompt
+
+Copy this into your agent. Replace the bracketed placeholders in the **Repo context** block before sending.
 
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
-You are migrating this codebase from the Project44 ocean tracking API to Terminal49.
+You are migrating this codebase from the project44 API to the Terminal49 API,
+side by side. Terminal49's authoritative migration guide is at
+https://terminal49.com/docs/migrate/project44. Use it as
+the source of truth for field mappings, event names, error codes, and behavior differences.
 
-What we are keeping:
-- The overall flow: collect a tracking number, get shipment data, display or act on it.
+# Repo context (fill this in before running)
 
-What we are changing:
-- Replace OAuth2 client-credentials token flow with a static `Authorization: Token` header.
-  Remove all token refresh logic.
-- Replace Project44 ocean shipment endpoints with `POST /v2/tracking_requests` and
-  `GET /v2/shipments` or `GET /v2/containers`.
-- Split multi-modal Project44 shipment resources: extract the ocean leg and send the BOL
-  or container number to Terminal49.
-- Replace Project44 REST/JSON responses with Terminal49 JSON:API responses.
-- Replace polling with webhooks where possible. If polling is retained, point the scheduler
-  at Terminal49 endpoints.
-- Handle `application/vnd.api+json` content type.
-- Handle async tracking request lifecycle: pending, succeeded, failed, awaiting_manifest.
-- Update timestamp parsing: UTC with a separate timezone field instead of varying formats.
-- Add Terminal49 terminal fields: `holds_at_pod_terminal`, `fees_at_pod_terminal`,
-  `pickup_lfd`, `available_for_pickup`, `import_deadlines`.
-- Update error handling to HTTP status codes (400, 401, 403, 404, 422, 429, 5xx).
-- Replace or update typed SDK errors if using the Terminal49 TypeScript SDK.
-- Environment variables: swap `PROJECT44_CLIENT_ID`, `PROJECT44_CLIENT_SECRET`, and
-  `PROJECT44_BASE_URL` for `TERMINAL49_API_KEY`. Remove token refresh cron jobs.
+- project44 client lives at: [path/to/client]
+- project44 is called from: [list the call sites or "find them"]
+- Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
+- Storage for tracking state: [e.g. Postgres table `shipments`]
+- Current polling schedule: [e.g. cron every 2h]
+- Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
+- Deployment target: [e.g. AWS ECS, Vercel, Fly.io]
+- Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
 
-Hold names are case-sensitive and exact: `freight`, `customs`, `USDA`, `VACIS`, `TMF`, `other`.
-Fee types are: `demurrage`, `extended_dwell_time`, `exam`, `total`, `other`.
-Terminal49 base URL: `https://api.terminal49.com/v2`.
-Webhook events of interest: `container.transport.vessel_discharged`,
-`container.transport.available`, `container.pickup_lfd.changed`,
-`tracking_request.succeeded`, `tracking_request.failed`, `container.updated`.
+# Rules
 
-Remove anything that only supported Project44 multi-modal legs (air, road, rail, LTL).
-Keep only the ocean path.
+1. Do not delete project44 code until the cleanup step. Migration is side by side.
+2. Ship in small PRs. Each PR must build, pass tests, and be independently revertable.
+3. Never invent Terminal49 fields, endpoints, or event names. If the guide does not
+   confirm a mapping, ask me. Do not guess.
+4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
+   `application/vnd.api+json`. Get this right on the first request.
+5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
+   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
+   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
+7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
+   not missing data. A fee `amount` of 0 is valid.
+8. On `container.updated`, prefer the `changeset` over diffing state yourself.
+9. Terminal49 uses a static API key. Delete the OAuth2 client-credentials token flow,
+   token refresh logic, and any token-refresh cron jobs in the cleanup step — do not
+   port them.
+10. Terminal49 covers the ocean leg only. Keep project44 air, road, rail, and LTL
+   tracking in place. Extract the ocean leg from each multi-modal shipment before
+   mapping it.
+
+# Plan (execute in order, one PR per step)
+
+## PR 1 — Discovery and interface
+
+- Grep the repo for every project44 call site. List them in the PR description.
+- Extract the project44 client's public surface into an interface
+  (`TrackingProvider` with methods like `track(number, type, carrier)`,
+  `getShipment(id)`, `refresh(id)`).
+- Make the existing project44 client implement it. No behavior change.
+
+## PR 2 — Terminal49 client
+
+- Add a `Terminal49Client` implementing the same `TrackingProvider` interface.
+- Auth via `T49_API_KEY` env var, header `Authorization: Token ${key}`.
+- Base URL `https://api.terminal49.com/v2`, content type `application/vnd.api+json`.
+- Implement:
+  - `createTrackingRequest({ request_number, request_type, scac })` returning the
+    tracking request ID.
+  - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge' })`.
+  - `getContainer(id)`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh` (a paid
+    feature — skip it unless our account has it enabled).
+- Normalize responses to the same shape project44 callers expect today, using the field
+  mapping from the guide. Split equipment codes into `equipment_type`, `equipment_length`,
+  `equipment_height`. Convert timestamps to UTC + `time_zone`.
+- Map errors to typed classes: `AuthenticationError` (401), `AuthorizationError` (403),
+  `ValidationError` (400/422), `RateLimitError` (429), `UpstreamError` (5xx),
+  `FeatureNotEnabledError` (403 + feature flag response).
+- Add unit tests using recorded fixtures. Do not hit the live API in tests.
+
+## PR 3 — Shadow mode
+
+- Add a `ShadowProvider` that wraps both clients. On every read:
+  - Call project44 as the primary. Return its response.
+  - Fire-and-forget a Terminal49 call for the same identifier.
+  - Log a structured diff: matched fields, diverged fields, T49-only fields.
+- Gate with env var `TRACKING_SHADOW_MODE=true`. Off by default.
+- Add a parity report script that aggregates shadow logs by SCAC and field.
+- Do NOT change what callers see. This step is observation only.
+
+## PR 4 — Backfill script
+
+- Write a one-shot script that reads all active shipments from our database and calls
+  `POST /tracking_requests` for each (one per BOL, booking, or container).
+- Store the returned `tracking_request.id` and eventual `shipment.id` on our records.
+- Rate-limit to respect Terminal49's limits (handle 429 with exponential backoff).
+- Idempotent: safe to re-run. Skip rows already backfilled.
+
+## PR 5 — Webhook receiver (only if we picked the webhook path)
+
+- Add `POST /webhooks/terminal49` endpoint.
+- Verify HMAC signature using the shared secret from `T49_WEBHOOK_SECRET`. Reject on
+  mismatch with 401.
+- Handle these events at minimum:
+  - `tracking_request.succeeded`, `tracking_request.failed`, `tracking_request.awaiting_manifest`
+  - `container.transport.vessel_discharged`, `container.transport.available`,
+    `container.transport.full_out`
+  - `container.updated` (use the `changeset`, do not diff)
+  - `container.pickup_lfd.changed`
+- Persist events idempotently keyed by event ID.
+- Register the webhook via `POST /v2/webhooks` from a bootstrap script, subscribing
+  only to events we handle.
+- If our firewall restricts inbound traffic, whitelist Terminal49 IPs from
+  `GET /v2/webhooks/ips`.
+
+## PR 6 — Cutover behind a flag
+
+- Add feature flag `TRACKING_PROVIDER` with values `project44` (default) and `terminal49`.
+- Route all reads through the flag. project44 stays available as a fallback for one
+  release cycle.
+- Flip staging to `terminal49`, verify parity report is clean, then flip production.
+
+## PR 7 — Cleanup
+
+- Delete the project44 client, its tests, its env vars, its dedupe cache, and any
+  equipment-code parsing helpers Terminal49 makes redundant.
+- Remove the shadow provider and the feature flag.
+- Update README and any runbooks. Note the new webhook endpoint if applicable.
+
+# Definition of done
+
+- All project44 call sites now go through Terminal49.
+- Webhook (or polling) is live in production.
+- Parity report shows no unexplained divergences for our top 10 SCACs.
+- Holds, fees, and LFD are exposed to whichever downstream system needs them
+  (dashboard, alerts, customer emails). Do not migrate without wiring these up. They
+  are the reason to do this properly.
+- project44 dependency, env vars, and dead code are gone from the repo.
+
+# Ask me before you
+
+- Choose between the webhook path and the polling path. Default to webhooks unless our
+  infra makes an inbound HTTPS endpoint hard.
+- Change the shape of any function project44 callers use today. Prefer a normalization
+  layer inside the Terminal49 client.
+- Add a new dependency. Prefer stdlib and what is already in the repo.
+- Touch anything outside the tracking integration.
 ```
 
 ## Getting help
@@ -507,6 +639,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/searates.mdx
+++ b/docs/migrate/searates.mdx
@@ -2,7 +2,6 @@
 title: "Migrate from SeaRates to Terminal49 API"
 sidebarTitle: "SeaRates"
 description: "Map SeaRates tracking API fields, parameters, and errors to their Terminal49 equivalents. Includes webhook setup, carrier coverage, and a migration checklist."
-icon: "face-smile-relaxed"
 ---
 
 If you have the SeaRates tracking API in production, this page maps it onto Terminal49 field by field, so you can cut over without reverse-engineering our schema.
@@ -44,8 +43,12 @@ You do not need to talk to anyone to try this.
 </Warning>
 
 <Tip>
-  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -75,9 +78,9 @@ You can keep polling if you prefer. Point your existing scheduler at `GET /v2/sh
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | None | 30\+ events, HMAC-signed |
-| Carrier identification | `sealine` (SCAC) | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | `sealine` (SCAC) | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Embeddable widget | Open lookup, any container | Your tracked shipments only (add-on) |
 | Getting an API key | Self-serve | Self-serve |
@@ -121,14 +124,14 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 | `type=BL` | `request_type: "bill_of_lading"` | Master or house BOL |
 | `type=BK` | `request_type: "booking_number"` |  |
 | `sealine` | `scac` | Same SCAC values for most carriers |
-| `sealine=auto` | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
-| `force_update` | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| `route` | Always included | See [Routing](/api-docs/in-depth-guides/routing) |
+| `sealine=auto` | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
+| `force_update` | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| `route` | `GET /v2/containers/{id}/map_geojson` — requires the Routing Data entitlement | See [Routing](/api-docs/in-depth-guides/routing) |
 | `ais` | Vessel endpoints and container GeoJSON | Not inline on the tracking response |
 | `api_key` | `Authorization` header |  |
 
 <Note>
-  SeaRates accepts a combined `BL_NUMBER/CONTAINER_NUMBER` value in a single `number` field. Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources.
+  SeaRates accepts a combined `BL_NUMBER/CONTAINER_NUMBER` value in a single `number` field. Terminal49 takes one identifier per tracking request. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -164,7 +167,7 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 | `data.containers[].events[]` | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  SeaRates returns a single `iso_code` string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  SeaRates returns a single `iso_code` string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
@@ -178,7 +181,7 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 | `data.locations[].country_code` | `port.attributes.country_code` |
 | `data.facilities[].name` | `terminal.attributes.name` |
 | `data.facilities[].smdg_code` | `terminal.attributes.smdg_code` |
-| `data.facilities[].bic_code` | `terminal.attributes.bic_code` |
+| `data.facilities[].bic_code` | `terminal.attributes.bic_facility_code` |
 | `data.vessels[].name` | `shipment.attributes.pod_vessel_name` |
 | `data.vessels[].imo` | `shipment.attributes.pod_vessel_imo` |
 | `data.vessels[].mmsi` | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
@@ -300,7 +303,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Replacing the SeaRates widget
@@ -385,7 +388,7 @@ Rough equivalence for the SeaRates errors you are handling today:
 | `AUTO_CANT_DETECT_SEALINE` | Infer endpoint returns no prediction |
 | `SEALINE_TEMPORARY_DISABLED`, `SEALINE_NO_RESPONSE` | Not surfaced. We retry internally. |
 
-The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`) and retries rate-limit and server errors automatically with exponential backoff.
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
 ## Where we are narrower than SeaRates
 
@@ -519,7 +522,7 @@ Copy this into your agent. Replace the bracketed placeholders in the **Repo cont
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
 You are migrating this codebase from the SeaRates tracking API to the Terminal49 API,
 side by side. Terminal49's authoritative migration guide is at
-https://terminal49.com/docs/api-docs/getting-started/migrate-from-searates. Use it as
+https://terminal49.com/docs/migrate/searates. Use it as
 the source of truth for field mappings, event names, error codes, and behavior differences.
 
 # Repo context (fill this in before running)
@@ -569,7 +572,7 @@ the source of truth for field mappings, event names, error codes, and behavior d
     tracking request ID.
   - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
   - `getContainer(id)`.
-  - `refreshContainer(id)` mapping to `POST /v2/containers/{id}/refresh`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
 - Normalize responses to the same shape SeaRates callers expect today, using the field
   mapping from the guide. Split `iso_code` into `equipment_type`, `equipment_length`,
   `equipment_height`. Convert timestamps to UTC + `time_zone`.
@@ -674,6 +677,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/searates.mdx
+++ b/docs/migrate/searates.mdx
@@ -10,11 +10,11 @@ There is no compatibility shim. You will change your request code and your respo
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Sign up at [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -41,6 +41,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 <Tip>
   If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.

--- a/docs/migrate/searates.mdx
+++ b/docs/migrate/searates.mdx
@@ -388,7 +388,7 @@ Rough equivalence for the SeaRates errors you are handling today:
 | `API_KEY_LIMIT_REACHED`, `API_KEY_RATE_LIMIT` | HTTP 429 |
 | `WRONG_PARAMETERS`, `WRONG_NUMBER`, `WRONG_TYPE` | HTTP 400 or 422 |
 | `WRONG_SEALINE`, `SEALINE_NOT_SUPPORTED` | HTTP 422 |
-| `SEALINE_HASNT_PROVIDE_INFO`, `NO_CONTAINERS`, `NO_EVENTS` | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| `SEALINE_HASNT_PROVIDE_INFO`, `NO_CONTAINERS`, `NO_EVENTS` | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | `AUTO_CANT_DETECT_SEALINE` | Infer endpoint returns no prediction |
 | `SEALINE_TEMPORARY_DISABLED`, `SEALINE_NO_RESPONSE` | Not surfaced. We retry internally. |
 
@@ -473,8 +473,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers`.
@@ -549,8 +549,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/shipsgo.mdx
+++ b/docs/migrate/shipsgo.mdx
@@ -10,9 +10,9 @@ There is no compatibility shim. You will change your request code and your respo
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
-1. [Create an account](https://app.terminal49.com) — the free Developer Key tracks up to 10 active containers.
+1. [Create an account](https://app.terminal49.com) — the free plan tracks up to 10 active containers.
 2. Generate a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
 3. Run this:
 
@@ -35,6 +35,10 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 

--- a/docs/migrate/shipsgo.mdx
+++ b/docs/migrate/shipsgo.mdx
@@ -461,7 +461,7 @@ Everyone does the base path. Then pick a branch.
     See [webhook best practices](/api-docs/webhooks/best-practices) for retries and idempotency.
   </Tab>
   <Tab title="Polling path">
-    1. Store the tracking request ID and shipment ID from the creation response.
+    1. Store the tracking request ID from the creation response. The shipment ID arrives later — the creation response is pending with no shipment attached; fetch the tracking request again (or handle `tracking_request.succeeded`) to get it once the carrier responds.
     2. Repoint your existing scheduler at `GET /v2/shipments` or `GET /v2/containers`.
     3. Keep your existing cadence.
 
@@ -528,8 +528,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/shipsgo.mdx
+++ b/docs/migrate/shipsgo.mdx
@@ -36,7 +36,11 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
   The full API key is shown once, right after you create it. Copy it before you navigate away — after that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
 
-If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -66,11 +70,11 @@ You can keep polling if you prefer — point your existing scheduler at `GET /v2
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Supported for shipment updates | 30\+ events, HMAC-signed |
-| Carrier identification | `carrier` (SCAC) | `scac`, or omit and use Infer |
+| Carrier identification | `carrier` (SCAC) | `scac`, or `auto_detect_vocc_scac` |
 | Credit per tracking request | Yes, one credit per creation | No per-track credits |
 | Rate limit | 100 requests per minute | See [Rate Limiting](/api-docs/in-depth-guides/rate-limiting) |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Embeddable widget | Open lookup, any container; live map | Your tracked shipments only (add-on) |
 | Getting an API key | Self-serve in dashboard | Self-serve in developer portal |
@@ -109,7 +113,7 @@ Note the `Token` prefix. It is not `Bearer`.
 | `bookingNumber` | `request_number` with `request_type: "booking_number"` |  |
 | `blNumber` | `request_number` with `request_type: "bill_of_lading"` | Master or house BOL |
 | `carrier` | `scac` | Same SCAC values for most carriers |
-| `carrier: "OTHERS"` | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
+| `carrier: "OTHERS"` | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
 | `reference` | Shipment reference tag | Set on the shipment or container after creation |
 | `followers`, `tags` | Shipment reference or your own metadata | Store in your system against the Terminal49 shipment ID |
 | `filters[status]` | `GET /v2/shipments` or `GET /v2/containers` query filters |  |
@@ -158,7 +162,7 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 | `container.events[]` | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  ShipsGo returns a combined container type or ISO code. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  ShipsGo returns a combined container type or ISO code. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
@@ -183,7 +187,7 @@ ShipsGo returns milestones in a flat `events[]` array with names like "Loaded", 
 
 | ShipsGo event name | Milestone | Terminal49 event |
 | --- | --- | --- |
-| `Booked` | Booking confirmed | `container.transport.booking_confirmed` |
+| `Booked` | Booking confirmed | No direct equivalent — the nearest signal is `tracking_request.succeeded` when tracking begins |
 | `Loaded` | Loaded on vessel at origin | `container.transport.vessel_loaded` |
 | `Sailing` | Vessel departed origin | `container.transport.vessel_departed` |
 | `Arrived` | Vessel arrived at destination | `container.transport.vessel_arrived` |
@@ -296,7 +300,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement — rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement — Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Replacing the ShipsGo widget
@@ -387,7 +391,7 @@ Rough equivalence for the ShipsGo errors you are handling today:
   Terminal49 does not charge per-track credits. If you were managing credit budgets and duplicate checks in ShipsGo to avoid burning credits, you can remove that logic.
 </Note>
 
-The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`) and retries rate-limit and server errors automatically with exponential backoff.
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
 ## Where we are narrower than ShipsGo
 
@@ -465,45 +469,167 @@ Everyone does the base path. Then pick a branch.
 
 ## Migrate with an AI coding agent
 
+If you use Claude Code, Cursor, Codex, Windsurf, Copilot, or another AI coding assistant, hand it the prompt below. It is written to run a **side-by-side migration**: the agent stands up a Terminal49 client next to your existing ShipsGo code, shadows every ShipsGo call with a Terminal49 call, diffs the responses, and only cuts over once parity is proven.
+
+<Tip>
+  Point your agent at this page as context (paste the URL or add it as a doc source). The prompt references the mappings above, so the more of this page the agent can see, the better it does.
+</Tip>
+
+<AccordionGroup>
+  <Accordion title="How to use this prompt" icon="wand-magic-sparkles">
+    1. Open your repo in your AI coding tool.
+    2. Add this page as a documentation source, or paste its URL into the chat.
+    3. Copy the prompt below into a new chat and send it.
+    4. Answer the agent's discovery questions (ShipsGo client location, env var names, carrier mix).
+    5. Review each PR the agent opens. It should ship in small, reviewable steps: client, shadow, parity harness, cutover, cleanup.
+  </Accordion>
+
+  <Accordion title="What the agent will produce" icon="list-check">
+    - A `Terminal49Client` alongside your existing ShipsGo client, sharing the same interface where possible.
+    - A shadow-mode wrapper that calls both providers and logs response diffs without changing behavior.
+    - A parity report per shipment: matched fields, diverged fields, and Terminal49-only fields (holds, fees, LFD).
+    - A feature-flagged cutover: route reads to Terminal49, keep ShipsGo as fallback until you flip the flag off.
+    - A webhook receiver with HMAC verification, or a polling scheduler, depending on which path you pick.
+    - A cleanup PR that removes ShipsGo code, env vars, dependencies, and dedupe logic.
+  </Accordion>
+</AccordionGroup>
+
+### The prompt
+
+Copy this into your agent. Replace the bracketed placeholders in the **Repo context** block before sending.
+
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
+You are migrating this codebase from the ShipsGo API to the Terminal49 API,
+side by side. Terminal49's authoritative migration guide is at
+https://terminal49.com/docs/migrate/shipsgo. Use it as
+the source of truth for field mappings, event names, error codes, and behavior differences.
 
-You are migrating this codebase from the ShipsGo tracking API to Terminal49.
+# Repo context (fill this in before running)
 
-Context you have:
-- Environment variables `SHIPSGO_USER_TOKEN` (old) and `TERMINAL49_API_KEY` (new).
-- A list of tracked shipments in the old system.
+- ShipsGo client lives at: [path/to/client]
+- ShipsGo is called from: [list the call sites or "find them"]
+- Language and framework: [e.g. TypeScript + Node, Python + FastAPI, Ruby on Rails]
+- Storage for tracking state: [e.g. Postgres table `shipments`]
+- Current polling schedule: [e.g. cron every 2h]
+- Carrier mix (SCACs we track most): [e.g. MAEU, MSCU, CMDU, HLCU, ONEY]
+- Deployment target: [e.g. AWS ECS, Vercel, Fly.io]
+- Secret store: [e.g. AWS Secrets Manager, `.env`, Doppler]
 
-Rules:
-1. Do not change business logic. Keep the same scheduling, alerting, and display behavior.
-2. Replace ShipsGo request building with Terminal49 request building.
-   - Auth: `Authorization: Token ${process.env.TERMINAL49_API_KEY}`.
-   - Content type: `application/vnd.api+json`.
-   - Base URL: `https://api.terminal49.com/v2`.
-   - Endpoints: `POST /tracking_requests`, `GET /v2/shipments`, `GET /v2/containers`.
-   - Parameter mapping:
-     - `containerNumber` -> `request_number` with `request_type: "container"`
-     - `bookingNumber` -> `request_number` with `request_type: "booking_number"`
-     - `blNumber` -> `request_number` with `request_type: "bill_of_lading"`
-     - `carrier` -> `scac` (or omit for Infer)
-3. Replace response parsing with JSON:API parsing.
-   - Use a JSON:API client library if the project does not already have one.
-   - Map shipment fields: `shipping_line_scac`, `shipping_line_name`, `bill_of_lading_number`, `pod_eta_at`, `pod_vessel_name`, `pod_vessel_imo`.
-   - Map container fields: `number`, `equipment_type`, `equipment_length`, `equipment_height`, `current_status`.
-   - Map port fields: `name`, `code`, `country_code`, `latitude`, `longitude`, `time_zone`.
-4. Add webhook handling if the old code polled.
-   - Recommended events: `container.transport.vessel_discharged`, `container.transport.available`, `container.pickup_lfd.changed`.
-   - Verify HMAC signatures on inbound POSTs.
-5. Update error handling.
-   - Replace ShipsGo HTTP status and credit-exhaustion checks with Terminal49 status codes.
-   - Use typed errors if the codebase uses the TypeScript SDK.
-6. Add Terminal49-specific fields where they improve the UI.
-   - `holds_at_pod_terminal`: show as red badges if any `status === "hold"`.
-   - `fees_at_pod_terminal`: show amount and currency; filter out `type === "total"` before summing.
-   - `pickup_lfd`: show as a date; subscribe to `container.pickup_lfd.changed` for alerts.
-   - `available_for_pickup`: green indicator when true and no active holds.
-7. Do not delete old code. Comment it out with a `// TODO: remove after cutover` so we can roll back.
-8. Add a feature flag `USE_TERMINAL49` so both paths can run in parallel during the transition.
-9. Output: the exact file changes, inline diff style, ready for review.
+# Rules
+
+1. Do not delete ShipsGo code until the cleanup step. Migration is side by side.
+2. Ship in small PRs. Each PR must build, pass tests, and be independently revertable.
+3. Never invent Terminal49 fields, endpoints, or event names. If the guide does not
+   confirm a mapping, ask me. Do not guess.
+4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
+   `application/vnd.api+json`. Get this right on the first request.
+5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
+   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
+   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
+7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
+   not missing data. A fee `amount` of 0 is valid.
+8. On `container.updated`, prefer the `changeset` over diffing state yourself.
+9. Terminal49 has no credit system. Remove ShipsGo credit-balance checks and
+   credit-exhaustion error handling in the cleanup step — do not port them.
+
+# Plan (execute in order, one PR per step)
+
+## PR 1 — Discovery and interface
+
+- Grep the repo for every ShipsGo call site. List them in the PR description.
+- Extract the ShipsGo client's public surface into an interface
+  (`TrackingProvider` with methods like `track(number, type, carrier)`,
+  `getShipment(id)`, `refresh(id)`).
+- Make the existing ShipsGo client implement it. No behavior change.
+
+## PR 2 — Terminal49 client
+
+- Add a `Terminal49Client` implementing the same `TrackingProvider` interface.
+- Auth via `T49_API_KEY` env var, header `Authorization: Token ${key}`.
+- Base URL `https://api.terminal49.com/v2`, content type `application/vnd.api+json`.
+- Implement:
+  - `createTrackingRequest({ request_number, request_type, scac })` returning the
+    tracking request ID.
+  - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge' })`.
+  - `getContainer(id)`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh` (a paid
+    feature — skip it unless our account has it enabled).
+- Normalize responses to the same shape ShipsGo callers expect today, using the field
+  mapping from the guide. Split equipment codes into `equipment_type`, `equipment_length`,
+  `equipment_height`. Convert timestamps to UTC + `time_zone`.
+- Map errors to typed classes: `AuthenticationError` (401), `AuthorizationError` (403),
+  `ValidationError` (400/422), `RateLimitError` (429), `UpstreamError` (5xx),
+  `FeatureNotEnabledError` (403 + feature flag response).
+- Add unit tests using recorded fixtures. Do not hit the live API in tests.
+
+## PR 3 — Shadow mode
+
+- Add a `ShadowProvider` that wraps both clients. On every read:
+  - Call ShipsGo as the primary. Return its response.
+  - Fire-and-forget a Terminal49 call for the same identifier.
+  - Log a structured diff: matched fields, diverged fields, T49-only fields.
+- Gate with env var `TRACKING_SHADOW_MODE=true`. Off by default.
+- Add a parity report script that aggregates shadow logs by SCAC and field.
+- Do NOT change what callers see. This step is observation only.
+
+## PR 4 — Backfill script
+
+- Write a one-shot script that reads all active shipments from our database and calls
+  `POST /tracking_requests` for each (one per BOL, booking, or container).
+- Store the returned `tracking_request.id` and eventual `shipment.id` on our records.
+- Rate-limit to respect Terminal49's limits (handle 429 with exponential backoff).
+- Idempotent: safe to re-run. Skip rows already backfilled.
+
+## PR 5 — Webhook receiver (only if we picked the webhook path)
+
+- Add `POST /webhooks/terminal49` endpoint.
+- Verify HMAC signature using the shared secret from `T49_WEBHOOK_SECRET`. Reject on
+  mismatch with 401.
+- Handle these events at minimum:
+  - `tracking_request.succeeded`, `tracking_request.failed`, `tracking_request.awaiting_manifest`
+  - `container.transport.vessel_discharged`, `container.transport.available`,
+    `container.transport.full_out`
+  - `container.updated` (use the `changeset`, do not diff)
+  - `container.pickup_lfd.changed`
+- Persist events idempotently keyed by event ID.
+- Register the webhook via `POST /v2/webhooks` from a bootstrap script, subscribing
+  only to events we handle.
+- If our firewall restricts inbound traffic, whitelist Terminal49 IPs from
+  `GET /v2/webhooks/ips`.
+
+## PR 6 — Cutover behind a flag
+
+- Add feature flag `TRACKING_PROVIDER` with values `shipsgo` (default) and `terminal49`.
+- Route all reads through the flag. ShipsGo stays available as a fallback for one
+  release cycle.
+- Flip staging to `terminal49`, verify parity report is clean, then flip production.
+
+## PR 7 — Cleanup
+
+- Delete the ShipsGo client, its tests, its env vars, its dedupe cache, and any
+  equipment-code parsing helpers Terminal49 makes redundant.
+- Remove the shadow provider and the feature flag.
+- Update README and any runbooks. Note the new webhook endpoint if applicable.
+
+# Definition of done
+
+- All ShipsGo call sites now go through Terminal49.
+- Webhook (or polling) is live in production.
+- Parity report shows no unexplained divergences for our top 10 SCACs.
+- Holds, fees, and LFD are exposed to whichever downstream system needs them
+  (dashboard, alerts, customer emails). Do not migrate without wiring these up. They
+  are the reason to do this properly.
+- ShipsGo dependency, env vars, and dead code are gone from the repo.
+
+# Ask me before you
+
+- Choose between the webhook path and the polling path. Default to webhooks unless our
+  infra makes an inbound HTTPS endpoint hard.
+- Change the shape of any function ShipsGo callers use today. Prefer a normalization
+  layer inside the Terminal49 client.
+- Add a new dependency. Prefer stdlib and what is already in the repo.
+- Touch anything outside the tracking integration.
 ```
 
 ## Getting help
@@ -526,6 +652,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/vizion.mdx
+++ b/docs/migrate/vizion.mdx
@@ -43,8 +43,12 @@ You do not need to talk to anyone to try this.
 </Warning>
 
 <Tip>
-  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success, failure, and edge-case outcomes.
+  If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.
 </Tip>
+
+<Note>
+  **Migration offer:** sign up now and the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-id) — vessel schedules, AIS positions, and projected routes — is free for your first month.
+</Note>
 
 ## The architectural shift
 
@@ -67,28 +71,28 @@ The biggest difference is not the workflow. It is the data surface. Terminal49 i
 |  | Vizion | Terminal49 |
 | --- | --- | --- |
 | Tracking model | Reference subscription, then push or poll | Register once, then push or poll |
-| Authentication | API key header (format varies by plan) | `Authorization: Token` header |
-| Base URL | `https://api.vizionapi.com` | `https://api.terminal49.com/v2` |
+| Authentication | `X-API-Key` header | `Authorization: Token` header |
+| Base URL | `https://prod.vizionapi.com` | `https://api.terminal49.com/v2` |
 | Content type | `application/json` | `application/vnd.api+json` |
 | Response format | Custom JSON | JSON:API |
 | Webhooks | Subscription-based | 30\+ events, HMAC-signed |
-| Carrier identification | Carrier reference or SCAC | `scac`, or omit and use Infer |
-| Terminal holds and fees | Not available | Included on the container object |
-| Last free day | Not available | Included, with per-source breakdown |
+| Carrier identification | Carrier reference or SCAC | `scac`, or `auto_detect_vocc_scac` |
+| Terminal holds and fees | No direct equivalent | Included on the container object |
+| Last free day | No direct equivalent | Included, with per-source breakdown |
 | Rail milestones | Limited | North American Class I and short-line |
 | Getting an API key | Typically requires sales contact for higher tiers | Self-serve |
 
 ## Authentication
 
-Move from Vizion's key header to Terminal49's `Token` prefix. Note the content type change.
+Move from Vizion's `X-API-Key` header to Terminal49's `Authorization: Token` header. Note the content type change.
 
 <CodeGroup>
 
 ```bash Vizion
-curl -X POST https://api.vizionapi.com/v1/references \
+curl -X POST https://prod.vizionapi.com/references \
   -H "Content-Type: application/json" \
-  -H "Authorization: YOUR_VIZION_KEY" \
-  -d '{"container": "MRKU9465770", "carrier": "MAEU"}'
+  -H "X-API-Key: YOUR_VIZION_KEY" \
+  -d '{"container_id": "MRKU9465770", "carrier_code": "MAEU"}'
 ```
 
 ```bash Terminal49
@@ -107,21 +111,21 @@ curl -X POST https://api.terminal49.com/v2/tracking_requests \
   Note the `Token` prefix. It is not `Bearer`.
 </Note>
 
-Vizion's exact header format varies by plan or integration type. If you pass the key in a custom header like `x-api-key`, the change is the same: move the value into `Authorization: Token YOUR_T49_KEY`.
+Vizion reads the key from the `X-API-Key` header. Terminal49 reads it from `Authorization: Token YOUR_T49_KEY` — a different header name and a prefixed value, so change both.
 
 ## Request parameter mapping
 
 | Vizion parameter | Terminal49 equivalent | Notes |
 | --- | --- | --- |
-| `container` or `bill_of_lading` | `request_number` | One identifier per tracking request |
-| `carrier` | `scac` | Same SCAC values for most carriers |
-| `carrier` omitted | Omit `scac`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) | Returns the predicted SCAC and number type |
+| `container_id` or `bill_of_lading` | `request_number` | One identifier per tracking request |
+| `carrier_code` | `scac` | Same SCAC values for most carriers |
+| `carrier_code` omitted | Set `auto_detect_vocc_scac: true`, or call [Infer Tracking Number](/api-docs/in-depth-guides/auto-detect-carrier) first | Auto-detection runs asynchronously; a failed inference fails the tracking request with `scac_auto_detect_failed` |
 | `callback_url` | `POST /v2/webhooks` | Register once, subscribe to specific events |
-| \[provider's refresh field\] | `POST /v2/containers/{id}/refresh` | Forces an immediate pull from all sources |
-| \[provider's reference tagging\] | `shipment.attributes.reference_numbers` | Tag shipments with your internal IDs |
+| Re-poll / refresh | `PATCH /v2/containers/{id}/refresh` | Forces an immediate pull from all sources. Paid feature — requires account enablement, limited to 10 requests per minute |
+| Your internal reference tags | `shipment.attributes.reference_numbers` | Tag shipments with your internal IDs |
 
 <Note>
-  Vizion accepts a carrier reference or name alongside the number. Terminal49 takes a SCAC (`request_type` \+ `scac`) or omits the SCAC to use Infer. Track by BOL and we return every container on that bill of lading as related container resources.
+  Vizion accepts a carrier reference or name alongside the number. Terminal49 takes a SCAC (`request_type` \+ `scac`) or omits the SCAC to use Infer. Track by BOL and we return every container on that bill of lading as related container resources. Container-number tracking requests are currently in beta.
 </Note>
 
 ## Response field mapping
@@ -134,47 +138,47 @@ Use the [`include` parameter](/api-docs/in-depth-guides/including-resources) to 
 
 | Vizion | Terminal49 |
 | --- | --- |
-| \[provider's shipment number field\] | `shipment.attributes.bill_of_lading_number` |
-| \[provider's carrier field\] | `shipment.attributes.shipping_line_scac` |
-| \[provider's carrier name field\] | `shipment.attributes.shipping_line_name` |
-| \[provider's shipment status field\] | Derived from container status and milestones |
-| \[provider's origin location field\] | `shipment.relationships.port_of_lading` |
-| \[provider's destination location field\] | `shipment.relationships.port_of_discharge` |
-| \[provider's inland destination field\] | `shipment.relationships.destination` |
-| \[provider's ETA field\] | `shipment.attributes.pod_eta_at` |
-| \[provider's vessel name field\] | `shipment.attributes.pod_vessel_name` |
-| \[provider's vessel IMO field\] | `shipment.attributes.pod_vessel_imo` |
+| Bill of lading number | `shipment.attributes.bill_of_lading_number` |
+| Carrier SCAC | `shipment.attributes.shipping_line_scac` |
+| Carrier name | `shipment.attributes.shipping_line_name` |
+| Shipment status | Derived from container status and milestones |
+| Port of loading | `shipment.relationships.port_of_lading` |
+| Port of discharge | `shipment.relationships.port_of_discharge` |
+| Inland destination | `shipment.relationships.destination` |
+| ETA at discharge port | `shipment.attributes.pod_eta_at` |
+| Vessel name | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO | `shipment.attributes.pod_vessel_imo` |
 
 ### Container level
 
 | Vizion | Terminal49 |
 | --- | --- |
-| \[provider's container number field\] | `container.attributes.number` |
-| \[provider's ISO code field\] | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
-| \[provider's container size/type field\] | Same three fields above |
-| \[provider's container status field\] | `container.attributes.current_status` |
-| \[provider's events array\] | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
+| Container number | `container.attributes.number` |
+| Equipment / ISO code | `container.attributes.equipment_type` \+ `equipment_length` \+ `equipment_height` |
+| Container size / type | Same three fields above |
+| Container status | `container.attributes.current_status` |
+| Events array | Container timestamps, [transport events](/api-docs/api-reference/containers/get-a-containers-transport-events), and webhook events |
 
 <Note>
-  Vizion returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, tank, hard top), length (20, 40, 45, 50), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
+  Vizion returns a single ISO code string like `45G1`. Terminal49 splits this into three normalized fields: type (dry, reefer, open top, flat rack, bulk, tank), length (10, 20, 40, 45), and height (standard, high cube). If you were parsing ISO codes yourself, you can delete that code.
 </Note>
 
 ### Locations, facilities, and vessels
 
 | Vizion | Terminal49 |
 | --- | --- |
-| \[provider's port name field\] | `port.attributes.name` |
-| \[provider's port UN/LOCODE field\] | `port.attributes.code` |
-| \[provider's port lat/lng fields\] | `port.attributes.latitude` / `.longitude` |
-| \[provider's port timezone field\] | `port.attributes.time_zone` |
-| \[provider's port country field\] | `port.attributes.country_code` |
-| \[provider's terminal name field\] | `terminal.attributes.name` |
-| \[provider's terminal SMDG field\] | `terminal.attributes.smdg_code` |
-| \[provider's terminal BIC field\] | `terminal.attributes.bic_code` |
-| \[provider's vessel name field\] | `shipment.attributes.pod_vessel_name` |
-| \[provider's vessel IMO field\] | `shipment.attributes.pod_vessel_imo` |
-| \[provider's vessel MMSI field\] | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
-| \[provider's vessel call sign/flag fields\] | Not returned |
+| Port name | `port.attributes.name` |
+| Port UN/LOCODE | `port.attributes.code` |
+| Port coordinates | `port.attributes.latitude` / `.longitude` |
+| Port timezone | `port.attributes.time_zone` |
+| Port country | `port.attributes.country_code` |
+| Terminal / facility name | `terminal.attributes.name` |
+| Terminal SMDG code | `terminal.attributes.smdg_code` |
+| Terminal BIC facility code | `terminal.attributes.bic_facility_code` |
+| Vessel name | `shipment.attributes.pod_vessel_name` |
+| Vessel IMO | `shipment.attributes.pod_vessel_imo` |
+| Vessel MMSI | Available via the [Vessels API](/api-docs/api-reference/vessels/get-a-vessel-using-the-imo) |
+| Vessel call sign / flag | Not returned |
 
 ## Milestone and event mapping
 
@@ -182,14 +186,14 @@ Vizion returns event arrays via updates or webhooks. Terminal49 exposes the same
 
 | Vizion event | Milestone | Terminal49 event |
 | --- | --- | --- |
-| \[provider's loaded event\] | Loaded on vessel at origin | `container.transport.vessel_loaded` |
-| \[provider's departed event\] | Vessel departed origin | `container.transport.vessel_departed` |
-| \[provider's arrived event\] | Vessel arrived at destination | `container.transport.vessel_arrived` |
-| \[provider's discharged event\] | Discharged from vessel | `container.transport.vessel_discharged` |
-| \[provider's gated out event\] | Gated out at destination | `container.transport.full_out` |
-| \[provider's gated in event\] | Gated in at origin | `container.transport.full_in` |
-| \[provider's empty pickup event\] | Empty picked up at origin | `container.transport.empty_out` |
-| \[provider's empty return event\] | Empty returned at destination | `container.transport.empty_in` |
+| Loaded on vessel | Loaded on vessel at origin | `container.transport.vessel_loaded` |
+| Vessel departed | Vessel departed origin | `container.transport.vessel_departed` |
+| Vessel arrived | Vessel arrived at destination | `container.transport.vessel_arrived` |
+| Discharged from vessel | Discharged from vessel | `container.transport.vessel_discharged` |
+| Gated out (full out) | Gated out at destination | `container.transport.full_out` |
+| Gated in (full in) | Gated in at origin | `container.transport.full_in` |
+| Empty picked up | Empty picked up at origin | `container.transport.empty_out` |
+| Empty returned | Empty returned at destination | `container.transport.empty_in` |
 
 Terminal49 also emits milestones Vizion has no equivalent for:
 
@@ -292,7 +296,7 @@ function isReadyForPickup(container) {
 Full detail in [Holds, Fees, and Release Readiness](/api-docs/in-depth-guides/holds-and-fees).
 
 <Info>
-  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Rail LFD and the embeddable widget are the main ones.
+  Holds, fees, LFD, and availability come back on the container object wherever the terminal is a supported source. They are not a paid add-on and they do not require a sales conversation. See [Entitlements](/api-docs/useful-info/entitlements) for the features that do require account enablement. Routing Data (container map and vessel positions), rail LFD, container refresh, and the embeddable map and widget are the gated ones.
 </Info>
 
 ## Gotchas that will bite you
@@ -341,15 +345,15 @@ Rough equivalence for the Vizion errors you are handling today:
 
 | Vizion error | Terminal49 |
 | --- | --- |
-| \[provider auth error\] | HTTP 401 |
-| \[provider permission error\] | HTTP 403 |
-| \[provider rate limit error\] | HTTP 429 |
-| \[provider validation error\] | HTTP 400 or 422 |
-| \[provider carrier not supported\] | HTTP 422 |
-| \[provider no data found\] | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
-| \[provider temporary unavailability\] | Not surfaced. We retry internally. |
+| Auth error | HTTP 401 |
+| Permission error | HTTP 403 |
+| Rate limit error | HTTP 429 |
+| Validation error | HTTP 400 or 422 |
+| Carrier not supported | HTTP 422 |
+| No data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| Temporary unavailability | Not surfaced. We retry internally. |
 
-The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`) and retries rate-limit and server errors automatically with exponential backoff.
+The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
 
 ## Where we are narrower than Vizion
 
@@ -483,7 +487,7 @@ Copy this into your agent. Replace the bracketed placeholders in the **Repo cont
 ```markdown Terminal49 migration agent prompt expandable icon=robot wrap
 You are migrating this codebase from the Vizion tracking API to the Terminal49 API,
 side by side. Terminal49's authoritative migration guide is at
-https://terminal49.com/docs/api-docs/getting-started/migrate-from-vizion. Use it as
+https://terminal49.com/docs/migrate/vizion. Use it as
 the source of truth for field mappings, event names, error codes, and behavior differences.
 
 # Repo context (fill this in before running)
@@ -533,7 +537,7 @@ the source of truth for field mappings, event names, error codes, and behavior d
     tracking request ID.
   - `getShipment(id, { include: 'containers,port_of_lading,port_of_discharge,...' })`.
   - `getContainer(id)`.
-  - `refreshContainer(id)` mapping to `POST /v2/containers/{id}/refresh`.
+  - `refreshContainer(id)` mapping to `PATCH /v2/containers/{id}/refresh`.
 - Normalize responses to the same shape Vizion callers expect today, using the field
   mapping from the guide. Split `iso_code` into `equipment_type`, `equipment_length`,
   `equipment_height`. Convert timestamps to UTC + `time_zone`.
@@ -638,6 +642,6 @@ If something in this mapping is wrong or incomplete, tell us. We would rather fi
   </Card>
 
   <Card title="Test numbers" icon="flask" href="/api-docs/useful-info/test-numbers">
-    Simulate success, failure, and edge cases
+    Simulate success and failure outcomes
   </Card>
 </CardGroup>

--- a/docs/migrate/vizion.mdx
+++ b/docs/migrate/vizion.mdx
@@ -354,7 +354,7 @@ Rough equivalence for the Vizion errors you are handling today:
 | Rate limit error | HTTP 429 |
 | Validation error | HTTP 400 or 422 |
 | Carrier not supported | HTTP 422 |
-| No data found | `tracking_request.failed`, or `awaiting_manifest` if not yet manifested |
+| No data found | `tracking_request.failed`, or `tracking_request.awaiting_manifest` if not yet manifested |
 | Temporary unavailability | Not surfaced. We retry internally. |
 
 The [TypeScript SDK](/sdk/introduction) maps these to typed errors (`AuthenticationError`, `ValidationError`, `RateLimitError`, `UpstreamError`, `FeatureNotEnabledError`, `AuthorizationError`, `NotFoundError`) and retries rate-limit and server errors automatically with exponential backoff.
@@ -438,8 +438,8 @@ Everyone does the base path. Then pick a branch.
   </Tab>
   <Tab title="Polling path">
     <Steps>
-      <Step title="Store the IDs">
-        Keep the tracking request ID and shipment ID from the creation response.
+      <Step title="Store the tracking request ID">
+        The creation response is pending and carries no shipment yet. Keep the tracking request ID, then fetch the tracking request again (or handle `tracking_request.succeeded`) to get the shipment ID once the carrier responds.
       </Step>
       <Step title="Repoint your scheduler">
         Point it at `GET /v2/shipments` or `GET /v2/containers`.
@@ -514,8 +514,8 @@ the source of truth for field mappings, event names, error codes, and behavior d
 4. Terminal49 uses `Authorization: Token <key>` (not `Bearer`) and content type
    `application/vnd.api+json`. Get this right on the first request.
 5. Terminal49 is asynchronous. `POST /tracking_requests` returns pending. Data arrives
-   via `tracking_request.succeeded`, `tracking_request.failed`, or `awaiting_manifest`
-   webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
+   via `tracking_request.succeeded`, `tracking_request.failed`, or
+   `tracking_request.awaiting_manifest` webhooks, or by polling `GET /v2/shipments`. Do not expect shipment data on creation.
 6. Timestamps are UTC with a separate IANA `time_zone` field. Do not assume local time.
 7. `holds_at_pod_terminal: []` and `fees_at_pod_terminal: []` are the normal state,
    not missing data. A fee `amount` of 0 is valid.

--- a/docs/migrate/vizion.mdx
+++ b/docs/migrate/vizion.mdx
@@ -10,11 +10,11 @@ There is no compatibility shim. You will change your request code and your respo
 
 ## Start in sixty seconds
 
-You do not need to talk to anyone to try this.
+Signing up and getting a key is self-serve.
 
 <Steps>
   <Step title="Create an account">
-    Sign up at [app.terminal49.com](https://app.terminal49.com). The free Developer Key tracks up to 10 active containers.
+    Sign up at [app.terminal49.com](https://app.terminal49.com). The free plan tracks up to 10 active containers.
   </Step>
   <Step title="Generate an API key">
     Create a key at [app.terminal49.com/developers/api-keys](https://app.terminal49.com/developers/api-keys).
@@ -41,6 +41,10 @@ You do not need to talk to anyone to try this.
 <Warning>
   The full API key is shown once, right after you create it. Copy it before you navigate away. After that it is masked and cannot be revealed. If you miss it, create a new key and delete the old one.
 </Warning>
+
+<Note>
+  The free plan tracks up to 10 active containers. Creating tracking requests through the API works right away; reading tracking data back through the API requires a free 7-day API trial (same 10-container limit) — contact us via in-app chat or support@terminal49.com and we enable it.
+</Note>
 
 <Tip>
   If you want to test without a live shipment, use the [test tracking numbers](/api-docs/useful-info/test-numbers), which simulate success and failure outcomes.


### PR DESCRIPTION
## Summary
Added a comprehensive migration guide for Gnosis Freight's Container Lifecycle Management (CLM) platform and standardized messaging across all existing migration guides.

## Key Changes

### New Content
- **Added `docs/migrate/gnosisfreight.mdx`**: Complete migration guide covering:
  - OAuth2 authentication to static API key migration
  - Request parameter mapping (MBL numbers to tracking requests)
  - Response field mapping across shipment, container, location, and vessel levels
  - Milestone and event mapping with webhook registration examples
  - Migration checklist and common gotchas
  - Detailed comparison tables for Gnosis Freight vs Terminal49 features

### Documentation Updates
Updated all existing migration guides (`fourkites.mdx`, `project44.mdx`, `beacon.mdx`, `shipsgo.mdx`, `vizion.mdx`, `gocomet.mdx`, `opentrack.mdx`, `searates.mdx`) with:
- Standardized "Start in sixty seconds" section messaging ("Signing up and getting a key is self-serve")
- Consistent free plan description ("free plan tracks up to 10 active containers" instead of "free Developer Key")
- Added standardized notes about API trial requirements and migration offer for Vessels API
- Updated test tracking numbers language ("success and failure outcomes" instead of "success, failure, and edge-case outcomes")
- Clarified carrier auto-detection parameter (`auto_detect_vocc_scac: true` instead of "omit and use Infer")
- Improved table descriptions for terminal holds/fees and last free day ("No direct equivalent" instead of "Not available")
- Fixed authentication scheme descriptions and base URL formatting for consistency
- Removed obsolete `icon` frontmatter from some guides

### Navigation
- Updated `docs/docs.json` to include the new Gnosis Freight guide in the migration section
- Updated `docs/migrate/home.mdx` to reference Gnosis Freight and updated AI tool recommendations

### Minor Fixes
- Removed redundant icon declarations from migration guides
- Standardized equipment type lists (added "bulk" to container type options)
- Clarified routing data entitlement requirements

https://claude.ai/code/session_01X3EP8JGaaRiU4gUE45xpHn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789844954&installation_model_id=18852&pr_number=330&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F330&signature=f40073a313c33650dd889d614e69a31d0a47305c3e09e67dc6c25f9db63bb450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Gnosis Freight migration guide and standardizes onboarding, trial, entitlement, API mapping, and migration-agent guidance across the existing provider guides.

- Adds Gnosis Freight field, event, authentication, and feature mappings.
- Adds the new guide to migration navigation and the migration landing page.
- Updates existing guides with consistent free-trial, carrier-detection, refresh, routing, and Vessels API messaging.
- Expands the entitlement overview to cover on-demand container refresh.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs the Gnosis Freight booking request type corrected before merging so readers are not directed to submit invalid tracking requests.

The new guide maps booking tracking to `request_type: "booking"`, while the public API contract requires `request_type: "booking_number"`, causing validation failures on that migration path.

**Files Needing Attention:** docs/migrate/gnosisfreight.mdx
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/migrate/gnosisfreight.mdx | Adds the comprehensive Gnosis Freight migration guide, but its booking mapping uses an invalid tracking-request enum value. |
| docs/migrate/beacon.mdx | Reworks Beacon authentication, field mappings, API behavior, and migration-agent guidance without an identified actionable defect. |
| docs/migrate/fourkites.mdx | Expands and standardizes FourKites migration guidance, including current refresh and routing entitlement details. |
| docs/migrate/home.mdx | Adds Gnosis Freight to the migration landing page and updates migration-tool recommendations. |
| docs/docs.json | Adds the new Gnosis Freight page to migration navigation with a matching page path. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22claude%2Fmigration-guide-verification-prompt-qsp83u%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fmigration-guide-verification-prompt-qsp83u%22.%0A%0AGreploop%20terminal49%2Fapi%20PR%20%23330%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=terminal49%2Fapi&pr=330&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22claude%2Fmigration-guide-verification-prompt-qsp83u%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fmigration-guide-verification-prompt-qsp83u%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fmigrate%2Fgnosisfreight.mdx%3A131%0A**Invalid%20booking%20request%20type**%0A%0AWhen%20an%20integration%20follows%20this%20mapping%20for%20booking-number%20tracking%2C%20it%20sends%20%60request_type%3A%20%22booking%22%60%2C%20which%20is%20outside%20the%20API's%20accepted%20enum%20and%20causes%20the%20tracking%20request%20to%20fail%20validation%20instead%20of%20tracking%20the%20booking.%0A%0A%60%60%60suggestion%0A%7C%20Booking%2C%20per-container%2C%20and%20air%20variants%20of%20create%20tracking%20request%20%7C%20%60request_type%3A%20%22booking_number%22%60%20or%20%60request_type%3A%20%22container%22%60%20for%20ocean%3B%20no%20air%20equivalent%20%7C%20Container-number%20tracking%20requests%20are%20currently%20in%20beta.%20Air%20cargo%20has%20no%20Terminal49%20equivalent.%20%7C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=330&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fmigrate%2Fgnosisfreight.mdx%3A131%0A**Invalid%20booking%20request%20type**%0A%0AWhen%20an%20integration%20follows%20this%20mapping%20for%20booking-number%20tracking%2C%20it%20sends%20%60request_type%3A%20%22booking%22%60%2C%20which%20is%20outside%20the%20API's%20accepted%20enum%20and%20causes%20the%20tracking%20request%20to%20fail%20validation%20instead%20of%20tracking%20the%20booking.%0A%0A%60%60%60suggestion%0A%7C%20Booking%2C%20per-container%2C%20and%20air%20variants%20of%20create%20tracking%20request%20%7C%20%60request_type%3A%20%22booking_number%22%60%20or%20%60request_type%3A%20%22container%22%60%20for%20ocean%3B%20no%20air%20equivalent%20%7C%20Container-number%20tracking%20requests%20are%20currently%20in%20beta.%20Air%20cargo%20has%20no%20Terminal49%20equivalent.%20%7C%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=330&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/migrate/gnosisfreight.mdx:131
**Invalid booking request type**

When an integration follows this mapping for booking-number tracking, it sends `request_type: "booking"`, which is outside the API's accepted enum and causes the tracking request to fail validation instead of tracking the booking.

```suggestion
| Booking, per-container, and air variants of create tracking request | `request_type: "booking_number"` or `request_type: "container"` for ocean; no air equivalent | Container-number tracking requests are currently in beta. Air cargo has no Terminal49 equivalent. |
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Rewrite Beacon migration guide against B..."](https://github.com/terminal49/api/commit/c3c0458036abd888bbe09ab78bf6284b0d5b4ed0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55287891)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->