### PR TITLE
DEV-12120: document supported document type schemas

### DIFF
--- a/docs/api-docs/api-reference/document-schemas/get-a-document-schema.mdx
+++ b/docs/api-docs/api-reference/document-schemas/get-a-document-schema.mdx
@@ -1,10 +1,12 @@
 ---
 title: "Get a document schema"
-description: "Retrieve a Terminal49 document schema for an extraction output, including the schema version and the structured payload contract for parsed fields."
+description: "Retrieve a versioned Terminal49 JSON Schema that validates a document_representation.payload."
 og:title: Get a Document Schema | Terminal49 API
-og:description: Retrieve a document schema by ID from the Terminal49 API. Returns the schema definition used to validate and extract structured shipping documents.
+og:description: Retrieve a versioned JSON Schema by ID from the Terminal49 API to validate a document representation payload.
 openapi: get /document_schemas/{id}
 ---
 <Info>
   **Beta Feature** - This endpoint is currently in beta. The API is stable, but the schema and behavior may evolve based on feedback.
 </Info>
+
+Returns the versioned JSON Schema used to validate `document_representation.payload`. It does not return the sanitized extraction-field structure for a supported document type; use [Get a document type](/api-docs/api-reference/documents/get-a-document-type) for that structure.

--- a/docs/api-docs/api-reference/documents/get-a-document-type.mdx
+++ b/docs/api-docs/api-reference/documents/get-a-document-type.mdx
@@ -1,0 +1,17 @@
+---
+title: "Get a document type"
+description: "Retrieve one account-visible document type and its sanitized extraction-field structure."
+openapi: "get /documents/types/{code}"
+---
+
+<Info>
+  **Beta Feature** - This endpoint is currently in beta. The API is stable, but the schema and behavior may evolve based on feedback.
+</Info>
+
+Returns one document type visible to the authenticated account. A code that is not in that account's catalog returns `404`.
+
+## Schema payload
+
+`schema.payload` is a sanitized structural projection for rendering the type's extraction fields. It can contain field types, formats, enum values, nested properties, array items, and required fields. A field type can be a string or an array of strings, such as `["string", "null"]`. Array `items` can be one schema or an array of schemas. It omits internal extensions, prompts, instructions, titles, and descriptions.
+
+This extraction-field structure does not validate `document_representation.payload`. For the versioned JSON Schema used to validate a document representation payload, use [Get a document schema](/api-docs/api-reference/document-schemas/get-a-document-schema).

--- a/docs/api-docs/api-reference/documents/list-document-types.mdx
+++ b/docs/api-docs/api-reference/documents/list-document-types.mdx
@@ -1,9 +1,13 @@
 ---
 title: "List document types"
-description: "List the allowed document types and labels configured for your Terminal49 account so your app can populate selectors and validate uploads correctly."
+description: "List the document types visible to your Terminal49 account, including metadata and a link to each extraction-field structure."
 openapi: "get /documents/types"
 ---
 
 <Info>
   **Beta Feature** - This endpoint is currently in beta. The API is stable, but the schema and behavior may evolve based on feedback.
 </Info>
+
+Returns document types available to the authenticated account. Account permissions and catalog visibility can filter the results.
+
+Each item contains thin metadata and `schema.detail_url` for retrieving its extraction-field structure on demand. The list does not include schema payloads, field counts, or derived field paths. See [Get a document type](/api-docs/api-reference/documents/get-a-document-type) for the detail response.

--- a/docs/api-docs/api-reference/documents/list-document-types.mdx
+++ b/docs/api-docs/api-reference/documents/list-document-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: "List document types"
-description: "List the document types visible to your Terminal49 account, including metadata and a link to each extraction-field structure."
+description: "List every document type allowed for your Terminal49 account, with public descriptions and schema links when available."
 openapi: "get /documents/types"
 ---
 
@@ -8,6 +8,6 @@ openapi: "get /documents/types"
   **Beta Feature** - This endpoint is currently in beta. The API is stable, but the schema and behavior may evolve based on feedback.
 </Info>
 
-Returns document types available to the authenticated account. Account permissions and catalog visibility can filter the results.
+Returns every document type allowed for the authenticated account so existing selectors and upload validation remain compatible.
 
-Each item contains thin metadata and `schema.detail_url` for retrieving its extraction-field structure on demand. The list does not include schema payloads, field counts, or derived field paths. See [Get a document type](/api-docs/api-reference/documents/get-a-document-type) for the detail response.
+Types included in the public catalog also contain a description and `schema.detail_url` for retrieving their extraction-field structure on demand. The list does not include schema payloads, field counts, or derived field paths. See [Get a document type](/api-docs/api-reference/documents/get-a-document-type) for the detail response.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -158,6 +158,7 @@
               "api-docs/api-reference/documents/edit-a-document",
               "api-docs/api-reference/documents/delete-a-document",
               "api-docs/api-reference/documents/list-document-types",
+              "api-docs/api-reference/documents/get-a-document-type",
               "api-docs/api-reference/documents/get-a-document-download-url",
               "api-docs/api-reference/documents/re-extract-a-document",
               "api-docs/api-reference/documents/re-classify-a-document",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9412,7 +9412,7 @@
     "/documents/types": {
       "get": {
         "summary": "List document types",
-        "description": "Returns account-scoped allowed document types and labels.",
+        "description": "Returns the document types visible to the authenticated account. Each item includes thin catalog metadata and a detail URL for its extraction-field structure. The response does not include a schema payload, field counts, or derived field paths.",
         "tags": [
           "Documents"
         ],
@@ -9423,23 +9423,138 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "document_types": {
                       "type": "array",
                       "items": {
+                        "$ref": "#/components/schemas/document_type_list_item"
+                      }
+                    }
+                  },
+                  "required": [
+                    "document_types"
+                  ]
+                },
+                "examples": {
+                  "document_types": {
+                    "value": {
+                      "document_types": [
+                        {
+                          "code": "packing_list",
+                          "label": "Packing List",
+                          "description": "Itemized shipment contents with package counts, dimensions, weights, and marks.",
+                          "schema": {
+                            "id": "packing_list@2026-03-23",
+                            "version": "2026-03-23",
+                            "detail_url": "/v2/documents/types/packing_list"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
-                          "code": {
-                            "type": "string"
-                          },
-                          "label": {
+                          "detail": {
                             "type": "string"
                           }
                         },
                         "required": [
-                          "code",
-                          "label"
+                          "detail"
                         ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "errors": [
+                        {
+                          "detail": "invalid API token"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "get-documents-types"
+      }
+    },
+    "/documents/types/{code}": {
+      "get": {
+        "summary": "Get a document type",
+        "description": "Returns one document type visible to the authenticated account and its sanitized extraction-field structure. The schema payload is for rendering extraction fields; it is not the versioned schema used to validate document representation payloads.",
+        "tags": [
+          "Documents"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "description": "Document type code from the list response.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "packing_list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "document_type": {
+                      "$ref": "#/components/schemas/document_type_detail"
+                    }
+                  },
+                  "required": [
+                    "document_type"
+                  ]
+                },
+                "examples": {
+                  "document_type": {
+                    "value": {
+                      "document_type": {
+                        "code": "packing_list",
+                        "label": "Packing List",
+                        "description": "Itemized shipment contents with package counts, dimensions, weights, and marks.",
+                        "schema": {
+                          "id": "packing_list@2026-03-23",
+                          "version": "2026-03-23",
+                          "format": "json_schema",
+                          "payload": {
+                            "type": "object",
+                            "properties": {}
+                          }
+                        }
                       }
                     }
                   }
@@ -9453,12 +9568,84 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "errors": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/error"
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "detail": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "detail"
+                        ]
                       }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "examples": {
+                  "unauthorized": {
+                    "value": {
+                      "errors": [
+                        {
+                          "detail": "invalid API token"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "status": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "title"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "errors"
+                  ]
+                },
+                "examples": {
+                  "document_type_not_found": {
+                    "summary": "Document type is not visible to the account",
+                    "value": {
+                      "errors": [
+                        {
+                          "status": "404",
+                          "title": "Not Found"
+                        }
+                      ]
                     }
                   }
                 }
@@ -9466,7 +9653,7 @@
             }
           }
         },
-        "operationId": "get-documents-types"
+        "operationId": "get-documents-types-code"
       }
     },
     "/documents/{id}": {
@@ -14615,7 +14802,7 @@
               "schema_payload": {
                 "type": "object",
                 "additionalProperties": true,
-                "description": "JSON Schema payload used to validate and describe extracted fields."
+                "description": "Versioned JSON Schema used to validate document_representation.payload. This is not the sanitized extraction-field structure returned by GET /documents/types/{code}."
               },
               "created_at": {
                 "type": "string",
@@ -15053,6 +15240,188 @@
         "required": [
           "id",
           "type"
+        ]
+      },
+      "document_type_list_item": {
+        "title": "Document type",
+        "type": "object",
+        "description": "Public catalog metadata for one document type visible to the authenticated account.",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable document type code."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable document type label."
+          },
+          "description": {
+            "type": "string",
+            "description": "Public description of the document type."
+          },
+          "schema": {
+            "type": "object",
+            "description": "Metadata for the extraction-field structure available from the detail endpoint.",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Fully qualified extraction schema ID.",
+                "example": "packing_list@2026-03-23"
+              },
+              "version": {
+                "type": "string",
+                "description": "Extraction schema version.",
+                "example": "2026-03-23"
+              },
+              "detail_url": {
+                "type": "string",
+                "description": "Relative URL for the document type detail endpoint.",
+                "example": "/v2/documents/types/packing_list"
+              }
+            },
+            "required": [
+              "id",
+              "version",
+              "detail_url"
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "label",
+          "description",
+          "schema"
+        ]
+      },
+      "sanitized_extraction_schema": {
+        "title": "Sanitized extraction-field schema",
+        "type": "object",
+        "description": "Recursive public-safe JSON Schema projection for rendering extraction fields. It includes only the structural keys retained by the sanitizer; internal extensions, prompts, instructions, titles, and descriptions are omitted.",
+        "additionalProperties": false,
+        "example": {
+          "type": "object",
+          "properties": {
+            "bill_of_lading_number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "properties": {
+          "type": {
+            "description": "JSON Schema field type. It can be a string or an array of strings, such as [\"string\", \"null\"] for nullable fields in Wayfair schemas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "format": {
+            "type": "string",
+            "description": "JSON Schema format, when available."
+          },
+          "enum": {
+            "type": "array",
+            "description": "Allowed field values, when available.",
+            "items": {}
+          },
+          "properties": {
+            "type": "object",
+            "description": "Nested object fields keyed by property name.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/sanitized_extraction_schema"
+            }
+          },
+          "items": {
+            "description": "Array item schema or tuple of item schemas.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/sanitized_extraction_schema"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/sanitized_extraction_schema"
+                }
+              }
+            ]
+          },
+          "required": {
+            "type": "array",
+            "description": "Required property names for an object field.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "document_type_detail": {
+        "title": "Document type detail",
+        "type": "object",
+        "description": "One public catalog item and its sanitized extraction-field structure.",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Stable document type code."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable document type label."
+          },
+          "description": {
+            "type": "string",
+            "description": "Public description of the document type."
+          },
+          "schema": {
+            "type": "object",
+            "description": "Sanitized extraction-field schema metadata and structure.",
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Fully qualified extraction schema ID.",
+                "example": "packing_list@2026-03-23"
+              },
+              "version": {
+                "type": "string",
+                "description": "Extraction schema version.",
+                "example": "2026-03-23"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json_schema"
+                ],
+                "description": "Format of the extraction-field structure."
+              },
+              "payload": {
+                "$ref": "#/components/schemas/sanitized_extraction_schema"
+              }
+            },
+            "required": [
+              "id",
+              "version",
+              "format",
+              "payload"
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "label",
+          "description",
+          "schema"
         ]
       }
     },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1315,7 +1315,7 @@
                           },
                           "auto_detect_vocc_scac": {
                             "type": "boolean",
-                            "description": "Set to `true` to have Terminal49 infer the carrier SCAC from `request_number` when `scac` is not supplied. Detection is asynchronous: the tracking request is created immediately (HTTP `201`) with `status: \"pending\"` and `scac: null`. If a carrier is inferred, the request transitions to `status: \"created\"` with the detected `scac` populated. If no supported carrier can be inferred, it transitions to `status: \"failed\"` with `failed_reason: \"scac_auto_detect_failed\"` and no shipment is created. Poll the tracking request or use webhooks to observe the outcome \u2014 the create response does not include the detected `scac`.",
+                            "description": "Set to `true` to have Terminal49 infer the carrier SCAC from `request_number` when `scac` is not supplied. Detection is asynchronous: the tracking request is created immediately (HTTP `201`) with `status: \"pending\"` and `scac: null`. If a carrier is inferred, the request transitions to `status: \"created\"` with the detected `scac` populated. If no supported carrier can be inferred, it transitions to `status: \"failed\"` with `failed_reason: \"scac_auto_detect_failed\"` and no shipment is created. Poll the tracking request or use webhooks to observe the outcome — the create response does not include the detected `scac`.",
                             "default": false,
                             "example": true
                           },
