### PR TITLE
fix(ci): unblock release-please and modernize publish workflows

### DIFF
--- a/.github/workflows/publish_typescript_cli.yml
+++ b/.github/workflows/publish_typescript_cli.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.release-tag.outputs.tag }}
 

--- a/.github/workflows/publish_typescript_sdk.yml
+++ b/.github/workflows/publish_typescript_sdk.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.release-tag.outputs.tag }}
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -27,11 +27,6 @@
         },
         {
           "type": "json",
-          "path": "packages/mcp/package-lock.json",
-          "jsonpath": "$.packages[''].dependencies['@terminal49/sdk']"
-        },
-        {
-          "type": "json",
           "path": "sdks/typescript-sdk-cli/package.json",
           "jsonpath": "$.dependencies['@terminal49/sdk']"
         }


### PR DESCRIPTION
Two defects in the release automation:

1. **release-please config referenced a nonexistent extra-file** — `packages/mcp/package-lock.json` doesn't exist (packages/mcp is a root workspace member covered by the root lockfile). A missing extra-file makes release-please's updater fail, which is the likely reason no `sdk-v-*`/`cli-v-*` release PRs were being cut automatically (0.4.0 and the CLI release had to be cut by hand). Removed the entry; the remaining four extra-files all exist.
2. **`actions/checkout@v4`** in both publish workflows targets deprecated Node 20 runners (CI warns on every run). Bumped to v5.

Verified: all remaining extra-file paths exist on main; workflows are otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bca2z6b3pMPb3pe911CXAP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789975616&installation_model_id=18852&pr_number=344&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F344&signature=83b0dbb3f35d3f1edff7890896d27877507ae50502799ab7a382415e3af569e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR repairs release automation by removing an extra-file target for a nonexistent package-local lockfile and upgrades checkout in both TypeScript publishing workflows.
- Removes the obsolete `packages/mcp/package-lock.json` release-please updater.
- Updates the SDK and CLI publish jobs from `actions/checkout@v4` to `actions/checkout@v5`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The publish workflows retain their existing triggers, tag references, and release steps, while the release-please removal aligns its extra-file targets with the repository’s current root-lockfile workspace layout.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish_typescript_cli.yml | Upgrades the CLI publish workflow to checkout v5 without changing its release-tag checkout or publication flow. |
| .github/workflows/publish_typescript_sdk.yml | Upgrades the SDK publish workflow to checkout v5 without changing its release-tag checkout or publication flow. |
| .release-please-config.json | Removes an updater for a nonexistent MCP package-local lockfile while retaining updates for the authoritative root lockfile and package manifests. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): unblock release-please and mode..."](https://github.com/terminal49/api/commit/05f483adbc472df26c60f931d852aff24923d3af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55819766)</sub>

<!-- /greptile_comment -->