### PR TITLE
docs: clarify paid-plan requirement in API permission error message

### DIFF
--- a/docs/api-docs/api-reference/introduction.mdx
+++ b/docs/api-docs/api-reference/introduction.mdx
@@ -37,7 +37,7 @@ Replace `YOUR_API_KEY` with the raw key value from the [developer portal](https:
 
 ### Restricted API access on Free plans
 
-Free-plan accounts can authenticate and create tracking requests, but read endpoints are gated. A valid key on a restricted account returns `401 Unauthorized` with `"You do not have permissions for using the API, except for creating tracking requests"` when you call any endpoint other than `POST /v2/tracking_requests`.
+Free-plan accounts can authenticate and create tracking requests, but read endpoints are gated. A valid key on a restricted account returns `401 Unauthorized` with `"You do not have permissions for using the API, except for creating tracking requests. All other permissions require a paid plan. See https://app.terminal49.com/settings/billing"` when you call any endpoint other than `POST /v2/tracking_requests`.
 
 To read tracking data (`GET /v2/shipments`, `GET /v2/containers`, `GET /v2/tracking_requests/{id}`, and other endpoints), your account needs full API access enabled. Full API access is not automatic on the Free plan. Contact [support@terminal49.com](mailto:support@terminal49.com) to enable a 7-day API trial, or see [Pricing](/api-docs/useful-info/pricing) for plans that include ongoing API read access.
 

--- a/docs/api-docs/useful-info/entitlements.mdx
+++ b/docs/api-docs/useful-info/entitlements.mdx
@@ -17,7 +17,7 @@ Some Terminal49 features require account enablement beyond standard API access.
 
 | Surface | Entitlement | How to request access | Non-entitled behavior |
 | --- | --- | --- | --- |
-| Read endpoints (`GET /v2/shipments`, `GET /v2/containers`, `GET /v2/tracking_requests/{id}`, and other GETs) | Full API access (paid plan or 7-day API trial) | Contact support@terminal49.com to enable the trial, or upgrade at [Pricing](/api-docs/useful-info/pricing) | `401 Unauthorized` with `You do not have permissions for using the API, except for creating tracking requests`. `POST /v2/tracking_requests` still works. |
+| Read endpoints (`GET /v2/shipments`, `GET /v2/containers`, `GET /v2/tracking_requests/{id}`, and other GETs) | Full API access (paid plan or 7-day API trial) | Contact support@terminal49.com to enable the trial, or upgrade at [Pricing](/api-docs/useful-info/pricing) | `401 Unauthorized` with `You do not have permissions for using the API, except for creating tracking requests. All other permissions require a paid plan. See https://app.terminal49.com/settings/billing`. `POST /v2/tracking_requests` still works. |
 | Container Map GeoJSON API (`GET /v2/containers/{id}/map_geojson`) | Routing Data | Contact sales@terminal49.com | `403 Forbidden` with `Routing data feature is not enabled for this account` |
 | Vessel position and future-position endpoints | Routing Data / vessel positions | Contact sales@terminal49.com | `403 Forbidden` with `Routing data feature is not enabled for this account` |
 | MCP `get_container_route` tool | Routing Data | Contact sales@terminal49.com | The tool returns a feature-not-enabled response; use `get_container_transport_events` for historical milestones |


### PR DESCRIPTION
Matches the updated tnt-api error string for DEV-12132: read/write endpoints beyond POST /v2/tracking_requests now explain in the 401 response that a paid plan is required, with a link to the billing settings page.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Terminal49/codesmith/API/pr/349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790281908&installation_model_id=18852&pr_number=349&repository=Terminal49%2FAPI&return_to=https%3A%2F%2Fgithub.com%2FTerminal49%2FAPI%2Fpull%2F349&signature=3b4661190e3d2e069ac1aebe3a56403d61b9352e7ba7f680dd479ecebed75cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR synchronizes the documented restricted API-access error with the updated response, clarifying that permissions beyond creating tracking requests require a paid plan and directing users to billing settings.
- Updates the API introduction’s example 401 response.
- Updates the entitlements table with the same paid-plan guidance.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The two pages consistently apply the intended paid-plan clarification, and no changed-code-triggered build, rendering, security, or documentation-contract failure was established.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/api-docs/api-reference/introduction.mdx | Updates the documented free-plan permission error with paid-plan and billing guidance; no actionable regression identified. |
| docs/api-docs/useful-info/entitlements.mdx | Keeps the entitlement overview consistent with the revised permission-error wording; no actionable regression identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify paid-plan requirement in A..."](https://github.com/terminal49/api/commit/61c73b6406be443542d473f1efa4c37a1bea0d69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56822457)</sub>

<!-- /greptile_comment -->