@@ -9412,7 +9412,7 @@
     "/documents/types": {
       "get": {
         "summary": "List document types",
-        "description": "Returns the document types visible to the authenticated account. Each item includes thin catalog metadata and a detail URL for its extraction-field structure. The response does not include a schema payload, field counts, or derived field paths.",
+        "description": "Returns every document type allowed for the authenticated account. Catalog-visible items also include a description and schema detail URL; option-only items contain just code and label. The response does not include a schema payload, field counts, or derived field paths.",
         "tags": [
           "Documents"
         ],
@@ -9449,6 +9449,10 @@
                             "version": "2026-03-23",
                             "detail_url": "/v2/documents/types/packing_list"
                           }
+                        },
+                        {
+                          "code": "unknown",
+                          "label": "Unknown"
                         }
                       ]
                     }
@@ -9506,7 +9510,7 @@
     "/documents/types/{code}": {
       "get": {
         "summary": "Get a document type",
-        "description": "Returns one document type visible to the authenticated account and its sanitized extraction-field structure. The schema payload is for rendering extraction fields; it is not the versioned schema used to validate document representation payloads.",
+        "description": "Returns one catalog-visible document type for the authenticated account and its sanitized extraction-field structure. Use this endpoint only for list items containing schema.detail_url; account-allowed option-only codes return 404. The schema payload is for rendering extraction fields; it is not the versioned schema used to validate document representation payloads.",
         "tags": [
           "Documents"
         ],
@@ -10940,7 +10944,7 @@
             }
           },
           "400": {
-            "description": "Bad request \u2014 missing required `query` parameter",
+            "description": "Bad request — missing required `query` parameter",
             "content": {
               "application/json": {
                 "schema": {
@@ -10970,7 +10974,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2014 missing or invalid API token",
+            "description": "Unauthorized — missing or invalid API token",
             "content": {
               "application/json": {
                 "schema": {
@@ -12163,6 +12167,53 @@
         ],
         "x-examples": {}
       },
+      "user": {
+        "title": "User model",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "user"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "description": "User attributes included by the requested resource. Available fields depend on the endpoint and caller permissions.",
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "email": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "email"
+              },
+              "company_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ]
+      },
       "error": {
         "title": "Error model",
         "type": "object",
@@ -13306,19 +13357,19 @@
                         "type": "string",
                         "format": "uuid"
                       },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "tracking_request",
-                            "estimated_event",
-                            "transport_event",
-                            "container_updated_event",
-                            "document"
-                          ]
-                        }
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "tracking_request",
+                          "estimated_event",
+                          "transport_event",
+                          "container_updated_event",
+                          "document"
+                        ]
                       }
                     }
                   }
