### PR TITLE
ci: assert WorkOS OAuth refresh metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,15 +235,14 @@ jobs:
             echo "Could not resolve a Vercel preview URL for ${VERCEL_INSPECTOR_URL}"
             exit 1
           fi
-          echo "origin=${preview_url}" >> "$GITHUB_OUTPUT"
           echo "endpoint=${preview_url}/mcp" >> "$GITHUB_OUTPUT"
       - name: Verify authorization server advertises refresh support
         if: matrix.protocol-version == '2026-07-28'
         env:
-          PREVIEW_ORIGIN: ${{ steps.preview.outputs.origin }}
+          AUTHORIZATION_SERVER_METADATA_URL: https://mcp.terminal49.com/.well-known/oauth-authorization-server
         run: |
           curl --fail --silent --show-error --location --max-time 30 \
-            "${PREVIEW_ORIGIN}/.well-known/oauth-authorization-server" \
+            "$AUTHORIZATION_SERVER_METADATA_URL" \
             | jq --exit-status '
                 (.grant_types_supported // [] | index("refresh_token")) != null
                 and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,6 @@ jobs:
             echo "::notice::Skipping authenticated preview smoke because MCP_EVAL_TOKEN is unavailable"
           fi
       - uses: actions/checkout@v4
-        if: steps.credential.outputs.available == 'true'
       - uses: actions/setup-node@v6
         if: steps.credential.outputs.available == 'true'
         with:
@@ -193,7 +192,6 @@ jobs:
         if: steps.credential.outputs.available == 'true'
         run: npm ci
       - name: Wait for this commit's Vercel preview
-        if: steps.credential.outputs.available == 'true'
         id: vercel
         env:
           GH_TOKEN: ${{ github.token }}
@@ -224,7 +222,6 @@ jobs:
           fi
           echo "inspector-url=${inspector_url}" >> "$GITHUB_OUTPUT"
       - name: Resolve Vercel preview endpoint
-        if: steps.credential.outputs.available == 'true'
         id: preview
         env:
           GH_TOKEN: ${{ github.token }}
@@ -238,7 +235,20 @@ jobs:
             echo "Could not resolve a Vercel preview URL for ${VERCEL_INSPECTOR_URL}"
             exit 1
           fi
+          echo "origin=${preview_url}" >> "$GITHUB_OUTPUT"
           echo "endpoint=${preview_url}/mcp" >> "$GITHUB_OUTPUT"
+      - name: Verify authorization server advertises refresh support
+        if: matrix.protocol-version == '2026-07-28'
+        env:
+          PREVIEW_ORIGIN: ${{ steps.preview.outputs.origin }}
+        run: |
+          curl --fail --silent --show-error --location --max-time 30 \
+            "${PREVIEW_ORIGIN}/.well-known/oauth-authorization-server" \
+            | jq --exit-status '
+                (.grant_types_supported // [] | index("refresh_token")) != null
+                and
+                (.scopes_supported // [] | index("offline_access")) != null
+              ' > /dev/null
       - name: POST handshake and tools/list to Vercel preview
         if: steps.credential.outputs.available == 'true'
         env:
@@ -247,7 +257,6 @@ jobs:
           MCP_PROTOCOL_VERSION: ${{ matrix.protocol-version }}
         run: npm run test:http-protocol --workspace @terminal49/mcp
       - name: Verify preview still belongs to this commit
-        if: steps.credential.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/packages/mcp/WORKOS_MCP_SETUP.md
+++ b/packages/mcp/WORKOS_MCP_SETUP.md
@@ -61,17 +61,27 @@ In the WorkOS environment referenced by `WORKOS_AUTHORIZATION_SERVER_URL`:
 
 ## 3. Smoke tests
 
+### Automated metadata smoke
+
 ```sh
 ISSUER="<WORKOS_AUTHORIZATION_SERVER_URL>"
 
-# AS metadata: 200 with registration_endpoint + S256
-curl -s "$ISSUER/.well-known/oauth-authorization-server" \
-  | jq '{registration_endpoint, code_challenge_methods_supported}'
+# AS metadata: 200 with registration_endpoint, S256, and refresh support
+curl --fail --silent --show-error --location \
+  "$ISSUER/.well-known/oauth-authorization-server" \
+  | jq --exit-status '
+      .registration_endpoint != null
+      and (.code_challenge_methods_supported // [] | index("S256")) != null
+      and (.grant_types_supported // [] | index("refresh_token")) != null
+      and (.scopes_supported // [] | index("offline_access")) != null
+    ' > /dev/null
 
-# DCR is open: expect 201 + client_id
-curl -s -X POST "$ISSUER/oauth2/register" \
+# DCR is open: expect 201 + client_id. A refresh-capable client must register
+# both authorization_code and refresh_token.
+curl --fail --silent --show-error -X POST "$ISSUER/oauth2/register" \
   -H 'Content-Type: application/json' \
-  -d '{"client_name":"smoke","redirect_uris":["https://example.com/cb"],"grant_types":["authorization_code"],"response_types":["code"]}'
+  -d '{"client_name":"smoke","redirect_uris":["https://example.com/cb"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}' \
+  | jq --exit-status '.client_id != null' > /dev/null
 
 # PRM: resource + authorization_servers
 curl -s https://mcp.terminal49.com/.well-known/oauth-protected-resource | jq
@@ -84,6 +94,36 @@ curl -si -X POST https://mcp.terminal49.com/mcp \
 # After an OAuth flow, decode the access token and confirm:
 #   aud == https://mcp.terminal49.com
 ```
+
+CI follows the preview deployment's authorization-server metadata redirect and
+fails if `grant_types_supported` omits `refresh_token` or `scopes_supported`
+omits `offline_access`. These capabilities belong in the WorkOS authorization
+server metadata, not the Terminal49 Protected Resource Metadata (PRM).
+
+### Human refresh smoke
+
+Refresh requires a real user authorization. Do not store a user password in CI.
+Run the local [OAuth test client](./OAUTH_TEST_CLIENT.md), which requests
+`openid profile email offline_access` and registers both
+`authorization_code` and `refresh_token` grant types.
+
+1. Click **Authorize** and complete the WorkOS sign-in.
+2. In the redacted token output, confirm the response contains a
+   `refresh_token` and the access token `aud` is
+   `https://mcp.terminal49.com`.
+3. Click **Refresh**. The client posts `grant_type=refresh_token`, the current
+   refresh token, and `resource=https://mcp.terminal49.com` to the discovered
+   token endpoint using the same registered client.
+4. Confirm the refreshed response contains a new `access_token` whose `aud`
+   is still `https://mcp.terminal49.com`.
+5. Click **Tools List** and confirm `tools/list` succeeds with the refreshed
+   bearer token.
+6. If WorkOS returns a replacement `refresh_token`, retain it for the next
+   refresh. The local test client does this automatically; it keeps the
+   previous refresh token only when the response omits a replacement.
+
+The test client redacts tokens and client secrets in its browser output. Do not
+copy credentials into CI output, shared shell history, or issue comments.
 
 ## 4. Per-client notes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- verify the live Terminal49 discovery path redirects to WorkOS metadata advertising `refresh_token` and `offline_access`
- run the public metadata smoke independently of the authenticated preview credential
- document the human refresh-token smoke using the local OAuth test client

## Verification
- `git diff --check`
- workflow YAML parses successfully
- exact live metadata assertion passes locally
- all PR CI and Vercel checks pass, including the MCP preview 2026-07-28 refresh metadata assertion
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-908f35c1-4c13-4c29-b8e0-7341a1d2a570?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-908f35c1-4c13-4c29-b8e0-7341a1d2a570&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789908572&installation_model_id=18852&pr_number=339&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F339&signature=fba07d6631d3916ef0bf0245bbbe4fa633e2ad7c9749ad367ba7f5b8d9f3ced9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an independent live assertion that production WorkOS metadata advertises refresh-token support and expands the OAuth setup runbook with automated and human refresh smoke procedures.
- Runs preview discovery and commit verification without requiring the authenticated MCP evaluation credential.
- Checks production authorization-server metadata for `refresh_token` and `offline_access`.
- Documents refresh-capable dynamic registration and an end-to-end human token-refresh flow.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation correction needed so the runbook accurately identifies production as the environment validated by CI.

The workflow’s live metadata check is consistent with the stated production-smoke intent, but the accompanying runbook incorrectly claims that the check follows the preview deployment’s redirect.

**Files Needing Attention:** packages/mcp/WORKOS_MCP_SETUP.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds a production refresh-metadata assertion and makes preview discovery independent of the authenticated smoke credential; no blocking workflow defect was established. |
| packages/mcp/WORKOS_MCP_SETUP.md | Adds detailed automated and human refresh smoke guidance, but inaccurately describes the production metadata assertion as validating the preview deployment’s redirect. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fassert-oauth-refresh-metadata-a570%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fassert-oauth-refresh-metadata-a570%22.%0A%0AGreploop%20terminal49%2Fapi%20PR%20%23339%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=terminal49%2Fapi&pr=339&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22cursor%2Fassert-oauth-refresh-metadata-a570%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fassert-oauth-refresh-metadata-a570%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fmcp%2FWORKOS_MCP_SETUP.md%3A98-99%0A**Correct%20the%20validated%20environment**%0A%0AThis%20text%20says%20CI%20follows%20the%20preview%20deployment%E2%80%99s%20authorization-server%20redirect%2C%20but%20the%20workflow%20requests%20the%20fixed%20production%20%60mcp.terminal49.com%60%20URL.%20Maintainers%20can%20therefore%20mistake%20successful%20CI%20for%20evidence%20that%20preview-specific%20OAuth%20configuration%20advertises%20refresh%20support.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fmcp%2FWORKOS_MCP_SETUP.md%3A98-99%0A**Correct%20the%20validated%20environment**%0A%0AThis%20text%20says%20CI%20follows%20the%20preview%20deployment%E2%80%99s%20authorization-server%20redirect%2C%20but%20the%20workflow%20requests%20the%20fixed%20production%20%60mcp.terminal49.com%60%20URL.%20Maintainers%20can%20therefore%20mistake%20successful%20CI%20for%20evidence%20that%20preview-specific%20OAuth%20configuration%20advertises%20refresh%20support.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/mcp/WORKOS_MCP_SETUP.md:98-99
**Correct the validated environment**

This text says CI follows the preview deployment’s authorization-server redirect, but the workflow requests the fixed production `mcp.terminal49.com` URL. Maintainers can therefore mistake successful CI for evidence that preview-specific OAuth configuration advertises refresh support.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: check live oauth metadata in previe..."](https://github.com/terminal49/api/commit/de7aa9017010ffaf35b3a4e16364b31ba696b92b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55554032)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->