### PR TITLE
fix: support Claude MCP protocol 2026-07-28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,34 @@ jobs:
         run: npm run lint --workspace @terminal49/mcp
       - name: Check API gateway (Vite+ and anti-slop)
         run: npm run lint:api
+
+  mcp-protocol-compat:
+    name: MCP protocol ${{ matrix.protocol-version }}
+    runs-on: ${{ (startsWith(vars.CI_RUNNER, 'blacksmith-') && vars.CI_RUNNER) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol-version:
+          - '2026-07-28'
+          - '2025-11-25'
+          - '2025-06-18'
+          - '2025-03-26'
+          - '2024-11-05'
+          - '2024-10-07'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install workspace dependencies
+        run: npm ci
+      - name: Build SDK dependency
+        run: npm run build --workspace @terminal49/sdk
+      - name: Build MCP server
+        run: npm run build --workspace @terminal49/mcp
+      - name: POST protocol handshake to built MCP server
+        env:
+          MCP_PROTOCOL_VERSION: ${{ matrix.protocol-version }}
+        run: npm run test:protocol --workspace @terminal49/mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,15 +203,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          comment="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+          preview_url="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --paginate \
-            --jq '[.[] | select(.user.login == "vercel[bot]" or .user.login == "vercel")][-1].body')"
-          if [[ "$comment" =~ \[Preview\]\((https://[^)]+\.vercel\.app)\) ]]; then
-            echo "endpoint=${BASH_REMATCH[1]}/mcp" >> "$GITHUB_OUTPUT"
-          else
+            --jq '[.[] | select(.user.login == "vercel[bot]" or .user.login == "vercel")][-1].body | capture("\\[Preview\\]\\((?<url>https://[^)]+\\.vercel\\.app)\\)").url')"
+          if [[ -z "$preview_url" ]]; then
             echo "Could not resolve Vercel preview URL"
             exit 1
           fi
+          echo "endpoint=${preview_url}/mcp" >> "$GITHUB_OUTPUT"
       - name: POST handshake and tools/list to Vercel preview
         env:
           MCP_HTTP_ENDPOINT: ${{ steps.preview.outputs.endpoint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,10 @@ jobs:
 
   mcp-preview-protocol:
     name: MCP preview ${{ matrix.protocol-version }}
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     needs: [mcp, mcp-protocol-compat]
     runs-on: ${{ (startsWith(vars.CI_RUNNER, 'blacksmith-') && vars.CI_RUNNER) || 'blacksmith-4vcpu-ubuntu-2404' }}
     strategy:
@@ -167,15 +170,31 @@ jobs:
           - '2026-07-28'
           - '2025-11-25'
     steps:
+      - name: Check preview credential availability
+        id: credential
+        env:
+          MCP_EVAL_TOKEN: ${{ secrets.MCP_EVAL_TOKEN }}
+        run: |
+          if [[ -n "$MCP_EVAL_TOKEN" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping authenticated preview smoke because MCP_EVAL_TOKEN is unavailable"
+          fi
       - uses: actions/checkout@v4
+        if: steps.credential.outputs.available == 'true'
       - uses: actions/setup-node@v6
+        if: steps.credential.outputs.available == 'true'
         with:
           node-version: 24
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - name: Install workspace dependencies
+        if: steps.credential.outputs.available == 'true'
         run: npm ci
       - name: Wait for this commit's Vercel preview
+        if: steps.credential.outputs.available == 'true'
+        id: vercel
         env:
           GH_TOKEN: ${{ github.token }}
           PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
@@ -197,23 +216,47 @@ jobs:
             echo "Timed out waiting for Vercel preview for ${PREVIEW_SHA}"
             exit 1
           fi
+          inspector_url="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PREVIEW_SHA}/status" \
+            --jq '[.statuses[] | select(.context == "Vercel")][0].target_url // empty')"
+          if [[ -z "$inspector_url" ]]; then
+            echo "Vercel status for ${PREVIEW_SHA} has no deployment URL"
+            exit 1
+          fi
+          echo "inspector-url=${inspector_url}" >> "$GITHUB_OUTPUT"
       - name: Resolve Vercel preview endpoint
+        if: steps.credential.outputs.available == 'true'
         id: preview
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERCEL_INSPECTOR_URL: ${{ steps.vercel.outputs.inspector-url }}
         run: |
           preview_url="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --paginate \
-            --jq '[.[] | select(.user.login == "vercel[bot]" or .user.login == "vercel")][-1].body | capture("\\[Preview\\]\\((?<url>https://[^)]+\\.vercel\\.app)\\)").url')"
+            --paginate --slurp | jq -r --arg inspector "$VERCEL_INSPECTOR_URL" \
+            'flatten | [.[] | select((.user.login == "vercel[bot]" or .user.login == "vercel") and (.body | contains($inspector)))][-1].body // "" | (try capture("\\[Preview\\]\\((?<url>https://[^)]+\\.vercel\\.app)\\)") catch {}) | .url // empty')"
           if [[ -z "$preview_url" ]]; then
-            echo "Could not resolve Vercel preview URL"
+            echo "Could not resolve a Vercel preview URL for ${VERCEL_INSPECTOR_URL}"
             exit 1
           fi
           echo "endpoint=${preview_url}/mcp" >> "$GITHUB_OUTPUT"
       - name: POST handshake and tools/list to Vercel preview
+        if: steps.credential.outputs.available == 'true'
         env:
           MCP_HTTP_ENDPOINT: ${{ steps.preview.outputs.endpoint }}
           MCP_HTTP_TOKEN: ${{ secrets.MCP_EVAL_TOKEN }}
           MCP_PROTOCOL_VERSION: ${{ matrix.protocol-version }}
         run: npm run test:http-protocol --workspace @terminal49/mcp
+      - name: Verify preview still belongs to this commit
+        if: steps.credential.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERCEL_INSPECTOR_URL: ${{ steps.vercel.outputs.inspector-url }}
+        run: |
+          matches="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp | jq -r --arg inspector "$VERCEL_INSPECTOR_URL" \
+            'flatten | [.[] | select((.user.login == "vercel[bot]" or .user.login == "vercel") and (.body | contains($inspector)))] | length')"
+          if [[ "$matches" != "1" ]]; then
+            echo "Vercel preview changed while the smoke test was running"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,22 +178,23 @@ jobs:
       - name: Wait for this commit's Vercel preview
         env:
           GH_TOKEN: ${{ github.token }}
+          PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           state=pending
           for attempt in {1..60}; do
-            state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status" \
+            state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PREVIEW_SHA}/status" \
               --jq '[.statuses[] | select(.context == "Vercel")][0].state // "pending"')"
             if [[ "$state" == "success" ]]; then
               break
             fi
             if [[ "$state" == "failure" || "$state" == "error" ]]; then
-              echo "Vercel preview failed for ${GITHUB_SHA}"
+              echo "Vercel preview failed for ${PREVIEW_SHA}"
               exit 1
             fi
             sleep 10
           done
           if [[ "$state" != "success" ]]; then
-            echo "Timed out waiting for Vercel preview for ${GITHUB_SHA}"
+            echo "Timed out waiting for Vercel preview for ${PREVIEW_SHA}"
             exit 1
           fi
       - name: Resolve Vercel preview endpoint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, master, feature/**]
 
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+
 jobs:
   # Consumer compatibility: the standalone SDK lockfile on every supported
   # Node version, with no workspace tooling involved.
@@ -149,3 +154,66 @@ jobs:
         env:
           MCP_PROTOCOL_VERSION: ${{ matrix.protocol-version }}
         run: npm run test:protocol --workspace @terminal49/mcp
+
+  mcp-preview-protocol:
+    name: MCP preview ${{ matrix.protocol-version }}
+    if: github.event_name == 'pull_request'
+    needs: [mcp, mcp-protocol-compat]
+    runs-on: ${{ (startsWith(vars.CI_RUNNER, 'blacksmith-') && vars.CI_RUNNER) || 'blacksmith-4vcpu-ubuntu-2404' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol-version:
+          - '2026-07-28'
+          - '2025-11-25'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install workspace dependencies
+        run: npm ci
+      - name: Wait for this commit's Vercel preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          state=pending
+          for attempt in {1..60}; do
+            state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/status" \
+              --jq '[.statuses[] | select(.context == "Vercel")][0].state // "pending"')"
+            if [[ "$state" == "success" ]]; then
+              break
+            fi
+            if [[ "$state" == "failure" || "$state" == "error" ]]; then
+              echo "Vercel preview failed for ${GITHUB_SHA}"
+              exit 1
+            fi
+            sleep 10
+          done
+          if [[ "$state" != "success" ]]; then
+            echo "Timed out waiting for Vercel preview for ${GITHUB_SHA}"
+            exit 1
+          fi
+      - name: Resolve Vercel preview endpoint
+        id: preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          comment="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq '[.[] | select(.user.login == "vercel[bot]" or .user.login == "vercel")][-1].body')"
+          if [[ "$comment" =~ \[Preview\]\((https://[^)]+\.vercel\.app)\) ]]; then
+            echo "endpoint=${BASH_REMATCH[1]}/mcp" >> "$GITHUB_OUTPUT"
+          else
+            echo "Could not resolve Vercel preview URL"
+            exit 1
+          fi
+      - name: POST handshake and tools/list to Vercel preview
+        env:
+          MCP_HTTP_ENDPOINT: ${{ steps.preview.outputs.endpoint }}
+          MCP_HTTP_TOKEN: ${{ secrets.MCP_EVAL_TOKEN }}
+          MCP_PROTOCOL_VERSION: ${{ matrix.protocol-version }}
+        run: npm run test:http-protocol --workspace @terminal49/mcp

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -8,8 +8,11 @@
 import '../packages/mcp/src/instrument.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createMcpHandler,
+  type McpHttpHandler,
+} from '@modelcontextprotocol/server';
+import { toNodeHandler } from '@modelcontextprotocol/node';
 import * as Sentry from '@sentry/node';
 import { createTerminal49McpServer } from '../packages/mcp/src/server.js';
 import { flushPostHogEvents } from '../packages/mcp/src/posthog.js';
@@ -37,7 +40,7 @@ function setCorsHeaders(res: ResponseLike): void {
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id',
+    'Content-Type, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id',
   );
 }
 
@@ -385,8 +388,7 @@ export default async function handler(
     return;
   }
 
-  let server: McpServer | undefined;
-  let transport: StreamableHTTPServerTransport | undefined;
+  let mcpHandler: McpHttpHandler | undefined;
   let cleanupPromise: Promise<void> | null = null;
   let shouldFlushSentry = false;
 
@@ -399,21 +401,12 @@ export default async function handler(
       const cleanupErrors: string[] = [];
       logLifecycle('mcp.request.cleanup.start', requestId, { reason });
 
-      if (transport?.close) {
+      if (mcpHandler) {
         try {
-          await transport.close();
+          await mcpHandler.close();
         } catch (error) {
           const err = error as Error;
-          cleanupErrors.push(`transport.close: ${err.message}`);
-        }
-      }
-
-      if (server?.close) {
-        try {
-          await server.close();
-        } catch (error) {
-          const err = error as Error;
-          cleanupErrors.push(`server.close: ${err.message}`);
+          cleanupErrors.push(`handler.close: ${err.message}`);
         }
       }
 
@@ -552,15 +545,32 @@ export default async function handler(
 
     setCorsHeaders(res);
 
-    // Create MCP server and per-request transport.
-    server = createTerminal49McpServer(
-      resolvedTerminal49Auth.apiToken,
-      process.env.T49_API_BASE_URL,
-      resolvedTerminal49Auth.accountId,
+    const observeMcpError = (error: Error): void => {
+      captureMcpException(error);
+      shouldFlushSentry = true;
+      logLifecycle('mcp.request.error', requestId, {
+        error: error.name,
+        message: error.message,
+      });
+    };
+
+    // The v2 HTTP entry serves the 2026-07-28 per-request protocol and keeps
+    // the established stateless 2025-era path for older clients.
+    mcpHandler = createMcpHandler(
+      () =>
+        createTerminal49McpServer(
+          resolvedTerminal49Auth.apiToken,
+          process.env.T49_API_BASE_URL,
+          resolvedTerminal49Auth.accountId,
+        ),
+      {
+        legacy: 'stateless',
+        responseMode: 'json',
+        onerror: observeMcpError,
+      },
     );
-    transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined, // Stateless mode
-      enableJsonResponse: true, // Return JSON instead of SSE
+    const nodeHandler = toNodeHandler(mcpHandler, {
+      onerror: observeMcpError,
     });
 
     // Clean up on response lifecycle and also in finally to guarantee closure.
@@ -571,9 +581,7 @@ export default async function handler(
       scheduleCleanup('response_finish');
     });
 
-    // Connect server to transport and handle request
-    await server.connect(transport);
-    await transport.handleRequest(req, res, req.body);
+    await nodeHandler(req, res, req.body);
     logLifecycle('mcp.request.complete', requestId, { reason: 'handled' });
   } catch (error) {
     const err = error as Error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,6 +254,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -271,6 +272,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -288,6 +290,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -305,6 +308,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -322,6 +326,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -339,6 +344,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -356,6 +362,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -373,6 +380,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -390,6 +398,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -407,6 +416,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -424,6 +434,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -441,6 +452,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -458,6 +470,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -475,6 +488,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -492,6 +506,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -509,6 +524,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -526,6 +542,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -543,6 +560,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -560,6 +578,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -577,6 +596,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -594,6 +614,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -611,6 +632,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -628,6 +650,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -645,6 +668,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -662,6 +686,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -679,6 +704,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3182,11 +3208,64 @@
         "zod": "^3.20.0"
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3220,6 +3299,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -4191,34 +4283,43 @@
       }
     },
     "node_modules/@posthog/mcp": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@posthog/mcp/-/mcp-0.10.1.tgz",
-      "integrity": "sha512-TMe6BvDCzMMaWP30jMuJKWDbqrDZ6xLjknzQFGXkaD5EPiq4EcU8FImjZBSZ6l1ipQdnPmkx2Z+R4bKhlx9Z6A==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@posthog/mcp/-/mcp-0.11.7.tgz",
+      "integrity": "sha512-hDokMScYN1LAYbQdO4vBSF7/hpnC0WvEz0xpC/m1zru7jaNXFIy8AMm4F6K40J3BX0EE9LzNdAPPA1bp5ntxsQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "^1.45.1"
+        "@posthog/core": "^1.48.2"
       },
       "engines": {
         "node": "^20.20.0 || >=22.22.0"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": ">=1.26.0",
+        "@modelcontextprotocol/server": ">=2.0.0",
         "posthog-node": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "@modelcontextprotocol/server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@posthog/mcp/node_modules/@posthog/core": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.48.1.tgz",
-      "integrity": "sha512-mxw31XdYgt/SnlwqLPAcltK67q+QmsiYjVLGQ4GbBc8OJ7O4yRFSDwAXt8QsokHokeyEZtTRWM6jDHL7LYMx1A==",
+      "version": "1.48.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.48.6.tgz",
+      "integrity": "sha512-lvSO1nrxxakrAfB51fetHC29gSqdDtT+AyRrGlnc5nDSWhiBGtyqKNjDqsbnlTQoj14bAaWXS7RtzuGoTo5IsQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "^1.404.1"
+        "@posthog/types": "^1.405.0"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.404.1",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.404.1.tgz",
-      "integrity": "sha512-i2Gei6ARfOSBeTN4s2yUP1p97s2UNI+1NWmtLjhnR/V6t3RFOfI1sBWKcJNWHjtoOCCWoAFU+PNPY6SgT2VtEQ==",
+      "version": "1.405.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.405.0.tgz",
+      "integrity": "sha512-4rZ/taVXKQxs9Jrf7ZjlCRgrOSL69oKAgIWJQa5kRNJ6wll1UANbrJTSY+Su1e88LIG4zZVjKKKjyQHCkHdHcw==",
       "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
@@ -6190,6 +6291,8 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -6848,6 +6951,8 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -7556,6 +7661,8 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7603,6 +7710,8 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -8788,6 +8897,8 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8831,6 +8942,8 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -9057,6 +9170,8 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -9176,6 +9291,8 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9973,6 +10090,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10830,7 +10948,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -11134,7 +11254,9 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jsona": {
       "version": "1.12.1",
@@ -12073,6 +12195,8 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12082,6 +12206,8 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -12902,6 +13028,8 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12911,6 +13039,8 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -13339,6 +13469,8 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14083,6 +14215,8 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -14651,6 +14785,8 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -15382,6 +15518,8 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -15550,6 +15688,8 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -15607,6 +15747,8 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -16861,6 +17003,8 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
@@ -16879,6 +17023,8 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18345,6 +18491,8 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
@@ -18363,8 +18511,10 @@
       "name": "@terminal49/mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp": "0.10.1",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0",
+        "@posthog/mcp": "^0.11.7",
         "@sentry/node": "^10.55.0",
         "@terminal49/sdk": "0.3.1",
         "posthog-node": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3212,6 +3212,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
       "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/core": "2.0.0",
@@ -8802,6 +8803,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -8814,6 +8816,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -14275,6 +14278,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -18511,7 +18515,6 @@
       "name": "@terminal49/mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/server": "^2.0.0",
         "@posthog/mcp": "^0.11.7",
@@ -18521,6 +18524,7 @@
         "zod": "~4.3.6"
       },
       "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@types/node": "^24.10.13",
         "@vitest/coverage-v8": "4.1.10",
         "tsx": "^4.22.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,8 +25,10 @@
     "eval:check": "tsc --noEmit -p tsconfig.eval.json"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@posthog/mcp": "0.10.1",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
+    "@posthog/mcp": "^0.11.7",
     "@sentry/node": "^10.55.0",
     "@terminal49/sdk": "0.3.1",
     "posthog-node": "^5.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,6 +15,7 @@
     "build": "tsc",
     "test": "vp test",
     "test:coverage": "vp test --run --coverage",
+    "test:http-protocol": "node scripts/http-protocol-smoke.mjs",
     "test:protocol": "node scripts/protocol-smoke.mjs",
     "lint": "vp lint src && vp fmt --check src",
     "format": "vp fmt --write src",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -25,7 +25,6 @@
     "eval:check": "tsc --noEmit -p tsconfig.eval.json"
   },
   "dependencies": {
-    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@posthog/mcp": "^0.11.7",
@@ -35,6 +34,7 @@
     "zod": "~4.3.6"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/node": "^24.10.13",
     "@vitest/coverage-v8": "4.1.10",
     "tsx": "^4.22.4",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,6 +15,7 @@
     "build": "tsc",
     "test": "vp test",
     "test:coverage": "vp test --run --coverage",
+    "test:protocol": "node scripts/protocol-smoke.mjs",
     "lint": "vp lint src && vp fmt --check src",
     "format": "vp fmt --write src",
     "format:check": "vp fmt --check src",

--- a/packages/mcp/scripts/http-protocol-smoke.mjs
+++ b/packages/mcp/scripts/http-protocol-smoke.mjs
@@ -1,0 +1,91 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+
+const endpoint = process.env.MCP_HTTP_ENDPOINT;
+const protocolVersion = process.env.MCP_PROTOCOL_VERSION;
+const token = process.env.MCP_HTTP_TOKEN;
+const scheme = process.env.MCP_HTTP_AUTH_SCHEME || 'Token';
+
+if (!endpoint) {
+  throw new Error('MCP_HTTP_ENDPOINT is required');
+}
+if (!protocolVersion) {
+  throw new Error('MCP_PROTOCOL_VERSION is required');
+}
+if (!token) {
+  throw new Error(
+    'MCP_HTTP_TOKEN is required because the deployed Terminal49 MCP rejects unauthenticated handshakes',
+  );
+}
+
+const isModern = protocolVersion === '2026-07-28';
+const expectedHandshake = isModern ? 'server/discover' : 'initialize';
+const observedRequests = [];
+
+const client = new Client(
+  { name: 'terminal49-preview-protocol-ci', version: '1.0.0' },
+  isModern
+    ? { versionNegotiation: { mode: { pin: protocolVersion } } }
+    : { supportedProtocolVersions: [protocolVersion] },
+);
+const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
+  requestInit: {
+    headers: {
+      Authorization: `${scheme} ${token}`,
+    },
+  },
+  fetch: async (url, init) => {
+    const requestBody =
+      typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+    if (requestBody?.method) {
+      observedRequests.push(requestBody.method);
+    }
+
+    const response = await fetch(url, init);
+    const responseBody = await response.clone().text();
+    if (
+      response.status === 400 ||
+      /unsupported protocol version/i.test(responseBody)
+    ) {
+      throw new Error(
+        `Preview rejected ${protocolVersion} (${response.status}): ${responseBody}`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Preview request failed for ${protocolVersion} (${response.status}): ${responseBody}`,
+      );
+    }
+    return response;
+  },
+});
+
+try {
+  await client.connect(transport);
+
+  if (client.getNegotiatedProtocolVersion() !== protocolVersion) {
+    throw new Error(
+      `Expected ${protocolVersion}, negotiated ${client.getNegotiatedProtocolVersion() ?? 'nothing'}`,
+    );
+  }
+  if (!observedRequests.includes(expectedHandshake)) {
+    throw new Error(
+      `Expected ${expectedHandshake} POST for ${protocolVersion}; observed ${observedRequests.join(', ')}`,
+    );
+  }
+
+  const { tools } = await client.listTools();
+  if (tools.length !== 10) {
+    throw new Error(
+      `Expected 10 preview tools over ${protocolVersion}, received ${tools.length}`,
+    );
+  }
+
+  console.log(
+    `Preview MCP ${protocolVersion}: ${expectedHandshake} accepted; ${tools.length} tools listed`,
+  );
+} finally {
+  await client.close();
+}

--- a/packages/mcp/scripts/protocol-smoke.mjs
+++ b/packages/mcp/scripts/protocol-smoke.mjs
@@ -1,0 +1,82 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { createMcpHandler } from '@modelcontextprotocol/server';
+import { createTerminal49McpServer } from '../dist/server.js';
+
+const protocolVersion = process.env.MCP_PROTOCOL_VERSION;
+if (!protocolVersion) {
+  throw new Error('MCP_PROTOCOL_VERSION is required');
+}
+
+const isModern = protocolVersion === '2026-07-28';
+const expectedHandshake = isModern ? 'server/discover' : 'initialize';
+const observedRequests = [];
+
+const handler = createMcpHandler(
+  () => createTerminal49McpServer('ci-test-token', 'https://api.test'),
+  {
+    legacy: 'stateless',
+    responseMode: 'json',
+  },
+);
+const client = new Client(
+  { name: 'terminal49-protocol-ci', version: '1.0.0' },
+  isModern
+    ? { versionNegotiation: { mode: { pin: protocolVersion } } }
+    : { supportedProtocolVersions: [protocolVersion] },
+);
+const transport = new StreamableHTTPClientTransport(
+  new URL('https://mcp.test/mcp'),
+  {
+    fetch: async (url, init) => {
+      const requestBody =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+      if (requestBody?.method) {
+        observedRequests.push(requestBody.method);
+      }
+
+      const response = await handler.fetch(new Request(url, init));
+      const responseBody = await response.clone().text();
+      if (
+        response.status === 400 ||
+        /unsupported protocol version/i.test(responseBody)
+      ) {
+        throw new Error(
+          `Protocol ${protocolVersion} was rejected (${response.status}): ${responseBody}`,
+        );
+      }
+      return response;
+    },
+  },
+);
+
+try {
+  await client.connect(transport);
+
+  if (client.getNegotiatedProtocolVersion() !== protocolVersion) {
+    throw new Error(
+      `Expected ${protocolVersion}, negotiated ${client.getNegotiatedProtocolVersion() ?? 'nothing'}`,
+    );
+  }
+  if (!observedRequests.includes(expectedHandshake)) {
+    throw new Error(
+      `Expected ${expectedHandshake} POST for ${protocolVersion}; observed ${observedRequests.join(', ')}`,
+    );
+  }
+
+  const { tools } = await client.listTools();
+  if (tools.length !== 10) {
+    throw new Error(
+      `Expected 10 tools over ${protocolVersion}, received ${tools.length}`,
+    );
+  }
+
+  console.log(
+    `MCP ${protocolVersion}: ${expectedHandshake} accepted; ${tools.length} tools listed`,
+  );
+} finally {
+  await client.close();
+  await handler.close();
+}

--- a/packages/mcp/src/mcp.test.ts
+++ b/packages/mcp/src/mcp.test.ts
@@ -1,3 +1,8 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { createMcpHandler } from '@modelcontextprotocol/server';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   buildListContract,
@@ -475,12 +480,59 @@ describe('MCP server wiring', () => {
     expect(instructions.length).toBeGreaterThan(400);
   });
 
-  it('registers the completions capability so carrier SCAC completion is reachable', () => {
-    const server = createTerminal49McpServer('token');
+  it('returns carrier SCAC completion values over MCP', async () => {
+    shippingLinesList.mockResolvedValue([
+      { scac: 'MAEU', name: 'Maersk', shortName: 'Maersk' },
+      {
+        scac: 'MSCU',
+        name: 'Mediterranean Shipping Company',
+        shortName: 'MSC',
+      },
+    ]);
 
-    const capabilities = (server as any).server.getCapabilities();
-    expect(capabilities.completions).toBeDefined();
-    expect((server as any)._completionHandlerInitialized).toBe(true);
+    const handler = createMcpHandler(
+      () => createTerminal49McpServer('token', 'https://api.test'),
+      {
+        legacy: 'stateless',
+        responseMode: 'json',
+      },
+    );
+    const client = new Client(
+      { name: 'terminal49-completion-test', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL('https://mcp.test/mcp'),
+      {
+        fetch: (url, init) => handler.fetch(new Request(url, init)),
+      },
+    );
+
+    try {
+      await client.connect(transport);
+
+      const broadMatch = await client.complete({
+        ref: { type: 'ref/prompt', name: 'track-shipment' },
+        argument: { name: 'carrier', value: 'm' },
+      });
+      expect(broadMatch.completion.values).toEqual(['MAEU', 'MSCU']);
+
+      const narrowMatch = await client.complete({
+        ref: { type: 'ref/prompt', name: 'track-shipment' },
+        argument: { name: 'carrier', value: 'ma' },
+      });
+      expect(narrowMatch.completion.values).toEqual(['MAEU']);
+
+      shippingLinesList.mockRejectedValue(new Error('upstream unavailable'));
+      const degraded = await client.complete({
+        ref: { type: 'ref/prompt', name: 'track-shipment' },
+        argument: { name: 'carrier', value: 'ma' },
+      });
+      expect(degraded.completion.values).toEqual([]);
+    } finally {
+      await client.close();
+      await handler.close();
+    }
   });
 
   it('list_containers result includes resource_link blocks with valid container URIs', async () => {

--- a/packages/mcp/src/mcp.test.ts
+++ b/packages/mcp/src/mcp.test.ts
@@ -1,4 +1,3 @@
-import { getCompleter } from '@modelcontextprotocol/sdk/server/completable.js';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   buildListContract,
@@ -34,15 +33,6 @@ beforeEach(() => {
   shippingLinesList.mockReset();
   containersList.mockReset();
 });
-
-// The SDK stores prompt arg schemas as a Zod object. Zod v3 exposes `.shape`;
-// Zod v4 keeps it on `_zod.def.shape`. Read it the way the SDK does so the
-// completion test stays version-robust.
-function getArgShape(argsSchema: any): Record<string, unknown> {
-  const v4Shape = argsSchema?._zod?.def?.shape;
-  const v3Shape = argsSchema?.shape;
-  return (v4Shape ?? v3Shape) as Record<string, unknown>;
-}
 
 function _hasResponseContract(schema: unknown): boolean {
   const typedSchema = schema as {
@@ -485,67 +475,12 @@ describe('MCP server wiring', () => {
     expect(instructions.length).toBeGreaterThan(400);
   });
 
-  it('registers the completions capability so carrier SCAC completion is reachable', async () => {
-    shippingLinesList.mockResolvedValue([
-      { scac: 'MAEU', name: 'Maersk', shortName: 'Maersk' },
-      {
-        scac: 'MSCU',
-        name: 'Mediterranean Shipping Company',
-        shortName: 'MSC',
-      },
-    ]);
-
+  it('registers the completions capability so carrier SCAC completion is reachable', () => {
     const server = createTerminal49McpServer('token');
 
-    // PRIMARY (registered-path) assertion. This is the actual HIGH-finding
-    // fix: `completable` must wrap the INNER string with `.optional()` applied
-    // AFTER, because the SDK unwraps ZodOptional before checking isCompletable
-    // when deciding whether to advertise `completions` and register a
-    // completion handler. With the previous OUTER-optional wiring the symbol
-    // sat on the ZodOptional, the SDK's unwrap missed it, and the capability
-    // was NEVER advertised — so these two assertions FAIL against the pre-fix
-    // wiring and PASS only once Fix 1 is applied.
     const capabilities = (server as any).server.getCapabilities();
     expect(capabilities.completions).toBeDefined();
     expect((server as any)._completionHandlerInitialized).toBe(true);
-
-    // SECONDARY (unit) assertion on the completion VALUES. We resolve the
-    // completer exactly the way the SDK's prompt registration does — unwrap
-    // the ZodOptional and read isCompletable/getCompleter off the inner
-    // string — then exercise it. (The SDK's prompt-completion *handler* checks
-    // isCompletable on the un-unwrapped optional field, so values are surfaced
-    // here via the same inner-string the registration keys off, rather than
-    // through handlePromptCompletion.)
-    const prompt = (server as any)._registeredPrompts['track-shipment'];
-    const carrierField = getArgShape(prompt.argsSchema).carrier as {
-      _def?: { innerType?: unknown };
-    };
-    // Symbol lives on the inner string, not the outer ZodOptional.
-    expect(getCompleter(carrierField as any)).toBeUndefined();
-    const innerCompleter = getCompleter(carrierField._def?.innerType as any);
-    expect(innerCompleter).toBeTypeOf('function');
-
-    // "m" matches Maersk (MAEU) and Mediterranean (MSCU); "ma" matches only Maersk.
-    expect(await innerCompleter!('m', undefined)).toEqual(['MAEU', 'MSCU']);
-    expect(await innerCompleter!('ma', undefined)).toEqual(['MAEU']);
-
-    // The completer reused the live supported-lines lookup, filtered by input.
-    expect(shippingLinesList).toHaveBeenCalled();
-  });
-
-  it('carrier completion degrades to empty suggestions when the API errors', async () => {
-    shippingLinesList.mockRejectedValue(new Error('upstream unavailable'));
-
-    const server = createTerminal49McpServer('token');
-    const prompt = (server as any)._registeredPrompts['track-shipment'];
-    // Resolve the completer off the inner string (the ZodOptional wraps it),
-    // matching how the SDK keys completion off the unwrapped inner schema.
-    const carrierField = getArgShape(prompt.argsSchema).carrier as {
-      _def?: { innerType?: unknown };
-    };
-    const completer = getCompleter(carrierField._def?.innerType as any);
-
-    await expect(completer!('ma', undefined)).resolves.toEqual([]);
   });
 
   it('list_containers result includes resource_link blocks with valid container URIs', async () => {

--- a/packages/mcp/src/posthog.test.ts
+++ b/packages/mcp/src/posthog.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 
 const instrumentMock = vi.fn();
 const postHogConstructed = vi.fn();

--- a/packages/mcp/src/posthog.ts
+++ b/packages/mcp/src/posthog.ts
@@ -16,8 +16,7 @@
  *
  * @see https://posthog.com/docs/mcp-analytics/installation
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { BeforeSendFn, UserIdentity } from '@posthog/mcp';
 // `PostHog` is imported from `@posthog/mcp`'s re-export rather than from
 // `posthog-node` directly, and deliberately so. `posthog-node` is a *peer*

--- a/packages/mcp/src/protocol-compat.test.ts
+++ b/packages/mcp/src/protocol-compat.test.ts
@@ -1,0 +1,91 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { createMcpHandler } from '@modelcontextprotocol/server';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { createTerminal49McpServer } from './server.js';
+
+const openConnections: Array<{
+  client: Client;
+  handler: ReturnType<typeof createMcpHandler>;
+}> = [];
+
+async function connectClient(
+  options: { era: 'modern' } | { era: 'legacy'; protocolVersion: '2025-11-25' },
+): Promise<Client> {
+  const handler = createMcpHandler(
+    () => createTerminal49McpServer('test-token', 'https://api.test'),
+    {
+      legacy: 'stateless',
+      responseMode: 'json',
+    },
+  );
+  const client = new Client(
+    { name: 'terminal49-protocol-test', version: '1.0.0' },
+    options.era === 'modern'
+      ? { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+      : { supportedProtocolVersions: [options.protocolVersion] },
+  );
+  const transport = new StreamableHTTPClientTransport(
+    new URL('https://mcp.test/mcp'),
+    {
+      fetch: (url, init) => handler.fetch(new Request(url, init)),
+    },
+  );
+
+  await client.connect(transport);
+  openConnections.push({ client, handler });
+  return client;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    openConnections.splice(0).map(async ({ client, handler }) => {
+      await client.close();
+      await handler.close();
+    }),
+  );
+});
+
+describe('MCP protocol compatibility', () => {
+  it.each([
+    { era: 'modern' as const, protocolVersion: '2026-07-28' },
+    {
+      era: 'legacy' as const,
+      protocolVersion: '2025-11-25' as const,
+    },
+  ])(
+    'lists the complete server surface over $protocolVersion',
+    async ({ era, protocolVersion }) => {
+      const client =
+        era === 'modern'
+          ? await connectClient({ era })
+          : await connectClient({ era, protocolVersion });
+
+      expect(client.getProtocolEra()).toBe(era);
+      expect(client.getNegotiatedProtocolVersion()).toBe(protocolVersion);
+
+      const [{ tools }, { prompts }, { resources }, { resourceTemplates }] =
+        await Promise.all([
+          client.listTools(),
+          client.listPrompts(),
+          client.listResources(),
+          client.listResourceTemplates(),
+        ]);
+
+      expect(tools).toHaveLength(10);
+      expect(prompts).toHaveLength(3);
+      expect(resources).toHaveLength(3);
+      expect(resourceTemplates).toHaveLength(1);
+
+      for (const tool of tools) {
+        expect(tool.annotations).toMatchObject({
+          readOnlyHint: false,
+          destructiveHint: false,
+          openWorldHint: false,
+        });
+      }
+    },
+  );
+});

--- a/packages/mcp/src/protocol-compat.test.ts
+++ b/packages/mcp/src/protocol-compat.test.ts
@@ -6,13 +6,26 @@ import { createMcpHandler } from '@modelcontextprotocol/server';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import { createTerminal49McpServer } from './server.js';
 
+const LEGACY_PROTOCOL_VERSIONS = [
+  '2025-11-25',
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+  '2024-10-07',
+] as const;
+
 const openConnections: Array<{
   client: Client;
   handler: ReturnType<typeof createMcpHandler>;
 }> = [];
 
 async function connectClient(
-  options: { era: 'modern' } | { era: 'legacy'; protocolVersion: '2025-11-25' },
+  options:
+    | { era: 'modern' }
+    | {
+        era: 'legacy';
+        protocolVersion: (typeof LEGACY_PROTOCOL_VERSIONS)[number];
+      },
 ): Promise<Client> {
   const handler = createMcpHandler(
     () => createTerminal49McpServer('test-token', 'https://api.test'),
@@ -51,10 +64,10 @@ afterEach(async () => {
 describe('MCP protocol compatibility', () => {
   it.each([
     { era: 'modern' as const, protocolVersion: '2026-07-28' },
-    {
+    ...LEGACY_PROTOCOL_VERSIONS.map((protocolVersion) => ({
       era: 'legacy' as const,
-      protocolVersion: '2025-11-25' as const,
-    },
+      protocolVersion,
+    })),
   ])(
     'lists the complete server surface over $protocolVersion',
     async ({ era, protocolVersion }) => {

--- a/packages/mcp/src/sentry.ts
+++ b/packages/mcp/src/sentry.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import * as Sentry from '@sentry/node';
 
 type Environment = NodeJS.ProcessEnv;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,14 +1,13 @@
 /**
  * Terminal49 MCP Server
- * Implementation using @modelcontextprotocol/sdk with McpServer API
+ * Implementation using the MCP TypeScript SDK v2 McpServer API
  */
-
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import {
+  completable,
   McpServer,
   ResourceTemplate,
-} from '@modelcontextprotocol/sdk/server/mcp.js';
-import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+} from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { Terminal49Client } from '@terminal49/sdk';
 import { executeGetContainer } from './tools/get-container.js';
@@ -37,7 +36,6 @@ import {
 import {
   instrumentMcpServerWithPostHog,
   registerPostHogExitHook,
-  shutdownPostHog,
 } from './posthog.js';
 import {
   captureMcpException,
@@ -1215,7 +1213,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         query: z
           .string()
           .min(1)
@@ -1223,8 +1221,8 @@ export function createTerminal49McpServer(
             'Search query - can be a container number, booking number, BL number, or reference number',
           ),
         intent: toolIntentSchema,
-      },
-      outputSchema: {
+      }),
+      outputSchema: z.object({
         containers: z.array(
           z.object({
             id: z.string(),
@@ -1247,7 +1245,7 @@ export function createTerminal49McpServer(
         ),
         total_results: z.number(),
         _response_contract: responseContractSchema,
-      },
+      }),
     },
     wrapToolWithContract(
       async ({ query }) => executeSearchContainer({ query }, client),
@@ -1270,7 +1268,7 @@ export function createTerminal49McpServer(
         idempotentHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         number: z
           .string()
           .optional()
@@ -1300,8 +1298,8 @@ export function createTerminal49McpServer(
           .optional()
           .describe('Optional reference numbers for matching'),
         intent: toolIntentSchema,
-      },
-      outputSchema: {
+      }),
+      outputSchema: z.object({
         error: z.string().optional(),
         message: z.string().optional(),
         id: z.string().optional(),
@@ -1310,7 +1308,7 @@ export function createTerminal49McpServer(
         tracking_request_created: z.boolean().optional(),
         infer_result: z.any().optional(),
         _response_contract: responseContractSchema.optional(),
-      },
+      }),
     },
     wrapToolWithContract(
       async ({
@@ -1354,7 +1352,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         id: z
           .string()
           .uuid()
@@ -1370,7 +1368,7 @@ export function createTerminal49McpServer(
               '• transport_events: Full event history, rail tracking (heavy 50-100 events, use for journey/timeline questions)',
           ),
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z
         .object({
           _response_contract: responseContractSchema,
@@ -1397,7 +1395,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         id: z
           .string()
           .uuid()
@@ -1410,7 +1408,7 @@ export function createTerminal49McpServer(
             'Include list of containers in this shipment. Default: true',
           ),
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z
         .object({
           _response_contract: responseContractSchema,
@@ -1439,13 +1437,13 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         id: z
           .string()
           .uuid()
           .describe('The Terminal49 container ID (UUID format)'),
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z
         .object({
           _response_contract: responseContractSchema,
@@ -1472,14 +1470,14 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         search: z
           .string()
           .optional()
           .describe('Optional: Filter by carrier name or SCAC code'),
         intent: toolIntentSchema,
-      },
-      outputSchema: {
+      }),
+      outputSchema: z.object({
         total_lines: z.number(),
         shipping_lines: z.array(
           z.object({
@@ -1496,7 +1494,7 @@ export function createTerminal49McpServer(
           remediation: z.string().optional(),
         }),
         _response_contract: responseContractSchema,
-      },
+      }),
     },
     wrapToolWithContract(
       async ({ search }) =>
@@ -1520,13 +1518,13 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         id: z
           .string()
           .uuid()
           .describe('The Terminal49 container ID (UUID format)'),
         intent: toolIntentSchema,
-      },
+      }),
       // Keep a single permissive schema because this tool can return either
       // route fields or feature-gating fields depending on account capability.
       outputSchema: z.object({
@@ -1604,7 +1602,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         status: z.string().optional().describe('Filter by shipment status'),
         port: z.string().optional().describe('Filter by POD port LOCODE'),
         carrier: z.string().optional().describe('Filter by shipping line SCAC'),
@@ -1621,7 +1619,7 @@ export function createTerminal49McpServer(
         page: listPageSchema,
         page_size: listPageSizeSchema,
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z.object({
         items: z.array(z.record(z.string(), z.any())),
         links: z.record(z.string(), z.string()).optional(),
@@ -1652,7 +1650,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         status: z.string().optional().describe('Filter by container status'),
         port: z.string().optional().describe('Filter by POD port LOCODE'),
         carrier: z.string().optional().describe('Filter by shipping line SCAC'),
@@ -1669,7 +1667,7 @@ export function createTerminal49McpServer(
         page: listPageSchema,
         page_size: listPageSizeSchema,
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z.object({
         items: z.array(z.record(z.string(), z.any())),
         links: z.record(z.string(), z.string()).optional(),
@@ -1704,7 +1702,7 @@ export function createTerminal49McpServer(
         destructiveHint: false,
         openWorldHint: false,
       },
-      inputSchema: {
+      inputSchema: z.object({
         filters: z
           .record(z.string(), z.string())
           .optional()
@@ -1720,7 +1718,7 @@ export function createTerminal49McpServer(
         page: listPageSchema,
         page_size: listPageSizeSchema,
         intent: toolIntentSchema,
-      },
+      }),
       outputSchema: z.object({
         items: z.array(z.record(z.string(), z.any())),
         links: z.record(z.string(), z.string()).optional(),
@@ -1753,7 +1751,7 @@ export function createTerminal49McpServer(
       title: 'Track Container Shipment',
       description:
         'Quick container tracking workflow with carrier autocomplete',
-      argsSchema: {
+      argsSchema: z.object({
         container_number: z
           .string()
           .describe('Container number (e.g., CAIU1234567)'),
@@ -1767,7 +1765,7 @@ export function createTerminal49McpServer(
             .describe('Shipping line SCAC code (e.g., MAEU for Maersk)'),
           completeCarrierScac,
         ).optional(),
-      },
+      }),
     },
     async ({ container_number, carrier }) => ({
       messages: [
@@ -1790,9 +1788,9 @@ export function createTerminal49McpServer(
     {
       title: 'Check Demurrage Risk',
       description: 'Analyze demurrage/detention risk for a container',
-      argsSchema: {
+      argsSchema: z.object({
         container_id: z.string().uuid().describe('Terminal49 container UUID'),
-      },
+      }),
     },
     async ({ container_id }) => ({
       messages: [
@@ -1818,9 +1816,9 @@ export function createTerminal49McpServer(
     {
       title: 'Analyze Journey Delays',
       description: 'Identify delays and root causes in container journey',
-      argsSchema: {
+      argsSchema: z.object({
         container_id: z.string().uuid().describe('Terminal49 container UUID'),
-      },
+      }),
     },
     async ({ container_id }) => ({
       messages: [
@@ -1941,23 +1939,15 @@ export async function runStdioServer() {
     process.exit(1);
   }
 
-  const server = createTerminal49McpServer(apiToken, apiBaseUrl);
-  const transport = new StdioServerTransport();
-
   // Long-lived process: drain queued analytics on natural exit. No-ops (and
   // registers no listener at all) when PostHog is unconfigured.
   registerPostHogExitHook();
 
-  // The client closing stdin ends the session; flush before we lose the events.
-  transport.onclose = () => {
-    void shutdownPostHog();
-  };
-
   if (process.env.T49_MCP_STDIO_BANNER === '1') {
     console.error('Terminal49 MCP Server v1.0.0 running on stdio');
     console.error('Available: 10 tools | 3 prompts | 4 resources');
-    console.error('SDK: @modelcontextprotocol/sdk (McpServer API)');
+    console.error('SDK: @modelcontextprotocol/server v2 (McpServer API)');
   }
 
-  await server.connect(transport);
+  serveStdio(() => createTerminal49McpServer(apiToken, apiBaseUrl));
 }

--- a/packages/mcp/tests/api-handler.test.ts
+++ b/packages/mcp/tests/api-handler.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 const mockState = vi.hoisted(() => ({
   servers: [] as any[],
-  transports: [] as any[],
+  handlers: [] as any[],
+  handlerOptions: [] as any[],
   serverCreateArgs: [] as Array<{
     apiToken: string;
     apiBaseUrl: string | undefined;
@@ -18,7 +19,6 @@ vi.mock('../src/server.js', () => ({
   createTerminal49McpServer: vi.fn(
     (apiToken: string, apiBaseUrl?: string, accountId?: string) => {
       const server = {
-        connect: vi.fn().mockResolvedValue(undefined),
         close: vi.fn().mockResolvedValue(undefined),
       };
 
@@ -29,24 +29,28 @@ vi.mock('../src/server.js', () => ({
   ),
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: class MockStreamableHTTPServerTransport {
-    handleRequest: ReturnType<typeof vi.fn>;
-    close: ReturnType<typeof vi.fn>;
+vi.mock('@modelcontextprotocol/server', () => ({
+  createMcpHandler: vi.fn((factory: () => unknown, options: unknown) => {
+    const handler = {
+      close: vi.fn().mockResolvedValue(undefined),
+      factory,
+    };
+    mockState.handlers.push(handler);
+    mockState.handlerOptions.push(options);
+    return handler;
+  }),
+}));
 
-    constructor() {
-      this.handleRequest = vi.fn(
-        async (req: unknown, res: unknown, body: unknown) => {
-          if (mockState.handleRequestImpl) {
-            await mockState.handleRequestImpl(req, res, body);
-          }
-        },
-      );
-      this.close = vi.fn().mockResolvedValue(undefined);
-
-      mockState.transports.push(this);
-    }
-  },
+vi.mock('@modelcontextprotocol/node', () => ({
+  toNodeHandler: vi.fn(
+    (handler: { factory: () => unknown }) =>
+      async (req: unknown, res: unknown, body: unknown) => {
+        handler.factory();
+        if (mockState.handleRequestImpl) {
+          await mockState.handleRequestImpl(req, res, body);
+        }
+      },
+  ),
 }));
 
 class MockResponse extends EventEmitter {
@@ -100,7 +104,8 @@ describe('api/mcp handler lifecycle', () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     mockState.servers.length = 0;
-    mockState.transports.length = 0;
+    mockState.handlers.length = 0;
+    mockState.handlerOptions.length = 0;
     mockState.serverCreateArgs.length = 0;
     mockState.handleRequestImpl = undefined;
     delete process.env.T49_API_TOKEN;
@@ -117,7 +122,7 @@ describe('api/mcp handler lifecycle', () => {
     delete process.env.T49_MCP_ALLOWED_ORIGINS;
   });
 
-  it('closes transport and server after successful request handling', async () => {
+  it('serves both protocol eras and closes the handler after a request', async () => {
     const { default: handler } = await import('../../../api/mcp.ts');
     const req = createRequest();
     const res = new MockResponse();
@@ -125,16 +130,14 @@ describe('api/mcp handler lifecycle', () => {
     await handler(req as any, res as any);
 
     expect(mockState.servers).toHaveLength(1);
-    expect(mockState.transports).toHaveLength(1);
-
-    const server = mockState.servers[0];
-    const transport = mockState.transports[0];
+    expect(mockState.handlers).toHaveLength(1);
 
     expect(mockState.serverCreateArgs[0]?.apiToken).toBe('test-token');
-    expect(server.connect).toHaveBeenCalledWith(transport);
-    expect(transport.handleRequest).toHaveBeenCalledWith(req, res, req.body);
-    expect(transport.close).toHaveBeenCalledTimes(1);
-    expect(server.close).toHaveBeenCalledTimes(1);
+    expect(mockState.handlerOptions[0]).toMatchObject({
+      legacy: 'stateless',
+      responseMode: 'json',
+    });
+    expect(mockState.handlers[0].close).toHaveBeenCalledTimes(1);
   });
 
   it('returns 500 and still closes transport and server when handler throws', async () => {
@@ -157,10 +160,7 @@ describe('api/mcp handler lifecycle', () => {
     // DEV-10663: the internal error message must never leak to clients.
     expect((res.payload as any)?.error?.data).toBeUndefined();
 
-    const server = mockState.servers[0];
-    const transport = mockState.transports[0];
-    expect(transport.close).toHaveBeenCalledTimes(1);
-    expect(server.close).toHaveBeenCalledTimes(1);
+    expect(mockState.handlers[0].close).toHaveBeenCalledTimes(1);
   });
 
   it('runs cleanup only once when response closes before finally executes', async () => {
@@ -174,10 +174,7 @@ describe('api/mcp handler lifecycle', () => {
 
     await handler(req as any, res as any);
 
-    const server = mockState.servers[0];
-    const transport = mockState.transports[0];
-    expect(transport.close).toHaveBeenCalledTimes(1);
-    expect(server.close).toHaveBeenCalledTimes(1);
+    expect(mockState.handlers[0].close).toHaveBeenCalledTimes(1);
   });
 
   it('accepts Authorization header using Token scheme', async () => {
@@ -229,7 +226,7 @@ describe('api/mcp handler lifecycle', () => {
       error: 'Unauthorized',
     });
     expect(mockState.servers).toHaveLength(0);
-    expect(mockState.transports).toHaveLength(0);
+    expect(mockState.handlers).toHaveLength(0);
   });
 
   it('uses T49_API_TOKEN as upstream credential when Authorization is present', async () => {
@@ -447,7 +444,7 @@ describe('api/mcp handler lifecycle', () => {
       message: 'Invalid client credentials.',
     });
     expect(mockState.servers).toHaveLength(0);
-    expect(mockState.transports).toHaveLength(0);
+    expect(mockState.handlers).toHaveLength(0);
   });
 
   it('returns 500 when T49_API_TOKEN is set without T49_MCP_CLIENT_SECRET', async () => {
@@ -469,7 +466,7 @@ describe('api/mcp handler lifecycle', () => {
       error: 'Server misconfiguration',
     });
     expect(mockState.servers).toHaveLength(0);
-    expect(mockState.transports).toHaveLength(0);
+    expect(mockState.handlers).toHaveLength(0);
   });
 
   it('returns 401 when neither Authorization header nor T49_API_TOKEN is set', async () => {
@@ -488,6 +485,6 @@ describe('api/mcp handler lifecycle', () => {
       error: 'Unauthorized',
     });
     expect(mockState.servers).toHaveLength(0);
-    expect(mockState.transports).toHaveLength(0);
+    expect(mockState.handlers).toHaveLength(0);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -53,7 +53,7 @@
         },
         {
           "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id"
+          "value": "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id"
         }
       ]
     },
@@ -70,7 +70,7 @@
         },
         {
           "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id"
+          "value": "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Session-Id"
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- migrate the public Terminal49 MCP server from the v1 monolith to the official v2 server and Node packages
- accept `2026-07-28` while preserving every previously advertised revision: `2025-11-25`, `2025-06-18`, `2025-03-26`, `2024-11-05`, and `2024-10-07`
- preserve all 10 tools, 3 prompts, 4 resource surfaces, OAuth/WorkOS behavior, conservative tool annotations, and prompt completion behavior
- allow the modern `Mcp-Method` and `Mcp-Name` request headers

## Protocol compatibility CI
- runs a six-entry in-process matrix against the built server for every supported revision
- waits for Vercel success on the PR head commit and correlates the Vercel comment to that commit's deployment inspector URL before selecting the preview endpoint
- re-verifies the same deployment correlation after the smoke request so a concurrent deployment cannot produce a false green result
- gates authenticated preview jobs to same-repository, non-Dependabot PRs and skips smoke steps with a notice when `MCP_EVAL_TOKEN` is unavailable
- preview checks POST `server/discover` for `2026-07-28` (the required modern equivalent; modern MCP has no `initialize` handshake) and `initialize` for `2025-11-25`
- authenticated preview checks call `tools/list` and require exactly 10 public tools

## Regression coverage
- verifies carrier completion values through the public MCP `completion/complete` path on `2026-07-28`: `m` returns `MAEU` and `MSCU`, `ma` returns `MAEU`
- verifies completion API failures still degrade to an empty suggestion list
- verifies every protocol revision receives the complete tools/prompts/resources lists and unchanged annotations

Fixes MCP-SERVER-E

Claude store launch remains blocked until this change is deployed to production. This PR intentionally excludes the separate 5+3 reviewer tool suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa152aa-6393-4cd1-ab56-41dc763eeac8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa152aa-6393-4cd1-ab56-41dc763eeac8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789866683&installation_model_id=18852&pr_number=333&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F333&signature=5b2a7c5b21c635206f964de5a016eeea41d116c4c9a502c93b87ca05e4686082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates the public MCP gateway and server to the official v2 packages, adding the 2026-07-28 protocol while preserving legacy revisions and the existing MCP surface.
- Replaces the v1 HTTP and stdio transports with v2 handlers.
- Converts tool and prompt registrations to v2 Zod object schemas.
- Adds protocol compatibility tests and preview-deployment smoke checks.
- Updates observability integrations, dependencies, and CORS headers for the modern protocol.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking CI reliability issue where preview checks can target a deployment unrelated to the workflow commit.

The production migration has broad protocol and surface coverage, while the accepted concern is limited to commit correlation in the newly added preview validation job.

**Files Needing Attention:** .github/workflows/ci.yml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/mcp.ts | Migrates the authenticated Vercel gateway from the v1 transport to a per-request v2 MCP handler while retaining existing security and cleanup paths. |
| packages/mcp/src/server.ts | Migrates server registrations and stdio serving to the v2 API while preserving the ten tools, three prompts, resources, and completion behavior. |
| .github/workflows/ci.yml | Adds local and deployed protocol matrices, but the preview URL lookup is not tied to the commit whose deployment status was validated. |
| packages/mcp/src/protocol-compat.test.ts | Exercises the complete MCP surface across the modern protocol and all five retained legacy revisions. |
| packages/mcp/package.json | Replaces the v1 MCP SDK dependency with official v2 client, server, and Node packages and adds protocol smoke scripts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant C as MCP Client
  participant G as Vercel MCP Gateway
  participant H as MCP v2 Handler
  participant S as Terminal49 MCP Server
  participant A as Terminal49 API
  C->>G: POST /mcp + protocol version
  G->>G: Validate host, origin, and authorization
  G->>H: Dispatch Node request
  H->>S: Create per-request server
  alt Modern 2026-07-28
    C->>H: server/discover
  else Legacy revision
    C->>H: initialize
  end
  C->>H: tools/list or tool call
  H->>S: Invoke registered operation
  S->>A: Authenticated API request
  A-->>S: Result
  S-->>H: MCP result
  H-->>C: JSON response
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fclaude-mcp-protocol-eac8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fclaude-mcp-protocol-eac8%22.%0A%0AGreploop%20terminal49%2Fapi%20PR%20%23333%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=terminal49%2Fapi&pr=333&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fclaude-mcp-protocol-eac8%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fclaude-mcp-protocol-eac8%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A206-208%0A**Preview%20URL%20lacks%20commit%20correlation**%0A%0AIf%20a%20pull%20request%20has%20multiple%20Vercel%20deployments%20or%20its%20deployment%20comment%20changes%20during%20the%20workflow%2C%20this%20step%20selects%20the%20latest%20Vercel%20bot%20comment%20without%20matching%20it%20to%20%60PREVIEW_SHA%60%2C%20so%20the%20protocol%20checks%20can%20run%20against%20a%20stale%20or%20newer%20deployment%20and%20report%20the%20wrong%20result%20for%20the%20reviewed%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yml%3A206-208%0A**Preview%20URL%20lacks%20commit%20correlation**%0A%0AIf%20a%20pull%20request%20has%20multiple%20Vercel%20deployments%20or%20its%20deployment%20comment%20changes%20during%20the%20workflow%2C%20this%20step%20selects%20the%20latest%20Vercel%20bot%20comment%20without%20matching%20it%20to%20%60PREVIEW_SHA%60%2C%20so%20the%20protocol%20checks%20can%20run%20against%20a%20stale%20or%20newer%20deployment%20and%20report%20the%20wrong%20result%20for%20the%20reviewed%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/ci.yml:206-208
**Preview URL lacks commit correlation**

If a pull request has multiple Vercel deployments or its deployment comment changes during the workflow, this step selects the latest Vercel bot comment without matching it to `PREVIEW_SHA`, so the protocol checks can run against a stale or newer deployment and report the wrong result for the reviewed commit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve Vercel preview URL with jq"](https://github.com/terminal49/api/commit/7d517c18ff80841afc2a5a5432155d149c61f742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55410103)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [MCP Gateway Auth Flow](https://app.greptile.com/terminal49/-/custom-context/knowledge-base/terminal49/api/-/docs/mcp-gateway-auth.md)
- Knowledge Base — [MCP Server Core (`@terminal49/mcp`)](https://app.greptile.com/terminal49/-/custom-context/knowledge-base/terminal49/api/-/docs/mcp-server-core.md)
- Knowledge Base — [Repo Tooling and CI](https://app.greptile.com/terminal49/-/custom-context/knowledge-base/terminal49/api/-/docs/repo-tooling-ci.md)
</details>

<!-- /greptile_comment -->