+                }
               }
             },
             "required": [
@@ -15245,7 +15296,7 @@
       "document_type_list_item": {
         "title": "Document type",
         "type": "object",
-        "description": "Public catalog metadata for one document type visible to the authenticated account.",
+        "description": "One document type allowed for the authenticated account. Public catalog metadata is present when a schema detail view is available.",
         "additionalProperties": false,
         "properties": {
           "code": {
@@ -15290,9 +15341,7 @@
         },
         "required": [
           "code",
-          "label",
-          "description",
-          "schema"
+          "label"
         ]
       },
       "sanitized_extraction_schema": {

--- a/packages/mcp/src/annotations.test.ts
+++ b/packages/mcp/src/annotations.test.ts
@@ -196,7 +196,7 @@ describe('MCP tool annotations', () => {
     expect(chatGpt.schema_version).toBe(1);
     expect(chatGpt.app_info).toMatchObject({
       display_name: 'Terminal49',
-      subtitle: 'Track ocean shipments',
+      subtitle: 'Track shipping containers',
       category: 'BUSINESS',
     });
     expect(chatGpt.app_info.description).toContain('Terminal49 helps users');

--- a/sdks/typescript-sdk/src/client/managers/containers.ts
+++ b/sdks/typescript-sdk/src/client/managers/containers.ts
@@ -18,6 +18,7 @@ const DEFAULT_CONTAINER_INCLUDES = [
   'pod_terminal',
   'pickup_facility',
 ] as const satisfies readonly ContainerInclude[];
+const DEFAULT_ROUTE_INCLUDE = 'port,vessel,route_location';
 
 export class ContainerManager extends BaseManager {
   async get(
@@ -92,13 +93,10 @@ export class ContainerManager extends BaseManager {
   }
 
   async route(id: string, options?: CallOptions): Promise<any> {
-    const raw = await this.transport.execute(() =>
-      this.transport.client.GET('/containers/{id}/route', {
-        params: {
-          path: { id },
-          query: { include: 'port,vessel,route_location' } as any,
-        },
-      }),
+    const encodedId = encodeURIComponent(id);
+    const include = encodeURIComponent(DEFAULT_ROUTE_INCLUDE);
+    const raw = await this.transport.executeManual(
+      `${this.transport.baseUrl}/containers/${encodedId}/route?include=${include}`,
     );
     return this.formatResult(raw, options?.format, mapRoute);
   }

--- a/sdks/typescript-sdk/src/generated/terminal49.ts
+++ b/sdks/typescript-sdk/src/generated/terminal49.ts
@@ -114,14 +114,13 @@ export interface paths {
         put?: never;
         /**
          * Create a tracking request
-         * @description To track an ocean shipment, you create a new tracking request.
-         *     Two attributes are required to track a shipment. A `bill of lading/booking number` and a shipping line `SCAC`.
+         * @description To track an ocean shipment, create a new tracking request. `request_type` and `request_number` are always required. Supply either a shipping line `scac` or set `auto_detect_vocc_scac` to `true` to have Terminal49 infer the SCAC from the request number before creating the tracking request.
          *
-         *     Once a tracking request is created we will attempt to fetch the shipment details and it's related containers from the shipping line. If the attempt is successful we will create in new shipment object including any related container objects. We will send a `tracking_request.succeeded` webhook notification to your webhooks.
+         *     Auto-detection uses the same carrier prediction capability as the Infer Tracking Number endpoint and runs asynchronously. The tracking request is created immediately (HTTP `201`) with `status: "pending"`; if no supported carrier can be inferred it transitions to `status: "failed"` with `failed_reason: "scac_auto_detect_failed"` and no shipment is created. Once a tracking request is created we will attempt to fetch the shipment details and its related containers from the shipping line. If the attempt is successful we will create a new shipment object including any related container objects. We will send a `tracking_request.succeeded` webhook notification to your webhooks.
          *
          *     If the attempt to fetch fails then we will send a `tracking_request.failed` webhook notification to your `webhooks`.
          *
-         *     A `tracking_request.succeeded` or `tracking_request.failed` webhook notificaiton will only be sent  if you have  atleast one active webhook. <br /><br /><Info>This endpoint is limited to 100 tracking requests per minute.</Info>
+         *     A `tracking_request.succeeded` or `tracking_request.failed` webhook notification will only be sent if you have at least one active webhook. <br /><br /><Info>This endpoint is limited to 100 tracking requests per minute.</Info>
          */
         post: operations["post-track"];
         delete?: never;
@@ -177,6 +176,50 @@ export interface paths {
         patch: operations["patch-track-request-by-id"];
         trace?: never;
     };
+    "/tracking_requests/{tracking_request_id}/custom_fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+            };
+            cookie?: never;
+        };
+        /** List tracking request custom fields */
+        get: operations["get-tracking-requests-custom-fields"];
+        put?: never;
+        /** Create a tracking request custom field */
+        post: operations["post-tracking-requests-custom-fields"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tracking_requests/{tracking_request_id}/custom_fields/{api_slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a tracking request custom field */
+        delete: operations["delete-tracking-requests-custom-fields-api-slug"];
+        options?: never;
+        head?: never;
+        /** Update a tracking request custom field */
+        patch: operations["patch-tracking-requests-custom-fields-api-slug"];
+        trace?: never;
+    };
     "/webhooks/{id}": {
         parameters: {
             query?: never;
@@ -227,6 +270,26 @@ export interface paths {
          *     This is the recommended way tracking shipments and containers via the API. You should use this instead of polling our the API periodically.
          */
         post: operations["post-webhooks"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List webhook events
+         * @description Returns webhook event categories and event names available to the authenticated account. Events may be filtered by account features.
+         */
+        get: operations["get-webhooks-events"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -309,6 +372,26 @@ export interface paths {
         get: operations["get-webhooks-ips"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/trigger": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger a webhook test delivery
+         * @description Send a one-time test webhook notification payload to a target HTTPS URL without creating a webhook endpoint. For document webhook events (`document_representation.created` and `document_representation.failed`), you can pass `sample.document_type` to test a specific document type payload.
+         */
+        post: operations["post-webhooks-trigger"];
         delete?: never;
         options?: never;
         head?: never;
@@ -412,28 +495,6 @@ export interface paths {
          *     This does not provide any estimated future events. See `container/:id/raw_events` endpoint for that.
          */
         get: operations["get-containers-id-transport_events"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/containers/{id}/route": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        /**
-         * Get container route
-         * @description Retrieves the route details from the port of lading to the port of discharge, including transshipments. <Note>This is a paid feature. Please contact sales@terminal49.com.</Note>
-         */
-        get: operations["get-containers-id-route"];
         put?: never;
         post?: never;
         delete?: never;
@@ -711,6 +772,219 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/custom_field_definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List custom field definitions */
+        get: operations["get-custom-field-definitions"];
+        put?: never;
+        /** Create a custom field definition */
+        post: operations["post-custom-field-definitions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/custom_field_definitions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** Get a custom field definition */
+        get: operations["get-custom-field-definitions-id"];
+        put?: never;
+        post?: never;
+        /** Delete a custom field definition */
+        delete: operations["delete-custom-field-definitions-id"];
+        options?: never;
+        head?: never;
+        /** Update a custom field definition */
+        patch: operations["patch-custom-field-definitions-id"];
+        trace?: never;
+    };
+    "/custom_field_definitions/{definition_id}/options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+            };
+            cookie?: never;
+        };
+        /** List custom field options */
+        get: operations["get-custom-field-options"];
+        put?: never;
+        /** Create a custom field option */
+        post: operations["post-custom-field-options"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/custom_field_definitions/{definition_id}/options/{option_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+                /** @description Custom field option ID */
+                option_id: string;
+            };
+            cookie?: never;
+        };
+        /** Get a custom field option */
+        get: operations["get-custom-field-options-id"];
+        put?: never;
+        post?: never;
+        /** Delete a custom field option */
+        delete: operations["delete-custom-field-options-id"];
+        options?: never;
+        head?: never;
+        /** Update a custom field option */
+        patch: operations["patch-custom-field-options-id"];
+        trace?: never;
+    };
+    "/custom_fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List custom fields */
+        get: operations["get-custom-fields"];
+        put?: never;
+        /** Create a custom field */
+        post: operations["post-custom-fields"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/custom_fields/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** Get a custom field */
+        get: operations["get-custom-fields-id"];
+        put?: never;
+        post?: never;
+        /** Delete a custom field */
+        delete: operations["delete-custom-fields-id"];
+        options?: never;
+        head?: never;
+        /** Update a custom field */
+        patch: operations["patch-custom-fields-id"];
+        trace?: never;
+    };
+    "/shipments/{shipment_id}/custom_fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+            };
+            cookie?: never;
+        };
+        /** List shipment custom fields */
+        get: operations["get-shipments-custom-fields"];
+        put?: never;
+        /** Create a shipment custom field */
+        post: operations["post-shipments-custom-fields"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/shipments/{shipment_id}/custom_fields/{api_slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a shipment custom field */
+        delete: operations["delete-shipments-custom-fields-api-slug"];
+        options?: never;
+        head?: never;
+        /** Update a shipment custom field */
+        patch: operations["patch-shipments-custom-fields-api-slug"];
+        trace?: never;
+    };
+    "/containers/{container_id}/custom_fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+            };
+            cookie?: never;
+        };
+        /** List container custom fields */
+        get: operations["get-containers-custom-fields"];
+        put?: never;
+        /** Create a container custom field */
+        post: operations["post-containers-custom-fields"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/containers/{container_id}/custom_fields/{api_slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a container custom field */
+        delete: operations["delete-containers-custom-fields-api-slug"];
+        options?: never;
+        head?: never;
+        /** Update a container custom field */
+        patch: operations["patch-containers-custom-fields-api-slug"];
+        trace?: never;
+    };
     "/parties/{id}": {
         parameters: {
             query?: never;
@@ -729,6 +1003,269 @@ export interface paths {
         head?: never;
         /** @description Updates a party */
         patch: operations["edit-party"];
+        trace?: never;
+    };
+    "/documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List documents
+         * @description Returns documents for the authenticated account. Supports filters, sorting, includes, and pagination.
+         */
+        get: operations["get-documents"];
+        put?: never;
+        /**
+         * Upload a document
+         * @description Creates a document record. Provide an ActiveStorage signed blob id in `attached_document`.
+         */
+        post: operations["post-documents"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List document types
+         * @description Returns every document type allowed for the authenticated account. Catalog-visible items also include a description and schema detail URL; option-only items contain just code and label. The response does not include a schema payload, field counts, or derived field paths.
+         */
+        get: operations["get-documents-types"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/types/{code}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a document type
+         * @description Returns one catalog-visible document type for the authenticated account and its sanitized extraction-field structure. Use this endpoint only for list items containing schema.detail_url; account-allowed option-only codes return 404. The schema payload is for rendering extraction fields; it is not the versioned schema used to validate document representation payloads.
+         */
+        get: operations["get-documents-types-code"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a document */
+        get: operations["get-documents-id"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a document
+         * @description Soft-deletes (discards) the document.
+         */
+        delete: operations["delete-documents-id"];
+        options?: never;
+        head?: never;
+        /**
+         * Edit a document
+         * @description Updates manual extraction and classification fields.
+         */
+        patch: operations["patch-documents-id"];
+        trace?: never;
+    };
+    "/documents/{id}/download_url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a document download URL
+         * @description Returns a presigned URL for downloading/viewing the current document file.
+         */
+        get: operations["get-documents-id-download_url"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{id}/reextract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-extract a document
+         * @description Triggers asynchronous extraction for the document.
+         */
+        post: operations["post-documents-id-reextract"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{id}/reclassify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-classify a document
+         * @description Triggers asynchronous classification for the document.
+         */
+        post: operations["post-documents-id-reclassify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{id}/relink": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-link a document
+         * @description Re-runs reference linking for the document.
+         */
+        post: operations["post-documents-id-relink"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{id}/rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate a document
+         * @description Queues a rotation update for image document types only. Non-image documents are not rotatable.
+         */
+        post: operations["post-documents-id-rotate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/email_submissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List email submissions
+         * @description Returns email submissions for the authenticated account.
+         */
+        get: operations["get-email_submissions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/email_submissions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an email submission */
+        get: operations["get-email_submissions-id"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/document_schemas/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a document schema */
+        get: operations["get-document_schemas-id"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search shipments, containers, and tracking requests
+         * @description Full-text search across shipments, containers (cargos), and tracking requests within your account. Results are ranked by type (shipments first, then containers, then tracking requests) and recency. Returns up to 25 results. Duplicate tracking requests (where a shipment exists with the same BL number) are automatically filtered out.
+         */
+        get: operations["searchAll"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
 }
@@ -821,19 +1358,40 @@ export interface components {
                 pod_vessel_name?: string | null;
                 pod_vessel_imo?: string | null;
                 pod_voyage_number?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Estimated Time of Departure from the Port of Lading, as reported by the shipping line. Carrier dependent; may be null.
+                 */
                 pol_etd_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Actual Time of Departure from the Port of Lading. Populated after the vessel has departed the origin port.
+                 */
                 pol_atd_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Estimated Time of Arrival at the Port of Discharge.
+                 */
                 pod_eta_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Initial Estimated Time of Arrival at the Port of Discharge, as first reported by the shipping line.
+                 */
                 pod_original_eta_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Actual Time of Arrival at the Port of Discharge.
+                 */
                 pod_ata_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Estimated Time of Arrival at the shipment's destination, as reported by the shipping line. For inland (rail) moves, see also the container-level `ind_eta_at`, which is reported by the rail carrier. Corresponding timezone is `destination_timezone`.
+                 */
                 destination_eta_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Actual Time of Arrival at the shipment's destination, as reported by the shipping line. For inland (rail) moves, see also the container-level `ind_ata_at`, which is reported by the rail carrier. Corresponding timezone is `destination_timezone`.
+                 */
                 destination_ata_at?: string | null;
                 /** @description IANA tz */
                 pol_timezone?: string | null;
@@ -900,7 +1458,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            type: "container";
+            type: "account";
             attributes: {
                 number?: string;
                 ref_numbers?: string[];
@@ -982,11 +1540,20 @@ export interface components {
                 pod_rail_loaded_at?: string | null;
                 /** Format: date-time */
                 pod_rail_departed_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Estimated Time of Arrival at the inland destination, as reported by the rail carrier. For the shipping-line view at the shipment's destination, see `destination_eta_at` on the shipment. Corresponding timezone is `final_destination_timezone`.
+                 */
                 ind_eta_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Actual Time of Arrival at the inland destination, as reported by the rail carrier. For the shipping-line view at the shipment's destination, see `destination_ata_at` on the shipment. Corresponding timezone is `final_destination_timezone`.
+                 */
                 ind_ata_at?: string | null;
-                /** Format: date-time */
+                /**
+                 * Format: date-time
+                 * @description Time when the container is unloaded from rail at the inland destination.
+                 */
                 ind_rail_unloaded_at?: string | null;
                 /**
                  * Format: date-time
@@ -1003,12 +1570,12 @@ export interface components {
                     pickup_lfd_terminal?: string | null;
                     /**
                      * Format: date-time
-                     * @description The last free day for pickup before demmurage accrues. Corresponding timezone is final_destination_timezone.
+                     * @description The last free day for pickup at the inland destination, as reported by the rail carrier. Corresponding timezone is final_destination_timezone. Subscribe to `container.pickup_lfd_rail.changed` to be notified of updates.
                      */
                     pickup_lfd_rail?: string | null;
                     /**
                      * Format: date-time
-                     * @description The last free day as reported by the line. Corresponding timezone is final_destination_timezone or pod_timezone.
+                     * @description The last free day as reported by the shipping line (carrier dependent). Corresponding timezone is final_destination_timezone or pod_timezone. Preferred source for the coalesced top-level `pickup_lfd` field.
                      */
                     pickup_lfd_line?: string | null;
                 } | null;
@@ -1098,9 +1665,25 @@ export interface components {
             /** Format: uuid */
             id: string;
             /** @enum {string} */
-            type: "container";
+            type: "account";
             attributes: {
                 company_name: string;
+            };
+        };
+        /** User model */
+        user: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "user";
+            /** @description User attributes included by the requested resource. Available fields depend on the endpoint and caller permissions. */
+            attributes: {
+                name?: string | null;
+                /** Format: email */
+                email?: string | null;
+                company_name?: string | null;
+            } & {
+                [key: string]: unknown;
             };
         };
         /** Error model */
@@ -1114,8 +1697,7 @@ export interface components {
             code?: string | null;
             status?: string | null;
             meta?: {
-                /** Format: uuid */
-                tracking_request_id?: string | null;
+                [key: string]: unknown;
             } | null;
         };
         /** Metro area model */
@@ -1221,10 +1803,10 @@ export interface components {
                 /** @enum {string} */
                 status: "pending" | "awaiting_manifest" | "created" | "failed" | "tracking_stopped";
                 /**
-                 * @description If the tracking request has failed, or is currently failing, the last reason we were unable to complete the request
+                 * @description If the tracking request has failed, or is currently failing, the last reason we were unable to complete the request. `scac_auto_detect_failed` means `auto_detect_vocc_scac` was set but no supported carrier SCAC could be inferred from the request number.
                  * @enum {string|null}
                  */
-                failed_reason?: "booking_cancelled" | "duplicate" | "expired" | "internal_processing_error" | "invalid_number" | "not_found" | "retries_exhausted" | "shipping_line_unreachable" | "unrecognized_response" | "data_unavailable" | null;
+                failed_reason?: "booking_cancelled" | "duplicate" | "expired" | "internal_processing_error" | "invalid_number" | "not_found" | "retries_exhausted" | "shipping_line_unreachable" | "unrecognized_response" | "data_unavailable" | "scac_auto_detect_failed" | null;
                 /**
                  * @example bill_of_lading
                  * @enum {string}
@@ -1277,7 +1859,7 @@ export interface components {
                  */
                 active: boolean;
                 /** @description The list of events to enabled for this endpoint */
-                events: ("container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available")[];
+                events: ("container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed")[];
                 /** @description A random token that will sign all delivered webhooks */
                 secret: string;
                 headers?: {
@@ -1359,7 +1941,7 @@ export interface components {
             type: "transport_event";
             attributes?: {
                 /** @enum {string} */
-                event?: "container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available";
+                event?: "container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed";
                 voyage_number?: string | null;
                 /** Format: date-time */
                 timestamp?: string | null;
@@ -1434,7 +2016,7 @@ export interface components {
                 /** Format: date-time */
                 estimated_timestamp: string;
                 /** @enum {string} */
-                event: "shipment.estimated.arrival";
+                event: "shipment.estimated.arrival" | "document_representation.created" | "document_representation.failed";
                 /** @description UNLOCODE of the event location */
                 location_locode?: string | null;
                 /** @description IANA tz */
@@ -1482,7 +2064,7 @@ export interface components {
             type?: "webhook_notification";
             attributes?: {
                 /** @enum {string} */
-                event: "container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available";
+                event: "container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed";
                 /**
                  * @description Whether the notification has been delivered to the webhook endpoint
                  * @default pending
@@ -1505,7 +2087,7 @@ export interface components {
                         /** Format: uuid */
                         id?: string;
                         /** @enum {string} */
-                        type?: "tracking_request" | "estimated_event" | "transport_event" | "container_updated_event";
+                        type?: "tracking_request" | "estimated_event" | "transport_event" | "container_updated_event" | "document";
                     };
                 };
             };
@@ -1717,120 +2299,6 @@ export interface components {
             };
             /** @enum {string} */
             type?: "party";
-        };
-        /** Route model */
-        route: {
-            /** Format: uuid */
-            id: string;
-            /** @enum {string} */
-            type: "route";
-            attributes: {
-                /** Format: uuid */
-                id: string;
-                /** Format: date-time */
-                created_at: string;
-                /** Format: date-time */
-                updated_at: string;
-            };
-            relationships: {
-                cargo?: {
-                    data?: {
-                        /** Format: uuid */
-                        id: string;
-                        /** @enum {string} */
-                        type: "container";
-                    };
-                };
-                shipment?: {
-                    data?: {
-                        /** Format: uuid */
-                        id: string;
-                        /** @enum {string} */
-                        type: "shipment";
-                    };
-                };
-                route_locations?: {
-                    data?: {
-                        /** Format: uuid */
-                        id: string;
-                        /** @enum {string} */
-                        type: "route_location";
-                    }[];
-                };
-            };
-        };
-        /** Route Location model */
-        route_location: {
-            /** Format: uuid */
-            id: string;
-            /** @enum {string} */
-            type: "route_location";
-            attributes: {
-                /** Format: uuid */
-                id: string;
-                inbound_scac?: string | null;
-                /** @enum {string|null} */
-                inbound_mode?: "vessel" | "rail" | null;
-                /** Format: date-time */
-                inbound_eta_at?: string | null;
-                /** Format: date-time */
-                inbound_ata_at?: string | null;
-                inbound_voyage_number?: string | null;
-                outbound_scac?: string | null;
-                /** @enum {string|null} */
-                outbound_mode?: "vessel" | "rail" | null;
-                /** Format: date-time */
-                outbound_etd_at?: string | null;
-                /** Format: date-time */
-                outbound_atd_at?: string | null;
-                outbound_voyage_number?: string | null;
-                /** Format: date-time */
-                created_at: string;
-                /** Format: date-time */
-                updated_at: string;
-            };
-            relationships: {
-                route?: {
-                    data?: {
-                        /** Format: uuid */
-                        id: string;
-                        /** @enum {string} */
-                        type: "route";
-                    };
-                };
-                inbound_vessel?: {
-                    data?: {
-                        /** Format: uuid */
-                        id?: string;
-                        /** @enum {string} */
-                        type?: "vessel";
-                    } | null;
-                };
-                outbound_vessel?: {
-                    data?: {
-                        /** Format: uuid */
-                        id?: string;
-                        /** @enum {string} */
-                        type?: "vessel";
-                    } | null;
-                };
-                location?: {
-                    data?: {
-                        /** Format: uuid */
-                        id?: string;
-                        /** @enum {string} */
-                        type?: "port" | "terminal";
-                    };
-                };
-                facility?: {
-                    data?: {
-                        /** Format: uuid */
-                        id?: string;
-                        /** @enum {string} */
-                        type?: "terminal" | "port";
-                    } | null;
-                };
-            };
         };
         /** Vessel with positions model */
         vessel_with_positions: {
@@ -2076,6 +2544,73 @@ export interface components {
              */
             coordinates: number[];
         };
+        /** @description Raw custom field value (type depends on definition) */
+        custom_field_value: (string | number | boolean | string[] | Record<string, never>) | null;
+        /** Custom field */
+        custom_field: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "custom_field";
+            attributes?: {
+                api_slug: string;
+                value?: components["schemas"]["custom_field_value"];
+                /** @description Formatted value for display */
+                display_value?: string | null;
+            };
+            relationships?: {
+                entity?: {
+                    data?: {
+                        /** @enum {string} */
+                        type: "shipment" | "container" | "tracking_request";
+                        /** Format: uuid */
+                        id: string;
+                    };
+                };
+                definition?: {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field_definition";
+                        /** Format: uuid */
+                        id: string;
+                    };
+                };
+            };
+        };
+        /** Custom field definition */
+        custom_field_definition: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "custom_field_definition";
+            attributes?: {
+                /** @enum {string} */
+                entity_type: "Shipment" | "Container" | "TrackingRequest";
+                api_slug: string;
+                display_name: string;
+                description?: string | null;
+                /** @enum {string} */
+                data_type: "short_text" | "number" | "date" | "datetime" | "boolean" | "enum" | "enum_multi" | "reference";
+                reference_type?: string | null;
+                validation?: {
+                    [key: string]: unknown;
+                } | null;
+                default_format?: string | null;
+                default_value?: components["schemas"]["custom_field_value"];
+            };
+        };
+        /** Custom field option */
+        custom_field_option: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "custom_field_option";
+            attributes?: {
+                label: string;
+                value: string;
+                position?: number | null;
+            };
+        };
         /** LineString */
         lineStringGeometry: {
             /** @enum {string} */
@@ -2093,6 +2628,401 @@ export interface components {
              *     ]
              */
             coordinates: number[][];
+        };
+        /** Document Representation */
+        document_representation: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "document_representation";
+            attributes?: {
+                schema_version?: string;
+                payload?: {
+                    [key: string]: unknown;
+                };
+                /** Format: date-time */
+                created_at?: string;
+                /** Format: date-time */
+                updated_at?: string;
+            };
+        };
+        /** Email Submission */
+        email_submission: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "email_submission";
+            attributes?: {
+                /** @description Email subject line. */
+                subject?: string;
+                /** @description Email body content captured from the inbound message. */
+                body?: string | null;
+                /** @description Sender email addresses. */
+                from?: string[];
+                /** @description Primary recipient email addresses. */
+                to?: string[];
+                /** @description CC recipient email addresses. */
+                cc?: string[];
+                /**
+                 * Format: date-time
+                 * @description Timestamp from the inbound email header.
+                 */
+                sent_at?: string | null;
+                /** @description Message-ID header value. */
+                message_id?: string | null;
+                /** @description In-Reply-To header value. */
+                in_reply_to?: string | null;
+                /** @description References header values. */
+                references?: string[];
+                /** @description Top-level MIME content type of the inbound email. */
+                content_type?: string | null;
+                /** @description Number of non-discarded documents created from this email. */
+                documents_count?: number;
+                /**
+                 * Format: date-time
+                 * @description When the email submission record was created.
+                 */
+                created_at?: string;
+                /**
+                 * Format: date-time
+                 * @description When the email submission record was last updated.
+                 */
+                updated_at?: string;
+            };
+            relationships?: {
+                account?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "account";
+                    };
+                };
+                user?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "user";
+                    } | null;
+                };
+                documents?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "document";
+                    }[];
+                };
+            };
+            links?: {
+                self?: string;
+            };
+        };
+        /** Document Schema */
+        document_schema: {
+            id: string;
+            /** @enum {string} */
+            type: "document_schema";
+            attributes?: {
+                /** @description Document type this schema applies to (for example, commercial_invoice). */
+                document_type?: string;
+                /** @description Human-readable label for the document type. */
+                label?: string;
+                /** @description Public schema version identifier. */
+                schema_version?: string;
+                /** @description Fully-qualified schema version id (for example, commercial_invoice@2026-03-23). */
+                full_version?: string;
+                /** @description Whether this schema version is currently active. */
+                current?: boolean;
+                /** @description Whether this schema version is marked as draft. */
+                draft?: boolean;
+                /**
+                 * Format: date-time
+                 * @description Timestamp when this schema version became active.
+                 */
+                active_at?: string | null;
+                /**
+                 * @description Schema payload format.
+                 * @enum {string}
+                 */
+                schema_format?: "json_schema";
+                /** @description Optional notes describing this schema. */
+                description?: string | null;
+                /** @description Versioned JSON Schema used to validate document_representation.payload. This is not the sanitized extraction-field structure returned by GET /documents/types/{code}. */
+                schema_payload?: {
+                    [key: string]: unknown;
+                };
+                /**
+                 * Format: date-time
+                 * @description When this schema record was created.
+                 */
+                created_at?: string;
+                /**
+                 * Format: date-time
+                 * @description When this schema record was last updated.
+                 */
+                updated_at?: string;
+            };
+            links?: {
+                self?: string;
+            };
+        };
+        /** Document */
+        document: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "document";
+            attributes?: {
+                /**
+                 * Format: uuid
+                 * @description Unique identifier for the document.
+                 */
+                id?: string;
+                /** @description Display name of the document. */
+                name?: string;
+                /** @description System-classified document type. */
+                document_type?: string;
+                /** @description Document type set manually by a user, when available. */
+                document_type_manual?: string | null;
+                /** @description Additional notes captured during document classification. */
+                classification_notes?: string | null;
+                /**
+                 * @description How the document was created in Terminal49.
+                 * @enum {string}
+                 */
+                source?: "upload" | "api" | "email" | "split_document";
+                /** @description Original file name of the uploaded or generated document. */
+                file_name?: string;
+                /** @description MIME type of the document file. */
+                file_content_type?: string | null;
+                /** @description File size in bytes. */
+                file_size_bytes?: number | null;
+                /** @description Additional parsing metadata. Present for child documents created from a split packet. */
+                parsed?: {
+                    /** @description Page range of the child document within the original packet. */
+                    packetSegment?: {
+                        /** @description Start page number (inclusive) in the parent packet. */
+                        startPage?: number;
+                        /** @description End page number (inclusive) in the parent packet. */
+                        endPage?: number;
+                    };
+                } | null;
+                /**
+                 * Format: date-time
+                 * @description Timestamp when the document was created.
+                 */
+                created_at?: string;
+                /**
+                 * Format: date-time
+                 * @description Timestamp when the document was last updated.
+                 */
+                updated_at?: string;
+            };
+            relationships?: {
+                account?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "account";
+                    };
+                };
+                user?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "user";
+                    } | null;
+                };
+                email_submission?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "email_submission";
+                    } | null;
+                };
+                last_document_representation?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "document_representation";
+                    } | null;
+                };
+                /** @description Present for child documents created from a split packet. */
+                parent_document?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "document";
+                    } | null;
+                };
+                shipments?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "shipment";
+                    }[];
+                };
+                cargos?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "container";
+                    }[];
+                };
+            };
+            links?: {
+                self?: string;
+                download?: string;
+            };
+        };
+        /** Document Email Submission */
+        document_email_submission: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "email_submission";
+            attributes?: {
+                subject?: string | null;
+                body_preview?: string | null;
+                from?: string[];
+                to?: string[];
+                cc?: string[];
+                message_id?: string | null;
+                /** Format: date-time */
+                sent_at?: string | null;
+                /** Format: date-time */
+                created_at?: string;
+                /** Format: date-time */
+                updated_at?: string;
+            };
+        };
+        /** Email Submission Document */
+        email_submission_document: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "document";
+            attributes?: {
+                name?: string;
+                /** @enum {string} */
+                source?: "upload" | "api" | "email" | "split_document";
+                document_type?: string;
+                /** Format: date-time */
+                created_at?: string;
+                /** Format: date-time */
+                updated_at?: string;
+            };
+            relationships?: {
+                last_document_representation?: {
+                    data?: {
+                        /** Format: uuid */
+                        id?: string;
+                        /** @enum {string} */
+                        type?: "document_representation";
+                    } | null;
+                };
+            };
+        };
+        /**
+         * Document type
+         * @description One document type allowed for the authenticated account. Public catalog metadata is present when a schema detail view is available.
+         */
+        document_type_list_item: {
+            /** @description Stable document type code. */
+            code: string;
+            /** @description Human-readable document type label. */
+            label: string;
+            /** @description Public description of the document type. */
+            description?: string;
+            /** @description Metadata for the extraction-field structure available from the detail endpoint. */
+            schema?: {
+                /**
+                 * @description Fully qualified extraction schema ID.
+                 * @example packing_list@2026-03-23
+                 */
+                id: string;
+                /**
+                 * @description Extraction schema version.
+                 * @example 2026-03-23
+                 */
+                version: string;
+                /**
+                 * @description Relative URL for the document type detail endpoint.
+                 * @example /v2/documents/types/packing_list
+                 */
+                detail_url: string;
+            };
+        };
+        /**
+         * Sanitized extraction-field schema
+         * @description Recursive public-safe JSON Schema projection for rendering extraction fields. It includes only the structural keys retained by the sanitizer; internal extensions, prompts, instructions, titles, and descriptions are omitted.
+         * @example {
+         *       "type": "object",
+         *       "properties": {
+         *         "bill_of_lading_number": {
+         *           "type": [
+         *             "string",
+         *             "null"
+         *           ]
+         *         }
+         *       }
+         *     }
+         */
+        sanitized_extraction_schema: {
+            /** @description JSON Schema field type. It can be a string or an array of strings, such as ["string", "null"] for nullable fields in Wayfair schemas. */
+            type?: string | string[];
+            /** @description JSON Schema format, when available. */
+            format?: string;
+            /** @description Allowed field values, when available. */
+            enum?: unknown[];
+            /** @description Nested object fields keyed by property name. */
+            properties?: {
+                [key: string]: components["schemas"]["sanitized_extraction_schema"];
+            };
+            /** @description Array item schema or tuple of item schemas. */
+            items?: components["schemas"]["sanitized_extraction_schema"] | components["schemas"]["sanitized_extraction_schema"][];
+            /** @description Required property names for an object field. */
+            required?: string[];
+        };
+        /**
+         * Document type detail
+         * @description One public catalog item and its sanitized extraction-field structure.
+         */
+        document_type_detail: {
+            /** @description Stable document type code. */
+            code: string;
+            /** @description Human-readable document type label. */
+            label: string;
+            /** @description Public description of the document type. */
+            description: string;
+            /** @description Sanitized extraction-field schema metadata and structure. */
+            schema: {
+                /**
+                 * @description Fully qualified extraction schema ID.
+                 * @example packing_list@2026-03-23
+                 */
+                id: string;
+                /**
+                 * @description Extraction schema version.
+                 * @example 2026-03-23
+                 */
+                version: string;
+                /**
+                 * @description Format of the extraction-field structure.
+                 * @enum {string}
+                 */
+                format: "json_schema";
+                payload: components["schemas"]["sanitized_extraction_schema"];
+            };
         };
     };
     responses: never;
@@ -2117,7 +3047,7 @@ export interface operations {
                 q?: string;
                 /** @description Comma delimited list of relations to include */
                 include?: string;
-                /** @description Search shipments by the original request tracking `request_number` */
+                /** @description Search shipments by the original tracking `request_number` — typically a master bill of lading or booking number. This filter does **not** match container numbers; to look up a shipment by container number, use `GET /containers?filter[number]={container_number}` and include the related shipment via `include=shipment`. */
                 number?: string;
                 /** @description Filter shipments by whether they are still tracking or not */
                 "filter[tracking_stopped]"?: boolean;
@@ -2193,6 +3123,17 @@ export interface operations {
                     };
                 };
             };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
         };
     };
     "patch-shipments-id": {
@@ -2218,7 +3159,7 @@ export interface operations {
                              */
                             ref_numbers?: string[];
                             /** @description Tags related to a shipment */
-                            shipment_tags?: string[];
+                            tags?: string[];
                         };
                     };
                 };
@@ -2376,12 +3317,41 @@ export interface operations {
                             request_type: "bill_of_lading" | "booking_number" | "container";
                             /** @example MEDUFR030802 */
                             request_number: string;
-                            /** @example MSCU */
-                            scac: string;
+                            /**
+                             * @description The carrier SCAC to use for this tracking request. Required unless `auto_detect_vocc_scac` is `true`.
+                             * @example MSCU
+                             */
+                            scac?: string;
+                            /**
+                             * @description Set to `true` to have Terminal49 infer the carrier SCAC from `request_number` when `scac` is not supplied. Detection is asynchronous: the tracking request is created immediately (HTTP `201`) with `status: "pending"` and `scac: null`. If a carrier is inferred, the request transitions to `status: "created"` with the detected `scac` populated. If no supported carrier can be inferred, it transitions to `status: "failed"` with `failed_reason: "scac_auto_detect_failed"` and no shipment is created. Poll the tracking request or use webhooks to observe the outcome — the create response does not include the detected `scac`.
+                             * @default false
+                             * @example true
+                             */
+                            auto_detect_vocc_scac?: boolean;
                             /** @description Optional list of reference numbers to be added to the shipment when tracking request completes */
                             ref_numbers?: string[];
                             /** @description Optional list of tags to be added to the shipment when tracking request completes */
                             shipment_tags?: string[];
+                            /** @description Optional custom field values to stage before the shipment and containers exist. Terminal49 applies `shipment` entries to the shipment and `containers` entries to matching containers once the tracking request resolves. Each `api_slug` must reference an existing custom field definition on your account. */
+                            initial_custom_fields?: {
+                                /** @description Custom field values to apply to the shipment created by this tracking request. */
+                                shipment?: {
+                                    /** @description The `api_slug` of a custom field definition scoped to the `Shipment` entity type. */
+                                    api_slug: string;
+                                    value: components["schemas"]["custom_field_value"];
+                                }[];
+                                /** @description Custom field values to apply to the containers created by this tracking request. Include `number` to target one specific container; omit it (or pass an empty string) to apply the value to every container on the shipment. */
+                                containers?: {
+                                    /** @description The `api_slug` of a custom field definition scoped to the `Container` entity type. */
+                                    api_slug: string;
+                                    value: components["schemas"]["custom_field_value"];
+                                    /**
+                                     * @description Container number to target. Omit this field, or pass an empty string, to broadcast this value to every container on the shipment.
+                                     * @example MSCU1234567
+                                     */
+                                    number?: string;
+                                }[];
+                            };
                         };
                         relationships?: {
                             customer?: {
@@ -2617,6 +3587,146 @@ export interface operations {
             };
         };
     };
+    "get-tracking-requests-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-tracking-requests-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                /**
+                 * @example {
+                 *       "data": {
+                 *         "type": "custom_field",
+                 *         "attributes": {
+                 *           "api_slug": "customer_reference_number",
+                 *           "value": "ABC124"
+                 *         }
+                 *       }
+                 *     }
+                 */
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            api_slug: string;
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-tracking-requests-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-tracking-requests-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Tracking request ID */
+                tracking_request_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
     "get-webhooks-id": {
         parameters: {
             query?: never;
@@ -2682,7 +3792,7 @@ export interface operations {
                              */
                             url?: string;
                             /** @description The list of events to enable for this endpoint. */
-                            events?: ("container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available")[];
+                            events?: ("container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed")[];
                             active?: boolean;
                             /** @description Optional custom headers to pass with each webhook invocation */
                             headers?: {
@@ -2758,7 +3868,7 @@ export interface operations {
                              */
                             url: string;
                             /** @description The list of events to enable for this endpoint. */
-                            events?: ("container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available")[];
+                            events?: ("container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed")[];
                             active: boolean;
                             /** @description Optional custom headers to pass with each webhook invocation */
                             headers?: {
@@ -2789,6 +3899,40 @@ export interface operations {
             };
         };
     };
+    "get-webhooks-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: {
+                            id: string;
+                            /** @enum {string} */
+                            type: "webhook_event_category";
+                            attributes: {
+                                name: string;
+                                events: {
+                                    /** @example tracking_request.succeeded */
+                                    name: string;
+                                    description: string;
+                                }[];
+                            };
+                        }[];
+                    };
+                };
+            };
+        };
+    };
     "get-webhook-notification-id": {
         parameters: {
             query?: {
@@ -2810,7 +3954,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         data?: components["schemas"]["webhook_notification"];
-                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"] | components["schemas"]["container_updated_event"])[];
+                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"] | components["schemas"]["container_updated_event"] | components["schemas"]["document"] | components["schemas"]["document_representation"] | components["schemas"]["document_email_submission"])[];
                     };
                 };
             };
@@ -2840,7 +3984,7 @@ export interface operations {
                         data?: components["schemas"]["webhook_notification"][];
                         links?: components["schemas"]["links"];
                         meta?: components["schemas"]["meta"];
-                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"])[];
+                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"] | components["schemas"]["container_updated_event"] | components["schemas"]["document"] | components["schemas"]["document_representation"] | components["schemas"]["document_email_submission"])[];
                     };
                 };
             };
@@ -2850,7 +3994,7 @@ export interface operations {
         parameters: {
             query?: {
                 /** @description The webhook notification event name you wish to see an example of */
-                event?: "container.transport.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.transport.available";
+                event?: "container.transport.vessel_arrived" | "container.transport.estimated.vessel_arrived" | "container.transport.vessel_discharged" | "container.transport.vessel_loaded" | "container.transport.vessel_departed" | "container.transport.estimated.vessel_departed" | "container.transport.rail_departed" | "container.transport.rail_arrived" | "container.transport.rail_loaded" | "container.transport.rail_unloaded" | "container.transport.transshipment_arrived" | "container.transport.transshipment_discharged" | "container.transport.transshipment_loaded" | "container.transport.transshipment_departed" | "container.transport.feeder_arrived" | "container.transport.feeder_discharged" | "container.transport.feeder_loaded" | "container.transport.feeder_departed" | "container.transport.empty_out" | "container.transport.full_in" | "container.transport.full_out" | "container.transport.empty_in" | "container.transport.vessel_berthed" | "shipment.estimated.arrival" | "tracking_request.succeeded" | "tracking_request.failed" | "tracking_request.awaiting_manifest" | "tracking_request.tracking_stopped" | "container.created" | "container.updated" | "container.pod_terminal_changed" | "container.transport.arrived_at_inland_destination" | "container.transport.estimated.arrived_at_inland_destination" | "container.pickup_lfd.changed" | "container.pickup_lfd_line.changed" | "container.pickup_lfd_terminal.changed" | "container.pickup_lfd_rail.changed" | "container.pickup_appointment.changed" | "container.transport.available" | "container.transport.not_available" | "container.transport.delivered" | "document_representation.created" | "document_representation.failed";
             };
             header?: never;
             path?: never;
@@ -2868,7 +4012,7 @@ export interface operations {
                         data?: components["schemas"]["webhook_notification"][];
                         links?: components["schemas"]["links"];
                         meta?: components["schemas"]["meta"];
-                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"])[];
+                        included?: (components["schemas"]["webhook"] | components["schemas"]["tracking_request"] | components["schemas"]["transport_event"] | components["schemas"]["estimated_event"] | components["schemas"]["container_updated_event"] | components["schemas"]["document"] | components["schemas"]["document_representation"] | components["schemas"]["document_email_submission"])[];
                     };
                 };
             };
@@ -2898,6 +4042,93 @@ export interface operations {
             };
         };
     };
+    "post-webhooks-trigger": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uri
+                     * @description Destination URL for the test webhook delivery. Must be HTTPS.
+                     * @example https://webhook.site/your-endpoint
+                     */
+                    url: string;
+                    /**
+                     * @description Webhook event name to use for generating an example payload.
+                     * @example tracking_request.succeeded
+                     */
+                    event: string;
+                    /**
+                     * @description Optional secret used to sign the request in `X-T49-Webhook-Signature`.
+                     * @example optional-test-secret
+                     */
+                    secret?: string;
+                    /** @description Optional test payload controls. Currently only supports `document_type` for document webhook events. */
+                    sample?: {
+                        /**
+                         * @description Specific document type to use when generating example payloads for `document_representation.created` or `document_representation.failed`. If omitted for these events, Terminal49 selects a default document type.
+                         * @example dray_delivery_order
+                         */
+                        document_type?: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Webhook test delivery attempt result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /**
+                         * Format: uri
+                         * @description Destination URL that the test webhook delivery attempted to call.
+                         */
+                        url?: string;
+                        /** @description Whether the webhook delivery attempt was considered successful (HTTP 200, 201, 202, or 204). */
+                        succeeded?: boolean;
+                        /** @description Error message captured when delivery failed, or `null` when no error occurred. */
+                        error?: string | null;
+                        /** @description HTTP status code returned by the destination endpoint, or `null` if no response was received. */
+                        status_code?: number | null;
+                        /** @description Headers sent by Terminal49 with the test webhook request. */
+                        request_headers?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Serialized JSON payload delivered to the target URL. */
+                        request_body?: string;
+                        /** @description Headers returned by the destination endpoint, or `null` when unavailable. */
+                        response_headers?: {
+                            [key: string]: unknown;
+                        } | null;
+                        /** @description Raw response body returned by the destination endpoint, or `null` when unavailable. */
+                        response_body?: string | null;
+                    };
+                };
+            };
+            /** @description Validation error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: {
+                            /** @example url is required */
+                            detail?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
     "get-containers": {
         parameters: {
             query?: {
@@ -2905,8 +4136,6 @@ export interface operations {
                 "page[size]"?: number;
                 /** @description Comma delimited list of relations to include */
                 include?: string;
-                /** @description Number of seconds in which containers were refreshed */
-                terminal_checked_before?: number;
             };
             header?: never;
             path?: never;
@@ -3039,49 +4268,6 @@ export interface operations {
                         included?: (components["schemas"]["shipment"] | components["schemas"]["container"] | components["schemas"]["port"] | components["schemas"]["metro_area"] | components["schemas"]["terminal"] | components["schemas"]["rail_terminal"] | components["schemas"]["vessel"])[];
                         links?: components["schemas"]["links"];
                         meta?: components["schemas"]["meta"];
-                    };
-                };
-            };
-        };
-    };
-    "get-containers-id-route": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["route"];
-                        included?: (components["schemas"]["port"] | components["schemas"]["vessel"] | components["schemas"]["route_location"] | components["schemas"]["shipment"])[];
-                    };
-                };
-            };
-            /** @description Forbidden - Routing data feature is not enabled for this account */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        errors?: {
-                            /** @example 403 */
-                            status?: string;
-                            /** @example Forbidden */
-                            title?: string;
-                            /** @example Routing data feature is not enabled for this account */
-                            detail?: string;
-                        }[];
                     };
                 };
             };
@@ -3621,6 +4807,799 @@ export interface operations {
             };
         };
     };
+    "get-custom-field-definitions": {
+        parameters: {
+            query?: {
+                "page[number]"?: number;
+                "page[size]"?: number;
+                /** @description Filter by entity type (Shipment or Container) */
+                "filter[entity_type]"?: string;
+                /** @description Filter by data type */
+                "filter[data_type]"?: string;
+                /** @description Filter by display name (prefix match) */
+                "filter[display_name]"?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_definition"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-custom-field-definitions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field_definition";
+                        attributes: {
+                            /** @enum {string} */
+                            entity_type: "Shipment" | "Container";
+                            api_slug: string;
+                            display_name: string;
+                            description?: string | null;
+                            /** @enum {string} */
+                            data_type: "short_text" | "number" | "date" | "datetime" | "boolean" | "enum" | "enum_multi" | "reference";
+                            reference_type?: string | null;
+                            validation?: {
+                                [key: string]: unknown;
+                            } | null;
+                            default_format?: string | null;
+                            default_value?: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_definition"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-custom-field-definitions-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_definition"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-custom-field-definitions-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-custom-field-definitions-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field_definition";
+                        attributes: {
+                            display_name?: string;
+                            description?: string | null;
+                            validation?: {
+                                [key: string]: unknown;
+                            } | null;
+                            default_format?: string | null;
+                            default_value?: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_definition"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-custom-field-options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_option"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-custom-field-options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field_option";
+                        attributes: {
+                            label: string;
+                            value: string;
+                            position?: number | null;
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_option"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-custom-field-options-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+                /** @description Custom field option ID */
+                option_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_option"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-custom-field-options-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+                /** @description Custom field option ID */
+                option_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-custom-field-options-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field definition ID */
+                definition_id: string;
+                /** @description Custom field option ID */
+                option_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field_option";
+                        attributes: {
+                            label?: string;
+                            position?: number | null;
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field_option"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-custom-fields": {
+        parameters: {
+            query?: {
+                "page[number]"?: number;
+                "page[size]"?: number;
+                /** @description Filter by entity type (Shipment or Container) */
+                "filter[entity_type]"?: string;
+                /** @description Filter by entity ID */
+                "filter[entity_id]"?: string;
+                /** @description Filter by custom field definition ID */
+                "filter[definition_id]"?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                /**
+                 * @example {
+                 *       "data": {
+                 *         "type": "custom_field",
+                 *         "attributes": {
+                 *           "api_slug": "customer_reference_number",
+                 *           "value": "ABC124"
+                 *         },
+                 *         "relationships": {
+                 *           "entity": {
+                 *             "data": {
+                 *               "type": "shipment",
+                 *               "id": "YOUR_SHIPMENT_ID"
+                 *             }
+                 *           }
+                 *         }
+                 *       }
+                 *     }
+                 */
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            api_slug: string;
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                        relationships: {
+                            entity?: {
+                                data?: {
+                                    /** @enum {string} */
+                                    type: "shipment" | "container";
+                                    /** Format: uuid */
+                                    id: string;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-custom-fields-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-custom-fields-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-custom-fields-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Custom field ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-shipments-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-shipments-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                /**
+                 * @example {
+                 *       "data": {
+                 *         "type": "custom_field",
+                 *         "attributes": {
+                 *           "api_slug": "customer_reference_number",
+                 *           "value": "ABC124"
+                 *         }
+                 *       }
+                 *     }
+                 */
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            api_slug: string;
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-shipments-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-shipments-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Shipment ID */
+                shipment_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "get-containers-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"][];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+        };
+    };
+    "post-containers-custom-fields": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                /**
+                 * @example {
+                 *       "data": {
+                 *         "type": "custom_field",
+                 *         "attributes": {
+                 *           "api_slug": "customer_reference_number",
+                 *           "value": "ABC124"
+                 *         }
+                 *       }
+                 *     }
+                 */
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            api_slug: string;
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
+    "delete-containers-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "patch-containers-custom-fields-api-slug": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Container ID */
+                container_id: string;
+                /** @description Custom field api_slug */
+                api_slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "custom_field";
+                        attributes: {
+                            value: components["schemas"]["custom_field_value"];
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["custom_field"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+        };
+    };
     "get-parties-id": {
         parameters: {
             query?: never;
@@ -3685,6 +5664,875 @@ export interface operations {
             };
             /** @description Unprocessable Entity */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-documents": {
+        parameters: {
+            query?: {
+                /** @description Comma-separated includes. Allowed: shipments, cargos, account, user, last_document_representation, email_submission, current_extraction (alias for last_document_representation). */
+                include?: string;
+                /** @description Sortable fields: document_type, added_by, created_at. Prefix with - for descending. */
+                sort?: string;
+                /** @description Filter by filename (full-text match). */
+                "filter[filename]"?: string;
+                /** @description Filter by reference token. */
+                "filter[reference]"?: string;
+                /** @description Comma-separated document types. */
+                "filter[document_types]"?: string;
+                "page[number]"?: number;
+                "page[size]"?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["document"][];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["shipment"] | components["schemas"]["container"] | components["schemas"]["document"] | components["schemas"]["document_email_submission"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "post-documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "document";
+                        attributes: {
+                            name: string;
+                            /** @description ActiveStorage signed blob id from direct upload. */
+                            attached_document: string;
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["document"];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["shipment"] | components["schemas"]["container"] | components["schemas"]["document"] | components["schemas"]["document_email_submission"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+            /** @description Duplicate document */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: {
+                            /** @example 409 */
+                            status?: string;
+                            /** @example duplicate_document */
+                            code?: string;
+                            /** @example Duplicate document */
+                            title?: string;
+                            detail?: string;
+                            meta?: {
+                                /** Format: uuid */
+                                existing_document_id?: string;
+                                existing_document_name?: string;
+                            };
+                        }[];
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-documents-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        document_types: components["schemas"]["document_type_list_item"][];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors: {
+                            detail: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    "get-documents-types-code": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /**
+                 * @description Document type code from the list response.
+                 * @example packing_list
+                 */
+                code: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        document_type: components["schemas"]["document_type_detail"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors: {
+                            detail: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors: {
+                            status: string;
+                            title: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    "get-documents-id": {
+        parameters: {
+            query?: {
+                /** @description Comma-separated includes. Allowed: shipments, cargos, account, user, last_document_representation, email_submission, current_extraction (alias for last_document_representation). */
+                include?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["document"];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["shipment"] | components["schemas"]["container"] | components["schemas"]["document"] | components["schemas"]["document_email_submission"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "delete-documents-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "patch-documents-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    data?: {
+                        /** @enum {string} */
+                        type: "document";
+                        attributes: {
+                            /** @description Manually override the document type. */
+                            document_type_manual?: string;
+                            /** @description Manually provide extracted key/value data. Set to null to clear manual values. */
+                            extracted_data_manual?: {
+                                [key: string]: unknown;
+                            } | null;
+                        };
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["document"];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["shipment"] | components["schemas"]["container"] | components["schemas"]["document"] | components["schemas"]["document_email_submission"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-documents-id-download_url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: uri */
+                        download_url: string;
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "post-documents-id-reextract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "accepted";
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "post-documents-id-reclassify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "accepted";
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "post-documents-id-relink": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "accepted";
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "post-documents-id-rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {integer} */
+                    degrees: 90 | 180 | 270;
+                };
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        status: "accepted";
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-email_submissions": {
+        parameters: {
+            query?: {
+                /** @description Allowed: account, user, documents, documents.last_document_representation. Defaults to documents + documents.last_document_representation. */
+                include?: string;
+                "page[number]"?: number;
+                "page[size]"?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["email_submission"][];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["email_submission_document"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["links"];
+                        meta?: components["schemas"]["meta"];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-email_submissions-id": {
+        parameters: {
+            query?: {
+                /** @description Allowed: account, user, documents, documents.last_document_representation. Defaults to documents + documents.last_document_representation. */
+                include?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["email_submission"];
+                        included?: (components["schemas"]["account"] | components["schemas"]["user"] | components["schemas"]["email_submission_document"] | components["schemas"]["document_representation"])[];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    "get-document_schemas-id": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Schema id in full-version format, e.g. commercial_invoice@2026-03-23. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["document_schema"];
+                        links?: components["schemas"]["link-self"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        errors?: components["schemas"]["error"][];
+                    };
+                };
+            };
+        };
+    };
+    searchAll: {
+        parameters: {
+            query: {
+                /** @description Search term to match against BL numbers, container numbers, reference numbers, and other indexed fields. Supports full-text search and partial (ILIKE) matching. */
+                query: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful search results */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": [
+                     *         {
+                     *           "id": "abc12345-6789-40ef-9012-3456789abcde",
+                     *           "type": "shipment",
+                     *           "attributes": {
+                     *             "entity_type": "shipment",
+                     *             "number": "MEDUA1234567",
+                     *             "shipment_id": null,
+                     *             "scac": "MSCU",
+                     *             "port_of_lading_name": "Shanghai",
+                     *             "port_of_discharge_name": "Los Angeles",
+                     *             "containers_count": 3,
+                     *             "tracking_stopped": false,
+                     *             "tracking_stopped_reason": null,
+                     *             "status": null,
+                     *             "failed_reason": null,
+                     *             "ref_numbers": [
+                     *               "PO-2026-001"
+                     *             ],
+                     *             "created_at": "2026-01-15T10:30:00.000Z",
+                     *             "updated_at": "2026-03-01T14:22:00.000Z"
+                     *           }
+                     *         },
+                     *         {
+                     *           "id": "def45678-9012-43ab-9cde-f0123456789a",
+                     *           "type": "cargo",
+                     *           "attributes": {
+                     *             "entity_type": "cargo",
+                     *             "number": "MSCU1234567",
+                     *             "shipment_id": "abc12345-6789-40ef-9012-3456789abcde",
+                     *             "scac": "MSCU",
+                     *             "port_of_lading_name": null,
+                     *             "port_of_discharge_name": null,
+                     *             "containers_count": null,
+                     *             "tracking_stopped": null,
+                     *             "tracking_stopped_reason": null,
+                     *             "status": null,
+                     *             "failed_reason": null,
+                     *             "ref_numbers": [],
+                     *             "created_at": "2026-01-15T10:30:00.000Z",
+                     *             "updated_at": "2026-03-01T14:22:00.000Z"
+                     *           }
+                     *         }
+                     *       ]
+                     *     }
+                     */
+                    "application/json": {
+                        data?: {
+                            /** @description Unique identifier of the matched resource */
+                            id?: string;
+                            /**
+                             * @description Resource type
+                             * @enum {string}
+                             */
+                            type?: "shipment" | "cargo" | "tracking_request";
+                            attributes?: {
+                                /** @description Type of the matched entity: `shipment`, `cargo`, or `tracking_request` */
+                                entity_type?: string;
+                                /** @description BL number (shipments), container number (cargos), or request number (tracking requests) */
+                                number?: string;
+                                /** @description Associated shipment ID (for cargos and tracking requests only) */
+                                shipment_id?: string | null;
+                                /** @description Standard Carrier Alpha Code of the shipping line */
+                                scac?: string | null;
+                                /** @description Port of lading name (shipments only) */
+                                port_of_lading_name?: string | null;
+                                /** @description Port of discharge name (shipments only) */
+                                port_of_discharge_name?: string | null;
+                                /** @description Number of containers on the shipment (shipments only) */
+                                containers_count?: number | null;
+                                /** @description Whether tracking has been stopped (shipments only) */
+                                tracking_stopped?: boolean | null;
+                                /** @description Reason tracking was stopped (shipments only) */
+                                tracking_stopped_reason?: string | null;
+                                /** @description Tracking request status (tracking requests only) */
+                                status?: string | null;
+                                /** @description Reason the tracking request failed (tracking requests only) */
+                                failed_reason?: string | null;
+                                /** @description Customer reference numbers */
+                                ref_numbers?: string[];
+                                /**
+                                 * Format: date-time
+                                 * @description When the resource was created
+                                 */
+                                created_at?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description When the resource was last updated
+                                 */
+                                updated_at?: string;
+                            };
+                        }[];
+                    };
+                };
+            };
+            /** @description Bad request — missing required `query` parameter */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "errors": [
+                     *         {
+                     *           "detail": "Query parameter is required"
+                     *         }
+                     *       ]
+                     *     }
+                     */
+                    "application/json": {
+                        errors?: {
+                            detail?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Unauthorized — missing or invalid API token */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Documents the account-scoped supported document type catalog and its on-demand extraction schema detail. The contract preserves every account-allowed option while exposing public catalog metadata only where a detail response exists.

## Changes

- Extend `GET /documents/types` with optional description and schema metadata while keeping `code` and `label` required for every option.
- Add `GET /documents/types/{code}` for catalog-visible sanitized extraction-field structure and clarify that option-only list values return 404 from detail.
- Distinguish extraction-field schemas from versioned `document_representation.payload` validation in the API reference.
- Regenerate the TypeScript SDK contract and use the SDK transport's manual path for the existing undocumented container route.
- Add the missing public-safe `user` component required to resolve existing OpenAPI references.
- Synchronize the MCP locked-listing assertion with the approved ChatGPT app subtitle so the repository-wide MCP suite remains green.

## Out-of-Scope Feedback

- **Repair the API docs Spectral ruleset source** — Pending

## Testing

- Passed: OpenAPI JSON assertions for required `code`/`label`, optional catalog metadata, the detail endpoint, option-only example, and public-safe `user` schema.
- Passed: TypeScript SDK generation, build, typecheck, and lint.
  - `npm run generate:types --workspace @terminal49/sdk`
  - `npm run build --workspace @terminal49/sdk`
  - `npm run type-check --workspace @terminal49/sdk`
  - `npm run lint --workspace @terminal49/sdk`
- Passed: targeted MCP annotation test and full MCP suite.
  - `npm run test --workspace @terminal49/mcp -- --run src/annotations.test.ts`
  - `npm run test --workspace @terminal49/mcp -- --run`
- Passed: replacement GitHub Actions CI run 32874453982, including MCP tests and all protocol preview jobs.
- Passed: `cd docs && npx -y mintlify@latest broken-links`.
- Passed: docs browser walkthrough and `git diff --check`.
- Confirmed: `Terminal49-API.postman_collection.json` is unchanged from `origin/main`.
- Blocked: `npx -y @stoplight/spectral-cli@6.16.3 lint --ruleset .spectral.mjs docs/openapi.json` cannot fetch the deleted remote branch `feat/container-event-timestamps` and returns HTTP 404.

Evidence:

---
**Attached Images and Videos**

![dev12120-final-list-document-types.png](https://api.us1.vorflux.com/assets/artifacts/dDQ5OmY6NzUx.ZvIK32STq5V3by4EXB9sNb2gRjL-BhXdVTFWtcS9FC0.png)

![dev12120-final-get-document-type.png](https://api.us1.vorflux.com/assets/artifacts/dDQ5OmY6NzUy.6_C3atpy5ohnsDS8Oi2hPd--0hnQfZY4TIcDnFQ99LU.png)

![dev12120-final-document-schema.png](https://api.us1.vorflux.com/assets/artifacts/dDQ5OmY6NzUz.VUWei5GC06SXIBEmPxenjGRktIUswbYkNDQaF5j0_4E.png)

🎥 [View recording: dev12120-final-docs-flow.webm](https://api.us1.vorflux.com/assets/artifacts/dDQ5OmY6NzU0.5RT4V0RLIkyNYlm0yjocX84UVOgLt6UTgEfy4r5wOfM.mp4)
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://t49.us1.vorflux.com/agent-sessions/336efcd0-ac8b-4123-99f4-992176923685)
- Requested by: Akshay Dodeja (akshay@terminal49.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790266827&installation_model_id=18852&pr_number=348&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F348&signature=9f7a1225f47e2ed72d9b213354b0bfc1559e23a4346d5f7852b03f414bd9fec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents account-visible document-type metadata and a detail endpoint exposing sanitized extraction-field structure, while clarifying the distinction from versioned payload-validation schemas.

- Adds list and detail contracts and recursive document-type schemas to the OpenAPI description.
- Adds Mintlify reference content and navigation for the detail endpoint.
- Regenerates the Postman collection with the new operations.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The generated TypeScript contract should be synchronized before merging; the malformed Postman detail example should also be corrected.

The OpenAPI source exposes a new typed operation that is absent from the committed SDK definitions, while the generated Postman response presents circular-reference diagnostics as example data.

**Files Needing Attention:** docs/openapi.json, sdks/typescript-sdk/src/generated/terminal49.ts, Terminal49-API.postman_collection.json
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/openapi.json | Adds the document-type detail contract and recursive schemas, but the corresponding committed TypeScript definitions remain stale. |
| Terminal49-API.postman_collection.json | Adds generated document-type requests, but the detail response example includes circular-reference diagnostics as payload values. |
| docs/api-docs/api-reference/documents/get-a-document-type.mdx | Adds a focused reference page explaining account visibility, sanitizer boundaries, and the distinction from validation schemas. |
| docs/docs.json | Adds the new document-type detail page to Documents navigation. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  OpenAPI[docs/openapi.json] --> Docs[Mintlify API reference]
  OpenAPI --> Postman[Postman collection]
  OpenAPI --> Generator[SDK generate:types]
  Generator --> SDK[Generated TypeScript paths and schemas]
  List[GET /documents/types] --> Detail[GET /documents/types/code]
  Detail --> Sanitized[Sanitized extraction-field structure]
  Versioned[GET /document_schemas/id] --> Validator[Representation payload validator]
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22vorflux%2Fdev-12120-supported-document-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22vorflux%2Fdev-12120-supported-document-types%22.%0A%0AGreploop%20terminal49%2Fapi%20PR%20%23348%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=terminal49%2Fapi&pr=348&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22terminal49%2Fapi%22%20on%20the%20existing%20branch%20%22vorflux%2Fdev-12120-supported-document-types%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22vorflux%2Fdev-12120-supported-document-types%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fopenapi.json%3A9506-9507%0A**Generated%20SDK%20contract%20is%20stale**%0A%0AWhen%20TypeScript%20SDK%20consumers%20use%20the%20newly%20documented%20detail%20endpoint%2C%20the%20committed%20generated%20contract%20contains%20neither%20%60GET%20%2Fdocuments%2Ftypes%2F%7Bcode%7D%60%20nor%20its%20response%20schemas%2C%20so%20the%20endpoint%20and%20response%20types%20are%20unavailable%20from%20the%20package.%20Regenerate%20%60sdks%2Ftypescript-sdk%2Fsrc%2Fgenerated%2Fterminal49.ts%60%20from%20this%20OpenAPI%20update.%0A%0A%23%23%23%20Issue%202%0ATerminal49-API.postman_collection.json%3A9455%0A**Circular-reference%20diagnostics%20pollute%20example**%0A%0AThe%20generated%20detail%20response%20contains%20literal%20%60%3CCircular%20reference%20...%20detected%3E%60%20values%20under%20%60payload.properties%60%20and%20%60payload.items%60.%20This%20exposes%20generator%20diagnostics%20instead%20of%20realistic%20response%20data%2C%20making%20the%20new%20endpoint's%20primary%20Postman%20example%20misleading%20and%20unusable%20as%20a%20sample%20payload.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fopenapi.json%3A9506-9507%0A**Generated%20SDK%20contract%20is%20stale**%0A%0AWhen%20TypeScript%20SDK%20consumers%20use%20the%20newly%20documented%20detail%20endpoint%2C%20the%20committed%20generated%20contract%20contains%20neither%20%60GET%20%2Fdocuments%2Ftypes%2F%7Bcode%7D%60%20nor%20its%20response%20schemas%2C%20so%20the%20endpoint%20and%20response%20types%20are%20unavailable%20from%20the%20package.%20Regenerate%20%60sdks%2Ftypescript-sdk%2Fsrc%2Fgenerated%2Fterminal49.ts%60%20from%20this%20OpenAPI%20update.%0A%0A%23%23%23%20Issue%202%0ATerminal49-API.postman_collection.json%3A9455%0A**Circular-reference%20diagnostics%20pollute%20example**%0A%0AThe%20generated%20detail%20response%20contains%20literal%20%60%3CCircular%20reference%20...%20detected%3E%60%20values%20under%20%60payload.properties%60%20and%20%60payload.items%60.%20This%20exposes%20generator%20diagnostics%20instead%20of%20realistic%20response%20data%2C%20making%20the%20new%20endpoint's%20primary%20Postman%20example%20misleading%20and%20unusable%20as%20a%20sample%20payload.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=terminal49%2Fapi&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/openapi.json:9506-9507
**Generated SDK contract is stale**

When TypeScript SDK consumers use the newly documented detail endpoint, the committed generated contract contains neither `GET /documents/types/{code}` nor its response schemas, so the endpoint and response types are unavailable from the package. Regenerate `sdks/typescript-sdk/src/generated/terminal49.ts` from this OpenAPI update.

### Issue 2
Terminal49-API.postman_collection.json:9455
**Circular-reference diagnostics pollute example**

The generated detail response contains literal `<Circular reference ... detected>` values under `payload.properties` and `payload.items`. This exposes generator diagnostics instead of realistic response data, making the new endpoint's primary Postman example misleading and unusable as a sample payload.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Auto-generate Postman collection ..."](https://github.com/terminal49/api/commit/311fb491d0cfdc272216ef0ea41fb9ce9ccf3814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56722071)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->